### PR TITLE
OJ-2045: use jwt signer in stepfunction

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -610,6 +610,7 @@ Resources:
         JwtTtlUnitParameter: !Ref JwtTtlUnitParameter
         CommonStackName: !Ref CommonStackName
         NinoUsersTable: !Ref NinoUsersTable
+        JwtSignerFunction: !GetAtt JwtSignerFunction.Arn
       Logging:
         Destinations:
           - CloudWatchLogsLogGroup:

--- a/integration-tests/jest.config-aws.ts
+++ b/integration-tests/jest.config-aws.ts
@@ -7,5 +7,6 @@ import commonConfig from "./jest.config.common";
 const config: Config.InitialOptions = {
   ...commonConfig,
   testMatch: ["**/tests/aws/*/*.test.ts"],
+  setupFiles: ["<rootDir>/tests/aws/setEnvVars.js"],
 };
 export default config;

--- a/integration-tests/jest.config-mocked.ts
+++ b/integration-tests/jest.config-mocked.ts
@@ -7,5 +7,6 @@ import commonConfig from "./jest.config.common";
 const config: Config.InitialOptions = {
   ...commonConfig,
   testMatch: ["**/tests/mocked/**/*.test.ts"],
+  setupFiles: ["<rootDir>/tests/mocked/setEnvVars.js"],
 };
 export default config;

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-config-prettier": "8.3.0",
         "eslint-plugin-prettier": "4.0.0",
         "jest": "^29.5.0",
+        "jose": "^5.1.1",
         "prettier": "2.8.7",
         "testcontainers": "^10.0.2",
         "ts-jest": "^29.1.0",
@@ -9855,6 +9856,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.1.1.tgz",
+      "integrity": "sha512-bfB+lNxowY49LfrBO0ITUn93JbUhxUN8I11K6oI5hJu/G6PO6fEUddVLjqdD0cQ9SXIHWXuWh7eJYwZF7Z0N/g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -20529,6 +20539,12 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "dev": true
+    },
+    "jose": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.1.1.tgz",
+      "integrity": "sha512-bfB+lNxowY49LfrBO0ITUn93JbUhxUN8I11K6oI5hJu/G6PO6fEUddVLjqdD0cQ9SXIHWXuWh7eJYwZF7Z0N/g==",
       "dev": true
     },
     "js-tokens": {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -11,14 +11,16 @@
     "test:mocked": "npm run unit:mocked",
     "compile": "tsc"
   },
