### PR TITLE
Bau validate bearer token

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -123,16 +123,16 @@
         "filename": "integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts",
         "hashed_secret": "c7372cf229fe9be17fcc7beede8abd17ae1eb123",
         "is_verified": false,
-        "line_number": 192
+        "line_number": 194
       },
       {
         "type": "Secret Keyword",
         "filename": "integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts",
         "hashed_secret": "7cf58dae7a45b611ee7e9e918ff6c7116b60f3de",
         "is_verified": false,
-        "line_number": 197
+        "line_number": 199
       }
     ]
   },
-  "generated_at": "2023-11-13T13:17:21Z"
+  "generated_at": "2023-11-13T13:35:59Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -132,11 +128,11 @@
       {
         "type": "Secret Keyword",
         "filename": "integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts",
-        "hashed_secret": "06f7e55424a21640d19bd91670b5b39342be2591",
+        "hashed_secret": "7cf58dae7a45b611ee7e9e918ff6c7116b60f3de",
         "is_verified": false,
         "line_number": 197
       }
     ]
   },
-  "generated_at": "2023-11-06T20:20:09Z"
+  "generated_at": "2023-11-13T13:17:21Z"
 }

--- a/infrastructure/public-api.yaml
+++ b/infrastructure/public-api.yaml
@@ -112,7 +112,7 @@ paths:
       - name: Authorization
         in: header
         required: true
-        description: "A valid access_token (e.g.: authorization: Bearer access-token-value)."
+        description: "A valid access_token (e.g.: Authorization: Bearer <access-token-value>)."
         schema:
           type: string
     post:
@@ -180,6 +180,7 @@ paths:
                 $resp.cause
                 #end
                 $params.jwt
+                $resp.output
 
 components:
   schemas:

--- a/infrastructure/public-api.yaml
+++ b/infrastructure/public-api.yaml
@@ -175,12 +175,12 @@ paths:
                 #end
                 #if($err == true)
                 #set($context.responseOverride.status = 400)
+                $resp.output
                 #elseif($resp.status == "FAILED")
                 #set($context.responseOverride.status = 500)
                 $resp.cause
                 #end
                 $params.jwt
-                $resp.output
 
 components:
   schemas:

--- a/infrastructure/public-api.yaml
+++ b/infrastructure/public-api.yaml
@@ -162,12 +162,23 @@ paths:
                 "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-NinoIssueCredential"
               }
         responses:
-          "200":
+          default:
             statusCode: 200
             responseTemplates:
               application/jwt: |
                 #set($resp = $util.parseJson($input.body))
                 #set($params = $util.parseJson($resp.output))
+                #foreach($paramName in $params.keySet())
+                #if($paramName == 'error')
+                #set($err = true)
+                #end
+                #end
+                #if($err == true)
+                #set($context.responseOverride.status = 400)
+                #elseif($resp.status == "FAILED")
+                #set($context.responseOverride.status = 500)
+                $resp.cause
+                #end
                 $params.jwt
 
 components:

--- a/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
@@ -2,6 +2,8 @@ import { stackOutputs } from "../resources/cloudformation-helper";
 import { executeStepFunction } from "../resources/stepfunction-helper";
 import { clearItems, populateTable } from "../resources/dynamodb-helper";
 
