### PR TITLE
OJ-1994: Updated `NinoCheckUrl` to use the Imposter URL for dev and b…

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -91,6 +91,16 @@ Conditions:
     - dev
   IsNotDevEnvironment: !Not
     - Condition: IsDevEnvironment
+  IsStubEnvironment: !Or
+    - !Equals [ !Ref Environment, dev ]
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, integration ]
+  IsStagingEnvironment: !Equals
+    - !Ref Environment
+    - staging
+  IsProductionEnvironment: !Equals
+    - !Ref Environment
+    - production
 
 Resources:
   UserAgent:
@@ -105,9 +115,21 @@ Resources:
     Type: AWS::SSM::Parameter
     Properties:
       Name: !Sub "/${AWS::StackName}/NinoCheckUrl"
-      Value: https://test-api.service.hmrc.gov.uk/individuals/authentication/authenticator/api/match
       Type: String
       Description: URL for HMRC /check endpoint
+      Value:
+        Fn::If:
+          - IsStubEnvironment
+          - Fn::Sub:
+              - "${ImposterApiUrl}/individuals/authentication/authenticator/api/match"
+              - { ImposterApiUrl: !ImportValue third-party-stubs-ImposterStubApiUrl }
+          - Fn::If:
+              - IsStagingEnvironment
+              - "https://test-api.service.hmrc.gov.uk/individuals/authentication/authenticator/api/match"
+              - Fn::If:
+                  - IsProductionEnvironment
+                  - "https://api.service.hmrc.gov.uk/individuals/authentication/authenticator/api/match"
+                  - ""
 
   MaxJwtTtlParameter:
     Type: AWS::SSM::Parameter


### PR DESCRIPTION
…uild environments. Staging to use the HMRC staging API and production to use the HMRC prod url

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1944](https://govukverify.atlassian.net/browse/OJ-1944)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
