### PR TITLE
BAU: Change integration to use sandbox URL

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -140,7 +140,7 @@ Resources:
               - "https://api.service.hmrc.gov.uk/individuals/authentication/authenticator/api/match"
               - Fn::Sub:
                   - "${ImposterApiUrl}/individuals/authentication/authenticator/api/match"
-                  - ImposterApiUrl: !ImportValue third-party-stubs-ImposterStubApiUrl,
+                  - ImposterApiUrl: !ImportValue third-party-stubs-ImposterStubApiUrl
 
   MaxJwtTtlParameter:
     Type: AWS::SSM::Parameter

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -92,10 +92,6 @@ Conditions:
     - dev
   IsNotDevEnvironment: !Not
     - Condition: IsDevEnvironment
-  IsStubEnvironment: !Or
-    - !Equals [!Ref Environment, dev]
-    - !Equals [!Ref Environment, build]
-    - !Equals [!Ref Environment, integration]
   IsStagingOrIntegrationEnvironment: !Or
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
@@ -137,19 +133,14 @@ Resources:
       Description: URL for HMRC /check endpoint
       Value:
         Fn::If:
-          - IsStubEnvironment
-          - Fn::Sub:
-              - "${ImposterApiUrl}/individuals/authentication/authenticator/api/match"
-              - {
-                  ImposterApiUrl: !ImportValue third-party-stubs-ImposterStubApiUrl,
-                }
+          - IsStagingOrIntegrationEnvironment
+          - "https://test-api.service.hmrc.gov.uk/individuals/authentication/authenticator/api/match"
           - Fn::If:
-              - IsStagingOrIntegrationEnvironment
-              - "https://test-api.service.hmrc.gov.uk/individuals/authentication/authenticator/api/match"
-              - Fn::If:
-                  - IsProductionEnvironment
-                  - "https://api.service.hmrc.gov.uk/individuals/authentication/authenticator/api/match"
-                  - ""
+              - IsProductionEnvironment
+              - "https://api.service.hmrc.gov.uk/individuals/authentication/authenticator/api/match"
+              - Fn::Sub:
+                  - "${ImposterApiUrl}/individuals/authentication/authenticator/api/match"
+                  - ImposterApiUrl: !ImportValue third-party-stubs-ImposterStubApiUrl,
 
   MaxJwtTtlParameter:
     Type: AWS::SSM::Parameter

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -96,9 +96,9 @@ Conditions:
     - !Equals [!Ref Environment, dev]
     - !Equals [!Ref Environment, build]
     - !Equals [!Ref Environment, integration]
-  IsStagingEnvironment: !Equals
-    - !Ref Environment
-    - staging
+  IsStagingOrIntegrationEnvironment: !Or
+    - !Equals [!Ref Environment, staging]
+    - !Equals [!Ref Environment, integration]
   IsProductionEnvironment: !Equals
     - !Ref Environment
     - production
@@ -144,7 +144,7 @@ Resources:
                   ImposterApiUrl: !ImportValue third-party-stubs-ImposterStubApiUrl,
                 }
           - Fn::If:
-              - IsStagingEnvironment
+              - IsStagingOrIntegrationEnvironment
               - "https://test-api.service.hmrc.gov.uk/individuals/authentication/authenticator/api/match"
               - Fn::If:
                   - IsProductionEnvironment


### PR DESCRIPTION
Integration does not use Imposter Stub so this has been changed so that it uses the HMRC sandbox URL instead