-  "dependencies": {},
+  "dependencies": {
+    "jose": "^5.1.2"
+  },
   "devDependencies": {
     "@aws-sdk/client-cloudformation": "^3.405.0",
     "@aws-sdk/client-dynamodb": "^3.398.0",
     "@aws-sdk/client-kms": "^3.451.0",
-    "@aws-sdk/client-ssm": "^3.454.0",
     "@aws-sdk/client-secrets-manager": "^3.454.0",
     "@aws-sdk/client-sfn": "^3.405.0",
+    "@aws-sdk/client-ssm": "^3.454.0",
     "@aws-sdk/lib-dynamodb": "^3.398.0",
     "aws-testing-library": "^4.0.6",
     "testcontainers": "^10.0.2"

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
@@ -1,3 +1,4 @@
+import { JWK, importJWK, jwtVerify } from "jose";
 import { stackOutputs } from "../resources/cloudformation-helper";
 import { executeStepFunction } from "../resources/stepfunction-helper";
 import {
@@ -10,6 +11,8 @@ import {
   getSSMParameters,
   updateSSMParameters,
 } from "../resources/ssm-param-helper";
+import { createPublicKey } from "crypto";
+import { getPublicKey } from "../resources/kms-helper";
 
 jest.setTimeout(30_000);
 
@@ -35,6 +38,46 @@ describe("nino-issue-credential-happy", () => {
     NinoUsersTable: string;
     NinoIssueCredentialStateMachineArn: string;
   }>;
+
+  const base64decode = (value: string) =>
+    Buffer.from(value, "base64").toString("utf-8");
+  const isValidTimestamp = (timestamp?: number) =>
+    !isNaN(new Date(timestamp as number).getTime());
+
+  const expectedPayload = {
+    iss: "0976c11e-8ef3-4659-b7f2-ee0b842b85bd",
+    jti: expect.any(String),
+    sub: "test",
+    vc: {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld",
+      ],
+      credentialSubject: {
+        name: [
+          {
+            nameParts: [
+              { type: "GivenName", value: "Jim" },
+              { type: "FamilyName", value: "Ferguson" },
+            ],
+          },
+        ],
+        socialSecurityRecord: [{ personalNumber: "AA000003D" }],
+      },
+      evidence: [
+        {
+          checkDetails: [
+            { checkMethod: "data", identityCheckPolicy: "published" },
+          ],
+          strengthScore: 2,
+          txn: expect.any(String),
+          type: "IdentityCheck",
+          validityScore: 2,
+        },
+      ],
+      type: ["VerifiableCredential", "IdentityCheckCredential"],
+    },
+  };
 
   beforeEach(async () => {
     output = await stackOutputs(process.env.STACK_NAME);
@@ -116,66 +159,25 @@ describe("nino-issue-credential-happy", () => {
   );
 
   it("should create signed JWT when nino check is successful", async () => {
-    const startExecutionResult = await executeStepFunction(
-      output.NinoIssueCredentialStateMachineArn as string,
-      {
-        bearerToken: "Bearer test",
-      }
-    );
-
-    const verifiableCredentialKmsSigningKeyId = `/${output.CommonStackName}/verifiableCredentialKmsSigningKeyId`;
-
-    const currentCredentialKmsSigningKeyId = await getSSMParameter(
-      verifiableCredentialKmsSigningKeyId
-    );
+    const startExecutionResult = await getExecutionResult("Bearer test");
 
     const token = JSON.parse(startExecutionResult.output as string);
 
+    const vcKmsSigningKeyId = `/${output.CommonStackName}/verifiableCredentialKmsSigningKeyId`;
     const [headerEncoded, payloadEncoded, _] = token.jwt.split(".");
 
-    const header = JSON.parse(atob(headerEncoded));
-    const payload = JSON.parse(atob(payloadEncoded));
+    const header = JSON.parse(base64decode(headerEncoded));
+    const payload = JSON.parse(base64decode(payloadEncoded));
 
-    expect(header.typ).toBe("JWT");
-    expect(header.alg).toBe("ES256");
-    expect(header.kid).toBe(currentCredentialKmsSigningKeyId);
+    expect(header).toEqual({
+      typ: "JWT",
+      alg: "ES256",
+      kid: await getSSMParameter(vcKmsSigningKeyId),
+    });
 
-    const evidence = payload.vc.evidence[0];
-    expect(evidence.type).toBe("IdentityCheck");
-    expect(evidence.strengthScore).toBe(2);
-    expect(evidence.validityScore).toBe(2);
-    expect(evidence.checkDetails[0].checkMethod).toBe("data");
-    expect(evidence.checkDetails[0].identityCheckPolicy).toBe("published");
-    expect(evidence.txn).not.toBeNull;
-
-    const credentialSubject = payload.vc.credentialSubject;
-    expect(credentialSubject.socialSecurityRecord[0].personalNumber).toBe(
-      testUser.nino
-    );
-    expect(credentialSubject.name[0].nameParts[0].type).toBe("GivenName");
-    expect(credentialSubject.name[0].nameParts[0].value).toBe(
-      testUser.firstName
-    );
-    expect(credentialSubject.name[0].nameParts[1].type).toBe("FamilyName");
-    expect(credentialSubject.name[0].nameParts[1].value).toBe(
-      testUser.lastName
-    );
-
-    expect(payload.vc.type[0]).toBe("VerifiableCredential");
-    expect(payload.vc.type[1]).toBe("IdentityCheckCredential");
-
-    expect(payload.vc["@context"][0]).toBe(
-      "https://www.w3.org/2018/credentials/v1"
-    );
-    expect(payload.vc["@context"][1]).toBe(
-      "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
-    );
-
-    expect(payload.sub).not.toBeNull;
-    expect(isValidTimestamp(payload.nbf)).toBe(true);
-    expect(payload.iss).not.toBeNull;
     expect(isValidTimestamp(payload.exp)).toBe(true);
-    expect(payload.jti).not.toBeNull;
+    expect(isValidTimestamp(payload.nbf)).toBe(true);
+    expect(payload).toEqual(expect.objectContaining(expectedPayload));
   });
 
   it("should create the valid expiry date", async () => {
@@ -183,8 +185,8 @@ describe("nino-issue-credential-happy", () => {
     const jwtTtlUnit = `/${process.env.STACK_NAME}/JwtTtlUnit`;
 
     const [currentMaxJwtTtl, currentJwtTtlUnit] = await getSSMParameters(
-      `/${process.env.STACK_NAME}/MaxJwtTtl`,
-      `/${process.env.STACK_NAME}/JwtTtlUnit`
+      maxJwtTtl,
+      jwtTtlUnit
     );
 
     await updateSSMParameters(
@@ -192,12 +194,7 @@ describe("nino-issue-credential-happy", () => {
       { name: jwtTtlUnit, value: "MINUTES" }
     );
 
-    const startExecutionResult = await executeStepFunction(
-      output.NinoIssueCredentialStateMachineArn as string,
-      {
-        bearerToken: "Bearer test",
-      }
-    );
+    const startExecutionResult = await getExecutionResult("Bearer test");
 
     await updateSSMParameters(
       { name: maxJwtTtl, value: currentMaxJwtTtl as string },
@@ -205,14 +202,68 @@ describe("nino-issue-credential-happy", () => {
     );
 
     const token = JSON.parse(startExecutionResult.output as string);
+    const payload = JSON.parse(base64decode(token.jwt.split(".")[1]));
 
-    const payloadEncoded = token.jwt.split(".")[1];
-
-    const payload = JSON.parse(atob(payloadEncoded));
-
-    expect(payload.exp).toBe(payload.nbf + 5 * 1000 * 60);
+    expect(payload.exp).toBeCloseTo(payload.nbf + 5 * 1000 * 60);
   });
 
-  const isValidTimestamp = (timestamp: number) =>
-    !isNaN(new Date(timestamp).getTime());
+  it("should have valid signature", async () => {
+    const vcKmsSigningKeyId = `/${output.CommonStackName}/verifiableCredentialKmsSigningKeyId`;
+    const authenticationAlg = `/${output.CommonStackName}/clients/ipv-core-stub-aws-build/jwtAuthentication/authenticationAlg`;
+
+    const startExecutionResult = await getExecutionResult("Bearer test");
+
+    const token = JSON.parse(startExecutionResult.output as string);
+    const [header, jwtPayload, signature] = token.jwt.split(".");
+
+    const kid = (await getSSMParameter(vcKmsSigningKeyId)) as string;
+    const alg = (await getSSMParameter(authenticationAlg)) as string;
+
+    const signingPublicJwk = await createSigningPublicJWK(kid, alg);
+    const publicVerifyingJwk = await importJWK(
+      signingPublicJwk,
+      signingPublicJwk?.alg || alg
+    );
+
+    const { payload } = await jwtVerify(
+      `${header}.${jwtPayload}.${base64decode(signature)}`,
+      publicVerifyingJwk,
+      { algorithms: [alg] }
+    );
+
+    expect(isValidTimestamp(payload.exp)).toBe(true);
+    expect(isValidTimestamp(payload.nbf)).toBe(true);
+    expect(payload).toEqual(expect.objectContaining(expectedPayload));
+  });
+
+  async function getExecutionResult(token: string) {
+    return await executeStepFunction(
+      output.NinoIssueCredentialStateMachineArn as string,
+      {
+        bearerToken: token,
+      }
+    );
+  }
+
+  async function createSigningPublicJWK(
+    kid: string,
+    alg: string
+  ): Promise<JWK> {
+    const key = Buffer.from(
+      (await getPublicKey(kid as string)).PublicKey as Uint8Array
+    );
+
+    const signingPublicJwk = createPublicKey({
+      key,
+      type: "spki",
+      format: "der",
+    }).export({ format: "jwk" });
+
+    return {
+      ...signingPublicJwk,
+      use: "sig",
+      kid,
+      alg,
+    };
+  }
 });

--- a/integration-tests/tests/aws/resources/kms-helper.ts
+++ b/integration-tests/tests/aws/resources/kms-helper.ts
@@ -1,0 +1,7 @@
+import { GetPublicKeyCommand, KMSClient } from "@aws-sdk/client-kms";
+
+const kmsClient = new KMSClient({ region: "eu-west-2" });
+
+export const getPublicKey = async (kid: string) => {
+  return await kmsClient.send(new GetPublicKeyCommand({ KeyId: kid }));
+};

--- a/integration-tests/tests/aws/setEnvVars.js
+++ b/integration-tests/tests/aws/setEnvVars.js
@@ -1,0 +1,1 @@
+process.env.AWS_REGION = "eu-west-2";

--- a/integration-tests/tests/mocked/setEnvVars.js
+++ b/integration-tests/tests/mocked/setEnvVars.js
@@ -12,3 +12,4 @@ process.env.STATE_MACHINE_ROLE =
 
 process.env.NINO_ATTEMPTS_TABLE = "pdv-matching-nino-attempts";
 process.env.NINO_USERS_TABLE = "pdv-matching-nino-users";
+process.env.AWS_REGION = "eu-west-2";

--- a/lambdas/issue-credential/tests/time-handler.test.ts
+++ b/lambdas/issue-credential/tests/time-handler.test.ts
@@ -3,24 +3,27 @@ import { Context } from "aws-lambda";
 import { TimeEvent } from "../src/time-event";
 
 describe("time-handler", () => {
+  const mon31st2021InMilliseconds = 1622502000000;
+  const mon31st2021InSeconds = 1622502000;
+
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetAllMocks();
   });
 
   it("should return the current time for nbf", async () => {
-    jest.spyOn(Date, "now").mockReturnValue(1622502000000);
+    jest.spyOn(Date, "now").mockReturnValue(mon31st2021InMilliseconds);
     const event = {
       ttl: 10,
       ttlUnit: "seconds",
     } as TimeEvent;
     const timeHandler = new TimeHandler();
     const result = await timeHandler.handler(event, {} as Context);
-    expect(result.nbf).toBe(1622502000000);
+    expect(result.nbf).toBe(mon31st2021InSeconds);
   });
 
   it("should return a expiry that expires in 10 seconds", async () => {
-    jest.spyOn(Date, "now").mockReturnValue(1622502000000);
+    jest.spyOn(Date, "now").mockReturnValue(mon31st2021InMilliseconds);
     const event = {
       ttl: 10,
       ttlUnit: "seconds",
@@ -28,13 +31,13 @@ describe("time-handler", () => {
     const timeHandler = new TimeHandler();
     const result = await timeHandler.handler(event, {} as Context);
     expect(result).toEqual({
-      nbf: 1622502000000,
-      expiry: 1622502000000 + 10000,
+      nbf: mon31st2021InSeconds,
+      expiry: mon31st2021InSeconds + 10000,
     });
   });
 
   it("should return a expiry that expires in 10 minutes", async () => {
-    jest.spyOn(Date, "now").mockReturnValue(1622502000000);
+    jest.spyOn(Date, "now").mockReturnValue(mon31st2021InMilliseconds);
     const event = {
       ttl: 10,
       ttlUnit: "minutes",
@@ -42,13 +45,13 @@ describe("time-handler", () => {
     const timeHandler = new TimeHandler();
     const result = await timeHandler.handler(event, {} as Context);
     expect(result).toEqual({
-      nbf: 1622502000000,
-      expiry: 1622502000000 + 10 * (1000 * 60),
+      nbf: mon31st2021InSeconds,
+      expiry: mon31st2021InSeconds + 10 * (1000 * 60),
     });
   });
 
   it("should return a expiry that expires in 1 hour", async () => {
-    jest.spyOn(Date, "now").mockReturnValue(1622502000000);
+    jest.spyOn(Date, "now").mockReturnValue(mon31st2021InMilliseconds);
     const event = {
       ttl: 1,
       ttlUnit: "hours",
@@ -56,13 +59,13 @@ describe("time-handler", () => {
     const timeHandler = new TimeHandler();
     const result = await timeHandler.handler(event, {} as Context);
     expect(result).toEqual({
-      nbf: 1622502000000,
-      expiry: 1622502000000 + 1000 * 60 * 60,
+      nbf: mon31st2021InSeconds,
+      expiry: mon31st2021InSeconds + 1000 * 60 * 60,
     });
   });
 
   it("should return a expiry that expires in 1 day", async () => {
-    jest.spyOn(Date, "now").mockReturnValue(1622502000000);
+    jest.spyOn(Date, "now").mockReturnValue(mon31st2021InMilliseconds);
     const event = {
       ttl: 1,
       ttlUnit: "days",
@@ -70,13 +73,13 @@ describe("time-handler", () => {
     const timeHandler = new TimeHandler();
     const result = await timeHandler.handler(event, {} as Context);
     expect(result).toEqual({
-      nbf: 1622502000000,
-      expiry: 1622502000000 + 1000 * 60 * 60 * 24,
+      nbf: mon31st2021InSeconds,
+      expiry: mon31st2021InSeconds + 1000 * 60 * 60 * 24,
     });
   });
 
   it("should return a expiry that expires in 1 month", async () => {
-    jest.spyOn(Date, "now").mockReturnValue(1622502000000);
+    jest.spyOn(Date, "now").mockReturnValue(mon31st2021InMilliseconds);
     const event = {
       ttl: 1,
       ttlUnit: "months",
@@ -84,13 +87,13 @@ describe("time-handler", () => {
     const timeHandler = new TimeHandler();
     const result = await timeHandler.handler(event, {} as Context);
     expect(result).toEqual({
-      nbf: 1622502000000,
-      expiry: 1622502000000 + 1000 * 60 * 60 * 24 * 30,
+      nbf: mon31st2021InSeconds,
+      expiry: mon31st2021InSeconds + 1000 * 60 * 60 * 24 * 30,
     });
   });
 
   it("should return a expiry that expires in 1 year", async () => {
-    jest.spyOn(Date, "now").mockReturnValue(1622502000000);
+    jest.spyOn(Date, "now").mockReturnValue(mon31st2021InMilliseconds);
     const event = {
       ttl: 1,
       ttlUnit: "years",
@@ -98,8 +101,8 @@ describe("time-handler", () => {
     const timeHandler = new TimeHandler();
     const result = await timeHandler.handler(event, {} as Context);
     expect(result).toEqual({
-      nbf: 1622502000000,
-      expiry: 1622502000000 + 1000 * 60 * 60 * 24 * 365,
+      nbf: mon31st2021InSeconds,
+      expiry: mon31st2021InSeconds + 1000 * 60 * 60 * 24 * 365,
     });
   });
 });

--- a/lambdas/jwt-signer/src/jwt-signer-handler.ts
+++ b/lambdas/jwt-signer/src/jwt-signer-handler.ts
@@ -4,6 +4,8 @@ import sigFormatter from "ecdsa-sig-formatter";
 import { fromEnv } from "@aws-sdk/credential-providers";
 import { SignerPayLoad } from "./signer-payload";
 import { SignageType } from "./signage-type";
+import { Logger } from "@aws-lambda-powertools/logger";
+
 import {
   KMSClient,
   MessageType,
@@ -11,6 +13,7 @@ import {
   SigningAlgorithmSpec,
 } from "@aws-sdk/client-kms";
 
+const logger = new Logger();
 export class JwtSignerHandler implements LambdaInterface {
   constructor(private kmsClient: KMSClient) {}
 
@@ -55,15 +58,10 @@ export class JwtSignerHandler implements LambdaInterface {
 
       return signingResponse.Signature;
     } catch (error) {
-      if (error instanceof SyntaxError) {
-        throw new Error(`KMS response is not in JSON format. ${error}`);
-      } else if (error instanceof Error) {
-        throw new Error(`KMS signing error: ${error}`);
-      } else {
-        throw new Error(
-          `An unknown error occurred while signing with KMS: ${error}`
-        );
-      }
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logger.error(`Error in JwtSignerHandler: ${errorMessage}`);
+      throw error;
     }
   }
 

--- a/lambdas/jwt-signer/tests/jwt-signer-handler.test.ts
+++ b/lambdas/jwt-signer/tests/jwt-signer-handler.test.ts
@@ -106,7 +106,7 @@ describe("Fails to sign a JWT", () => {
     );
 
     await expect(jwtSignerHandler.handler(event, {})).rejects.toThrow(
-      "KMS signing error: Error: KMS response does not contain a valid Signature."
+      "KMS response does not contain a valid Signature."
     );
   });
 
@@ -124,7 +124,7 @@ describe("Fails to sign a JWT", () => {
     await expect(
       jwtSignerHandler.handler(event as SignerPayLoad, {})
     ).rejects.toThrow(
-      "KMS signing error: Error: ValidationException: 1 validation error detected: Value null at 'keyId' failed to satisfy constraint: Member must not be null"
+      "ValidationException: 1 validation error detected: Value null at 'keyId' failed to satisfy constraint: Member must not be null"
     );
   });
 
@@ -132,27 +132,23 @@ describe("Fails to sign a JWT", () => {
     const event: Partial<SignerPayLoad> = { header, claimsSet };
 
     kmsClient.send.mockImplementationOnce(() =>
-      Promise.reject(new SyntaxError("Unknown error"))
+      Promise.reject(new Error("Unknown error"))
     );
 
     await expect(
       jwtSignerHandler.handler(event as SignerPayLoad, {})
-    ).rejects.toThrow(
-      "KMS response is not in JSON format. SyntaxError: Unknown error"
-    );
+    ).rejects.toThrow("Unknown error");
   });
 
-  it("Should throw an error for an unknown error during signing with KMS", async () => {
+  it("should throw due to the signature with an invalid format", async () => {
     const event: Partial<SignerPayLoad> = { header, claimsSet };
 
     kmsClient.send.mockImplementationOnce(() =>
-      Promise.reject({ Signature: "invalid-response" })
+      Promise.resolve({ Signature: new Uint8Array() })
     );
 
     await expect(
       jwtSignerHandler.handler(event as SignerPayLoad, {})
-    ).rejects.toThrow(
-      "An unknown error occurred while signing with KMS: [object Object]"
-    );
+    ).rejects.toThrow('Could not find expected "seq"');
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,9 @@
     },
     "integration-tests": {
       "name": "check-hmrc-api-integration-tests",
+      "dependencies": {
+        "jose": "^5.1.2"
+      },
       "devDependencies": {
         "@aws-sdk/client-cloudformation": "^3.405.0",
         "@aws-sdk/client-dynamodb": "^3.398.0",
@@ -11642,10 +11645,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.1.0.tgz",
-      "integrity": "sha512-H+RVqxA6apaJ0rcQYupKYhos7uosAiF42gUcWZiwhICWMphDULFj/CRr1R0tV/JCv9DEeJaSyYYpc9luHHNT4g==",
-      "dev": true,
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.1.2.tgz",
+      "integrity": "sha512-X7TOC/d8KPvx4wPUuLHVgTSdoWw0UW5TQOUwhvCvj+ZPfsf9vUPhhksYPjNBWVGPQ/6yd/JrL1gQxBnIDwYdFg==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -20015,6 +20017,7 @@
         "@aws-sdk/client-ssm": "^3.454.0",
         "@aws-sdk/lib-dynamodb": "^3.398.0",
         "aws-testing-library": "^4.0.6",
+        "jose": "^5.1.2",
         "testcontainers": "^10.0.2"
       }
     },
@@ -22707,10 +22710,9 @@
       "dev": true
     },
     "jose": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.1.0.tgz",
-      "integrity": "sha512-H+RVqxA6apaJ0rcQYupKYhos7uosAiF42gUcWZiwhICWMphDULFj/CRr1R0tV/JCv9DEeJaSyYYpc9luHHNT4g==",
-      "dev": true
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.1.2.tgz",
+      "integrity": "sha512-X7TOC/d8KPvx4wPUuLHVgTSdoWw0UW5TQOUwhvCvj+ZPfsf9vUPhhksYPjNBWVGPQ/6yd/JrL1gQxBnIDwYdFg=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -307,7 +307,7 @@
     },
     "Create VC Claim Set": {
       "Type": "Pass",
-      "Next": "Base64 and Combine JWT Header and Payload",
+      "Next": "Base64 encode Header and Payload",
       "Parameters": {
         "header": {
           "kid.$": "$[0].kid.value",
@@ -327,35 +327,50 @@
             "evidence.$": "$[2].vc.evidence"
           }
         }
-      },
-      "ResultPath": "$"
-    },
-    "Base64 and Combine JWT Header and Payload": {
-      "Type": "Pass",
-      "Next": "Sign VC claimset",
-      "Parameters": {
-        "header.$": "States.Base64Encode(States.JsonToString($.header))",
-        "payload.$": "States.Base64Encode(States.JsonToString($.payload))",
-        "kid.$": "$.header.kid"
       }
     },
-    "Sign VC claimset": {
-      "Type": "Task",
-      "Next": "Create Signed JWT",
+    "Base64 encode Header and Payload": {
+      "Type": "Pass",
+      "Next": "Sign VC claimsSet",
       "Parameters": {
-        "KeyId.$": "$.kid",
-        "Message.$": "States.Format('{}.{}', $.header,$.payload)",
-        "SigningAlgorithm": "ECDSA_SHA_256"
+        "header.$": "States.Base64Encode(States.JsonToString($.header))",
+        "payload.$": "States.Base64Encode(States.JsonToString($.payload))"
       },
-      "Resource": "arn:aws:states:::aws-sdk:kms:sign",
-      "ResultPath": "$.sign"
+      "ResultPath": "$.encoded"
+    },
+    "Sign VC claimsSet": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "Payload": {
+          "kid.$": "$.header.kid",
+          "header.$": "$.encoded.header",
+          "claimsSet.$": "$.encoded.payload"
+        },
+        "FunctionName": "${JwtSignerFunction}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Create Signed JWT",
+      "ResultPath": "$.signature"
     },
     "Create Signed JWT": {
       "Type": "Pass",
-      "End": true,
       "Parameters": {
-        "jwt.$": "States.Format('{}.{}.{}', $.header, $.payload, States.Base64Encode($.sign.Signature))"
-      }
+        "jwt.$": "States.Format('{}.{}.{}', $.encoded.header, $.encoded.payload, States.Base64Encode($.signature.Payload))"
+      },
+      "End": true
     }
   }
 }


### PR DESCRIPTION
## Proposed changes

The **second** PART to https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/pull/70
Which ties the `jwt-signer-handler` to the step function

### What changed

KMS signing used to be done using step function integration, this was inadequate for two reasons:

- The format of the signature is DER and ideally should be JOSE format
- If the VC payload becomes heavy enough, then the signed message sha256 hashed

The `jwt-signer-handler` does the above two jobs

### Why did it change

Verification of the signature in typescript, was difficult moving the functionality into typescript allowed better testabililty

### Other stuff done:

- Made the region default to eu-west-2 in test helpers this makes a little easier to test integration locally
- Simplified catch block of jwt-signer-handler, and make it look similar to existing lambda handlers
- nbf and expiry, where in milliseconds, they should be in seconds
- Implemented signature verification integration test

see
- [OJ-2045](https://govukverify.atlassian.net/browse/OJ-2045)



[OJ-2045]: https://govukverify.atlassian.net/browse/OJ-2045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