### PR TITLE
BAU: Changed "Invoke Check Session" to use StartSyncExecution

### DIFF
--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -4,20 +4,16 @@
   "States": {
     "Invoke Check Session": {
       "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "Parameters": {
-        "Payload": {
-          "stateMachineArn": "${CheckSessionStateMachineArn}",
-          "input": {
-            "sessionId.$": "$.sessionId"
-          }
-        },
-        "FunctionName": "${ExecuteStateMachineFunctionName}"
-      },
       "Next": "Is Session Valid?",
-      "ResultPath": "$.sessionCheck",
+      "Parameters": {
+        "StateMachineArn": "${CheckSessionStateMachineArn}",
+        "Input.$": "States.JsonToString($)"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:startSyncExecution",
       "ResultSelector": {
-        "result.$": "States.StringToJson($.Payload)"
+        "sessionId.$": "$$.Execution.Input.sessionId",
+        "nino.$": "$$.Execution.Input.nino",
+        "sessionCheck.$": "States.StringToJson($.Output)"
       }
     },
     "Is Session Valid?": {
@@ -25,7 +21,7 @@
       "Choices": [
         {
           "Not": {
-            "Variable": "$.sessionCheck.result.status",
+            "Variable": "$.sessionCheck.status",
             "StringMatches": "SESSION_OK"
           },
           "Next": "Err: Invalid Session"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
The "Invoke Check Session" uses the StartSyncExecution instead of a Lambda invoke.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
We previously used a Lambda because invoking a state machine from an express state machine was not supported. This has since changed so we no longer need to use a Lambda to invoke an express state machine from another express state machine.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
