### PR TITLE
OJ-2045: Simplify JWT signer tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -109,80 +109,21 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_secret",
+      "pattern": [
+        "Lz57KV7UC1jY_zabLAiIkXkhktmV0Gwg7rG2Z05roY-Ow150MmfDWbVavcpGP8do88MebxM47H-0q30F-CfB2A",
+        "diWgdrCGYnjrZK7cMPEKwJXvpGn6rvhCBteCl_I2ejg",
+        "BiUZkuU4MFE8zg5zpghGdn-g-uepv14qXAXal4vpgnAk0qZSutsRFvhw_YNRoVwxsacBA6RCEHrHmYpTxsJ9sQ",
+        "ElcRbqkXk-XBnhYC55hApLY9oGnZA5H5MUlqe02gGXA",
+        "A84nU-ZLSFNs8VI6VXkunvWwRx-T3gAXvw2JPRrP78c",
+        "badToken",
+        "HMRCBearerToken",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\\.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ\\..*"
+      ]
     }
   ],
-  "results": {
-    "infrastructure/public-api.yaml": [
-      {
-        "type": "JSON Web Token",
-        "filename": "infrastructure/public-api.yaml",
-        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
-        "is_verified": false,
-        "line_number": 129
-      }
-    ],
-    "integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts",
-        "hashed_secret": "c7372cf229fe9be17fcc7beede8abd17ae1eb123",
-        "is_verified": false,
-        "line_number": 197
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts",
-        "hashed_secret": "7cf58dae7a45b611ee7e9e918ff6c7116b60f3de",
-        "is_verified": false,
-        "line_number": 203
-      }
-    ],
-    "lambdas/jwt-signer/src/test-data.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/jwt-signer/src/test-data.ts",
-        "hashed_secret": "5608e7fe2e5f8e672e29445a9f7586e9b73048c8",
-        "is_verified": false,
-        "line_number": 56
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/jwt-signer/src/test-data.ts",
-        "hashed_secret": "36f3a08fec7a82a77bb7af0b22002572075e22d0",
-        "is_verified": false,
-        "line_number": 136
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/jwt-signer/src/test-data.ts",
-        "hashed_secret": "fe085a0aeed906da6f029c9d77d7e3a1ed783f7e",
-        "is_verified": false,
-        "line_number": 137
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/jwt-signer/src/test-data.ts",
-        "hashed_secret": "4d06a23135695a31e68029e92da60ff8a8a358f9",
-        "is_verified": false,
-        "line_number": 140
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/jwt-signer/src/test-data.ts",
-        "hashed_secret": "b222935d90e76681b08c4d86e554826007c40673",
-        "is_verified": false,
-        "line_number": 142
-      }
-    ],
-    "lambdas/jwt-signer/tests/jwt-signer-handler.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/jwt-signer/tests/jwt-signer-handler.test.ts",
-        "hashed_secret": "5608e7fe2e5f8e672e29445a9f7586e9b73048c8",
-        "is_verified": false,
-        "line_number": 96
-      }
-    ]
-  },
-  "generated_at": "2023-11-14T17:41:07Z"
+  "results": {},
+  "generated_at": "2023-11-21T10:48:16Z"
 }

--- a/lambdas/jwt-signer/src/test-data.ts
+++ b/lambdas/jwt-signer/src/test-data.ts
@@ -1,4 +1,5 @@
 import { base64url } from "jose";