+jest.setTimeout(30_000);
+
 describe("nino-check-happy", () => {
   const input = {
     sessionId: "123456789",

--- a/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
@@ -10,6 +10,8 @@ import {
   secretManagerUpdate,
 } from "../resources/secret-manager-helper";
 
+jest.setTimeout(30_000);
+
 describe("nino-check-unhappy", () => {
   const input = {
     sessionId: "123456789",

--- a/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
@@ -194,7 +194,7 @@ describe("nino-check-unhappy", () => {
 
     await secretManagerUpdate({
       SecretId: "HMRCBearerToken",
-      SecretString: "bad-value",
+      SecretString: "badToken",
     });
 
     const startExecutionResult = await executeStepFunction(

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
@@ -7,6 +7,8 @@ import {
   ssmParamterUpdate,
 } from "../resources/ssm-param-helper";
 
+jest.setTimeout(30_000);
+
 describe("nino-issue-credential-happy", () => {
   const input = {
     sessionId: "123456789",

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
@@ -2,6 +2,8 @@ import { stackOutputs } from "../resources/cloudformation-helper";
 import { executeStepFunction } from "../resources/stepfunction-helper";
 import { clearItems, populateTable } from "../resources/dynamodb-helper";
 
+jest.setTimeout(30_000);
+
 describe("nino-issue-credential-unhappy", () => {
   const input = {
     sessionId: "123456789",
@@ -106,7 +108,7 @@ describe("nino-issue-credential-unhappy", () => {
       output.NinoIssueCredentialStateMachineArn
     );
 
-    const token = JSON.parse(startExecutionResult.output as any);
+    const token = JSON.parse(startExecutionResult.output as never);
 
     const [headerEncoded, payloadEncoded, signatureEncoded] =
       token.jwt.split(".");

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -1,7 +1,46 @@
 {
   "Comment": "A description of my state machine",
-  "StartAt": "Fetch Max JWT TTL",
+  "StartAt": "Fetch Session Table Name",
   "States": {
+    "Fetch Session Table Name": {
+      "Type": "Task",
+      "Next": "Query Session Item",
+      "Parameters": {
+        "Name": "/${CommonStackName}/SessionTableName"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
+      "ResultSelector": {
+        "value.$": "$.Parameter.Value"
+      },
+      "ResultPath": "$.sessionTable"
+    },
+    "Query Session Item": {
+      "Type": "Task",
+      "Parameters": {
+        "TableName.$": "$.sessionTable.value",
+        "IndexName": "access-token-index",
+        "KeyConditionExpression": "accessToken = :value",
+        "ExpressionAttributeValues": {
+          ":value": {
+            "S.$": "$.bearerToken"
+          }
+        }
+      },
+      "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
+      "ResultPath": "$.querySessionResult",
+      "Next": "Bearer Token Valid?"
+    },
+    "Bearer Token Valid?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.querySessionResult.Count",
+          "NumericGreaterThan": 0,
+          "Next": "Fetch Max JWT TTL"
+        }
+      ],
+      "Default": "Err: Invalid Bearer Token"
+    },
     "Fetch Max JWT TTL": {
       "Type": "Task",
       "Parameters": {
@@ -52,7 +91,7 @@
     },
     "Fetch Person Identity Table Name": {
       "Type": "Task",
-      "Next": "Fetch Session Table Name",
+      "Next": "Filter Session Result",
       "Parameters": {
         "Name": "/${CommonStackName}/PersonIdentityTableName"
       },
@@ -61,45 +100,6 @@
         "value.$": "$.Parameter.Value"
       },
       "ResultPath": "$.personIdentityTableName"
-    },
-    "Fetch Session Table Name": {
-      "Type": "Task",
-      "Next": "Query Session Item",
-      "Parameters": {
-        "Name": "/${CommonStackName}/SessionTableName"
-      },
-      "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
-      "ResultSelector": {
-        "value.$": "$.Parameter.Value"
-      },
-      "ResultPath": "$.sessionTable"
-    },
-    "Query Session Item": {
-      "Type": "Task",
-      "Parameters": {
-        "TableName.$": "$.sessionTable.value",
-        "IndexName": "access-token-index",
-        "KeyConditionExpression": "accessToken = :value",
-        "ExpressionAttributeValues": {
-          ":value": {
-            "S.$": "$.bearerToken"
-          }
-        }
-      },
-      "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
-      "ResultPath": "$.querySessionResult",
-      "Next": "Bearer Token Valid?"
-    },
-    "Bearer Token Valid?": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.querySessionResult.Count",
-          "NumericGreaterThan": 0,
-          "Next": "Filter Session Result"
-        }
-      ],
-      "Default": "Err: Invalid Bearer Token"
     },
     "Filter Session Result": {
       "Type": "Pass",

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -1,29 +1,7 @@
 {
   "Comment": "A description of my state machine",
-  "StartAt": "Check Bearer Token Present",
+  "StartAt": "Fetch Max JWT TTL",
   "States": {
-    "Check Bearer Token Present": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.bearerToken",
-          "IsPresent": false,
-          "Next": "Error: Invalid Bearer Token"
-        }
-      ],
-      "Default": "Validate Bearer Token"
-    },
-    "Validate Bearer Token": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.bearerToken",
-          "IsPresent": false,
-          "Next": "Error: No access code"
-        }
-      ],
-      "Default": "Fetch Max JWT TTL"
-    },
     "Fetch Max JWT TTL": {
       "Type": "Task",
       "Parameters": {
@@ -109,12 +87,35 @@
         }
       },
       "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
+      "ResultPath": "$.querySessionResult",
+      "Next": "Bearer Token Valid?"
+    },
+    "Bearer Token Valid?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.querySessionResult.Count",
+          "NumericGreaterThan": 0,
+          "Next": "Filter Session Result"
+        }
+      ],
+      "Default": "Err: Invalid Bearer Token"
+    },
+    "Filter Session Result": {
+      "Type": "Pass",
       "Next": "Create Credential Subject And Evidence",
-      "ResultSelector": {
-        "sessionId.$": "$.Items[0].sessionId.S",
-        "subject.$": "$.Items[0].subject.S"
-      },
-      "ResultPath": "$.querySession"
+      "ResultPath": "$.querySession",
+      "Parameters": {
+        "sessionId.$": "$.querySessionResult.Items[0].sessionId.S",
+        "subject.$": "$.querySessionResult.Items[0].subject.S"
+      }
+    },
+    "Err: Invalid Bearer Token": {
+      "Type": "Pass",
+      "End": true,
+      "Parameters": {
+        "error": "Invalid Bearer Token"
+      }
     },
     "Create Credential Subject And Evidence": {
       "Type": "Parallel",
@@ -355,14 +356,6 @@
       "Parameters": {
         "jwt.$": "States.Format('{}.{}.{}', $.header, $.payload, States.Base64Encode($.sign.Signature))"
       }
-    },
-    "Error: No access code": {
-      "Type": "Pass",
-      "End": true
-    },
-    "Error: Invalid Bearer Token": {
-      "Type": "Pass",
-      "End": true
     }
   }
 }


### PR DESCRIPTION
## Proposed changes

### Why did it change

`public-api.yaml`: To respond with 400s and 500s on error

`nino_issue_credential.asl.json`: Updated so the placeholder "validate bearer token" has been replaced with actual bearer token checking.

Screenshot:

Before:
![image](https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/assets/76599223/46f26752-dda4-42ae-beed-918af8092d79)


After:
![image](https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/assets/76599223/c339d935-d6bd-449d-b310-411cf19fd3af)

