### PR TITLE
BAU: Add stage name to Imposter URL

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -121,7 +121,7 @@ Resources:
         Fn::If:
           - IsStubEnvironment
           - Fn::Sub:
-              - "${ImposterApiUrl}/individuals/authentication/authenticator/api/match"
+              - "${ImposterApiUrl}/individuals/authentication/authenticator/api/match?stageName=third-party-stubs-ImposterStubFunction"
               - {
                   ImposterApiUrl: !ImportValue third-party-stubs-ImposterStubApiUrl,
                 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change
To call the Imposter URL, AWS needs a stage name which is currently defined as the Imposter function name.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