+
 interface Address {
   buildingNumber: string;
   buildingName: string;
@@ -9,6 +10,7 @@ interface Address {
 }
 
 export const kid = "0976c11e-8ef3-4659-b7f2-ee0b842b85bd";
+
 export const header = base64url.encode(
   JSON.stringify({
     kid,
@@ -16,6 +18,7 @@ export const header = base64url.encode(
     alg: "ES256",
   })
 );
+
 export const claimsSet = base64url.encode(
   JSON.stringify({
     sub: "urn:fdc:gov.uk:2022:0df67954-5537-4c98-92d9-e95f0b2e6f44",
@@ -58,31 +61,25 @@ export const claimsSet = base64url.encode(
     iat: 1697516406,
   })
 );
-export const generateFixedString = (length = 10): string => {
-  const charset =
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-  return Array.from(
-    { length },
-    (_, index) => charset[index % charset.length]
-  ).join("");
+
+const generateFixedString = (length: number = 10) =>
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".substring(
+    0,
+    length
+  );
+
+const fixedAddressSection: Address = {
+  buildingNumber: generateFixedString(),
+  buildingName: generateFixedString(),
+  streetName: generateFixedString(),
+  addressLocality: generateFixedString(),
+  postalCode: generateFixedString(),
+  validFrom: "2021-01-01",
 };
 
-const generateRandomAddressSection = (): Address => {
-  return {
-    buildingNumber: generateFixedString(),
-    buildingName: generateFixedString(),
-    streetName: generateFixedString(),
-    addressLocality: generateFixedString(),
-    postalCode: generateFixedString(),
-    validFrom: "2021-01-01",
-  };
-};
-const generateRandomAddressSections = (numSections: number): Address[] => {
-  return Array.from({ length: numSections }, generateRandomAddressSection);
-};
 const numAdditionalSections = 15;
-const additionalAddressSections = generateRandomAddressSections(
-  numAdditionalSections
+const additionalAddressSections = Array(numAdditionalSections).fill(
+  fixedAddressSection
 );
 
 export const largeClaimsSet = base64url.encode(
@@ -128,6 +125,7 @@ export const largeClaimsSet = base64url.encode(
     iat: 1697516406,
   })
 );
+
 export const publicVerifyingJwk = {
   kty: "EC",
   use: "sig",
@@ -136,7 +134,9 @@ export const publicVerifyingJwk = {
   x: "A84nU-ZLSFNs8VI6VXkunvWwRx-T3gAXvw2JPRrP78c",
   y: "ElcRbqkXk-XBnhYC55hApLY9oGnZA5H5MUlqe02gGXA",
 };
+
 export const joseSignature =
   "BiUZkuU4MFE8zg5zpghGdn-g-uepv14qXAXal4vpgnAk0qZSutsRFvhw_YNRoVwxsacBA6RCEHrHmYpTxsJ9sQ";
+
 export const joseLargeClaimsSetSignature =
   "Lz57KV7UC1jY_zabLAiIkXkhktmV0Gwg7rG2Z05roY-Ow150MmfDWbVavcpGP8do88MebxM47H-0q30F-CfB2A";

--- a/lambdas/jwt-signer/tests/jwt-signer-handler.test.ts
+++ b/lambdas/jwt-signer/tests/jwt-signer-handler.test.ts
@@ -1,6 +1,5 @@
 import { KMSClient } from "@aws-sdk/client-kms";
 import { JwtSignerHandler } from "../src/jwt-signer-handler";
-import { Context } from "aws-lambda";
 import sigFormatter from "ecdsa-sig-formatter";
 import { SignerPayLoad } from "../src/signer-payload";
 import { importJWK, jwtVerify } from "jose";
@@ -13,203 +12,147 @@ import {
   largeClaimsSet,
   publicVerifyingJwk,
 } from "../src/test-data";
-let mockedKMSClient: jest.MockedObjectDeep<typeof KMSClient>;
 
-beforeEach(() => {
-  mockedKMSClient = jest.mocked(KMSClient);
-});
-afterEach(() => jest.clearAllMocks());
+const kmsClient = jest.mocked(KMSClient).prototype;
+const jwtSignerHandler = new JwtSignerHandler(kmsClient);
 
-describe("jwt-signer-handler", () => {
-  describe("succeed in signing a jwt", () => {
-    describe("with RAW signage mode", () => {
-      it("should verify a signed jwt message smaller than 4096", async () => {
-        const event: SignerPayLoad = { kid, header, claimsSet };
-        const jwtSignerHandler = new JwtSignerHandler(
-          mockedKMSClient.prototype
-        );
-        const signatureBuffer = sigFormatter.joseToDer(joseSignature, "ES256");
-        const spy = jest.spyOn(mockedKMSClient.prototype, "send");
-        spy.mockImplementationOnce(() =>
-          Promise.resolve({
-            Signature: signatureBuffer,
-          })
-        );
-        const signature = await jwtSignerHandler.handler(event, {} as Context);
+jest.spyOn(kmsClient, "send");
 
-        const publicSigningVerifyingKey = await importJWK(
-          publicVerifyingJwk,
-          "ES256"
-        );
-        const { payload } = await jwtVerify(
-          `${header}.${claimsSet}.${signature}`,
-          publicSigningVerifyingKey,
-          {
-            algorithms: ["ES256"],
-          }
-        );
-        expect(signature).not.toBeUndefined();
-        expect(spy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            input: expect.objectContaining({
-              MessageType: "RAW",
-            }),
-          })
-        );
-        expect(payload).toEqual({
-          aud: "https://review-a.dev.account.gov.uk",
-          client_id: "ipv-core-stub-aws-build",
-          exp: 4102444800,
-          govuk_signin_journey_id: "84521e2b-43ab-4437-a118-f7c3a6d24c8e",
-          iat: 1697516406,
-          iss: "https://cri.core.build.stubs.account.gov.uk",
-          nbf: 1697516406,
-          persistent_session_id: "a67c497b-ac49-46a0-832c-8e7864c6d4cf",
-          redirect_uri: "https://cri.core.build.stubs.account.gov.uk/callback",
-          response_type: "code",
-          scope: "openid",
-          shared_claims: {
-            "@context": [
-              "https://www.w3.org/2018/credentials/v1",
-              "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld",
-            ],
-            address: [
-              {
-                addressLocality: "",
-                buildingName: "",
-                buildingNumber: "",
-                postalCode: "",
-                streetName: "",
-                validFrom: "2021-01-01",
-              },
-            ],
-            birthDate: [{ value: "1948-04-23" }],
-            name: [
-              {
-                nameParts: [
-                  { type: "GivenName", value: "Jim" },
-                  { type: "FamilyName", value: "Ferguson" },
-                ],
-              },
-            ],
-          },
-          state: "diWgdrCGYnjrZK7cMPEKwJXvpGn6rvhCBteCl_I2ejg",
-          sub: "urn:fdc:gov.uk:2022:0df67954-5537-4c98-92d9-e95f0b2e6f44",
-        });
-      });
-    });
-    describe("using DIGEST signing mode", () => {
-      it("should verify a large signed jwt with claimset greater than 4096x", async () => {
-        const event: SignerPayLoad = { kid, header, claimsSet: largeClaimsSet };
-        const jwtSignerHandler = new JwtSignerHandler(
-          mockedKMSClient.prototype
-        );
-
-        const signatureBuffer = sigFormatter.joseToDer(
-          joseLargeClaimsSetSignature,
-          "ES256"
-        );
-        const spy = jest.spyOn(mockedKMSClient.prototype, "send");
-        spy.mockImplementationOnce(() =>
-          Promise.resolve({
-            Signature: signatureBuffer,
-          })
-        );
-        const signature = await jwtSignerHandler.handler(event, {} as Context);
-
-        const publicSigningVerifyingKey = await importJWK(
-          publicVerifyingJwk,
-          "ES256"
-        );
-        const { payload } = await jwtVerify(
-          `${header}.${event.claimsSet}.${signature}`,
-          publicSigningVerifyingKey,
-          {
-            algorithms: ["ES256"],
-          }
-        );
-        expect(signature).not.toBeUndefined();
-        expect(spy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            input: expect.objectContaining({
-              MessageType: "DIGEST",
-            }),
-          })
-        );
-        expect(payload).toEqual(
-          JSON.parse(Buffer.from(event.claimsSet, "base64").toString())
-        );
-      });
-    });
-  });
-  describe("does not sign a jwt", () => {
-    it("should error when signature is undefined", async () => {
+describe("Successfully signs a JWT", () => {
+  describe("With RAW signing mode", () => {
+    it("Should verify a signed JWT message smaller than 4096", async () => {
       const event: SignerPayLoad = { kid, header, claimsSet };
-      const jwtSignerHandler = new JwtSignerHandler(mockedKMSClient.prototype);
-      jest.spyOn(mockedKMSClient.prototype, "send").mockImplementationOnce(() =>
+
+      kmsClient.send.mockImplementationOnce(() =>
         Promise.resolve({
-          Signature: undefined,
+          Signature: sigFormatter.joseToDer(joseSignature, "ES256"),
         })
       );
 
-      await expect(
-        jwtSignerHandler.handler(event as SignerPayLoad, {} as Context)
-      ).rejects.toThrow(
-        "KMS signing error: Error: KMS response does not contain a valid Signature."
+      const signature = await jwtSignerHandler.handler(event, {});
+
+      const { payload } = await jwtVerify(
+        `${header}.${claimsSet}.${signature}`,
+        await importJWK(publicVerifyingJwk, "ES256"),
+        {
+          algorithms: ["ES256"],
+        }
+      );
+
+      expect(signature).toBeDefined();
+
+      expect(kmsClient.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            MessageType: "RAW",
+          }),
+        })
+      );
+
+      expect(payload).toStrictEqual(
+        JSON.parse(Buffer.from(event.claimsSet, "base64").toString())
       );
     });
-    it("should fail when key Id is missing", async () => {
-      const event: Partial<SignerPayLoad> = { header, claimsSet };
-      const kmsClient = new KMSClient({ region: "eu-west-2" });
-      const jwtSignerHandler = new JwtSignerHandler(kmsClient);
-      const mockSignCommand = jest.fn().mockReturnValue({
-        Signature: new Uint8Array(),
-      });
-      kmsClient.send = mockSignCommand;
+  });
 
-      mockSignCommand.mockRejectedValueOnce(
+  describe("Using DIGEST signing mode", () => {
+    it("Should verify a large signed JWT with claimset greater than 4096", async () => {
+      const event: SignerPayLoad = { kid, header, claimsSet: largeClaimsSet };
+
+      kmsClient.send.mockImplementationOnce(() =>
+        Promise.resolve({
+          Signature: sigFormatter.joseToDer(
+            joseLargeClaimsSetSignature,
+            "ES256"
+          ),
+        })
+      );
+
+      const signature = await jwtSignerHandler.handler(event, {});
+
+      const { payload } = await jwtVerify(
+        `${header}.${event.claimsSet}.${signature}`,
+        await importJWK(publicVerifyingJwk, "ES256"),
+        {
+          algorithms: ["ES256"],
+        }
+      );
+
+      expect(signature).toBeDefined();
+
+      expect(kmsClient.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            MessageType: "DIGEST",
+          }),
+        })
+      );
+
+      expect(payload).toStrictEqual(
+        JSON.parse(Buffer.from(event.claimsSet, "base64").toString())
+      );
+    });
+  });
+});
+
+describe("Fails to sign a JWT", () => {
+  it("Should error when signature is undefined", async () => {
+    const event: SignerPayLoad = { kid, header, claimsSet };
+
+    kmsClient.send.mockImplementationOnce(() =>
+      Promise.resolve({
+        Signature: undefined,
+      })
+    );
+
+    await expect(jwtSignerHandler.handler(event, {})).rejects.toThrow(
+      "KMS signing error: Error: KMS response does not contain a valid Signature."
+    );
+  });
+
+  it("Should fail when key ID is missing", async () => {
+    const event: Partial<SignerPayLoad> = { header, claimsSet };
+
+    kmsClient.send.mockImplementationOnce(() =>
+      Promise.reject(
         new Error(
           "ValidationException: 1 validation error detected: Value null at 'keyId' failed to satisfy constraint: Member must not be null"
         )
-      );
-      await expect(
-        jwtSignerHandler.handler(event as SignerPayLoad, {} as Context)
-      ).rejects.toThrow(
-        "KMS signing error: Error: ValidationException: 1 validation error detected: Value null at 'keyId' failed to satisfy constraint: Member must not be null"
-      );
-    });
-    it("should throw an error if KMS response is not in JSON format", async () => {
-      const event: Partial<SignerPayLoad> = { header, claimsSet };
-      const kmsClient = new KMSClient({ region: "eu-west-2" });
-      const jwtSignerHandler = new JwtSignerHandler(kmsClient);
-      const mockSignCommand = jest.fn().mockReturnValue({
-        Signature: new Uint8Array(),
-      });
-      kmsClient.send = mockSignCommand;
-      mockSignCommand.mockRejectedValueOnce(new SyntaxError("Unknown error"));
-      await expect(
-        jwtSignerHandler.handler(event as SignerPayLoad, {} as Context)
-      ).rejects.toThrow(
-        "KMS response is not in JSON format. SyntaxError: Unknown error"
-      );
-    });
-    it("should throw an error for an unknown error during signing with KMS", async () => {
-      const event: Partial<SignerPayLoad> = { header, claimsSet };
-      const kmsClient = new KMSClient({ region: "eu-west-2" });
-      const jwtSignerHandler = new JwtSignerHandler(kmsClient);
+      )
+    );
 
-      const mockSignCommand = jest.fn().mockReturnValue({
-        Signature: new Uint8Array(),
-      });
+    await expect(
+      jwtSignerHandler.handler(event as SignerPayLoad, {})
+    ).rejects.toThrow(
+      "KMS signing error: Error: ValidationException: 1 validation error detected: Value null at 'keyId' failed to satisfy constraint: Member must not be null"
+    );
+  });
 
-      kmsClient.send = mockSignCommand;
-      mockSignCommand.mockRejectedValueOnce({ Signature: "invalid-response" });
+  it("Should throw an error if KMS response is not in JSON format", async () => {
+    const event: Partial<SignerPayLoad> = { header, claimsSet };
 
-      await expect(
-        jwtSignerHandler.handler(event as SignerPayLoad, {} as Context)
-      ).rejects.toThrow(
-        "An unknown error occurred while signing with KMS: [object Object]"
-      );
-    });
+    kmsClient.send.mockImplementationOnce(() =>
+      Promise.reject(new SyntaxError("Unknown error"))
+    );
+
+    await expect(
+      jwtSignerHandler.handler(event as SignerPayLoad, {})
+    ).rejects.toThrow(
+      "KMS response is not in JSON format. SyntaxError: Unknown error"
+    );
+  });
+
+  it("Should throw an error for an unknown error during signing with KMS", async () => {
+    const event: Partial<SignerPayLoad> = { header, claimsSet };
+
+    kmsClient.send.mockImplementationOnce(() =>
+      Promise.reject({ Signature: "invalid-response" })
+    );
+
+    await expect(
+      jwtSignerHandler.handler(event as SignerPayLoad, {})
+    ).rejects.toThrow(
+      "An unknown error occurred while signing with KMS: [object Object]"
+    );
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
       }
     },
     "lambdas/der-signature-to-jose": {
+      "extraneous": true,
       "dependencies": {
         "ecdsa-sig-formatter": "^1.0.11",
         "esbuild": "0.19.5"
@@ -4241,10 +4242,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/der-signature-to-jose": {
-      "resolved": "lambdas/der-signature-to-jose",
-      "link": true
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -12387,13 +12384,6 @@
       "requires": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
-      }
-    },
-    "der-signature-to-jose": {
-      "version": "file:lambdas/der-signature-to-jose",
-      "requires": {
-        "ecdsa-sig-formatter": "^1.0.11",
-        "esbuild": "0.19.5"
       }
     },
     "detect-newline": {


### PR DESCRIPTION
**OJ-2045: Simplify JWT signer tests**

- Move common setup code to the top of the test file
  Set up the `KMSClient` mock at the top
  Spy once on the method we want to mock so the spy doesn't need to be created in each test
  Improve readability as it's easier to understand `expect(kmsClient.send)....` than `expect(spy)...`

- Refactor and reduce the amount of code
  Remove unnecessary type assertions
  Inline one-time use constants that are not large enough to be defined separately

- Add newlines and make the tests easier to read, understand the logic and maintain
  Reduce nesting of tests

- Use the javascript `String.substring` and `Array.fill` functions to replace the more complex logic

**BAU: Exclude test secrets from secrets check**

Exclude specific known non-secrets rather than having to update the baseline file each time the line numbers change