### PR TITLE
BAU: use result selector

### DIFF
--- a/step-functions/check_session.asl.json
+++ b/step-functions/check_session.asl.json
@@ -21,6 +21,9 @@
         "FunctionName": "${CurrentTimeFunctionArn}"
       },
       "Next": "Fetch Session",
+      "ResultSelector": {
+        "value.$": "$.Payload"
+      },
       "ResultPath": "$.currentTime"
     },
     "Fetch Session": {
@@ -36,13 +39,17 @@
         }
       },
       "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
+      "ResultSelector": {
+        "count.$": "$.Count",
+        "items.$": "$.Items"
+      },
       "ResultPath": "$.sessionQuery"
     },
     "Check Session Exists": {
       "Type": "Choice",
       "Choices": [
         {
-          "Variable": "$.sessionQuery.Count",
+          "Variable": "$.sessionQuery.count",
           "NumericLessThanEquals": 0,
           "Next": "Err: No session found"
         }
@@ -53,8 +60,8 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Variable": "$.currentTime.Payload",
-          "StringGreaterThanPath": "$.sessionQuery.Items[0].expiryDate.N",
+          "Variable": "$.currentTime.value",
+          "StringGreaterThanPath": "$.sessionQuery.items[0].expiryDate.N",
           "Next": "Err: Session Expired"
         }
       ],


### PR DESCRIPTION
## Proposed changes

Restrict output to required data using ResultSelector

### What changed

Unecessary data is passed across states

### Why did it change

Makes outputs more obvious,  and less bloated

Now 

```
{
  "sessionId": "123456789",
  "currentTime": {
    "value": "1700829076"
  },
  "sessionQuery": {
    "count": 1,
    "items": [
      {
        "expiryDate": {
          "N": "0"
        },
        "sessionId": {
          "S": "123456789"
        }
      }
    ]
  }
}
```

Before 

```
{
  "sessionId": "123456789",
  "currentTime": {
    "ExecutedVersion": "$LATEST",
    "Payload": "1700581384",
    "SdkHttpMetadata": {
      "AllHttpHeaders": {
        "X-Amz-Executed-Version": [
          "$LATEST"
        ],
        "x-amzn-Remapped-Content-Length": [
          "0"
        ],
        "Connection": [
          "keep-alive"
        ],
        "x-amzn-RequestId": [
          "1a2f46e5-1d43-42db-b722-a9932d6f1480"
        ],
        "Content-Length": [
          "12"
        ],
        "Date": [
          "Tue, 21 Nov 2023 15:43:04 GMT"
        ],
        "X-Amzn-Trace-Id": [
          "root=1-655cd008-726abe456e46229a1e3fd389;sampled=0;lineage=16323262:0"
        ],
        "Content-Type": [
          "application/json"
        ]
      },
      "HttpHeaders": {
        "Connection": "keep-alive",
        "Content-Length": "12",
        "Content-Type": "application/json",
        "Date": "Tue, 21 Nov 2023 15:43:04 GMT",
        "X-Amz-Executed-Version": "$LATEST",
        "x-amzn-Remapped-Content-Length": "0",
        "x-amzn-RequestId": "1a2f46e5-1d43-42db-b722-a9932d6f1480",
        "X-Amzn-Trace-Id": "root=1-655cd008-726abe456e46229a1e3fd389;sampled=0;lineage=16323262:0"
      },
      "HttpStatusCode": 200
    },
    "SdkResponseMetadata": {
      "RequestId": "1a2f46e5-1d43-42db-b722-a9932d6f1480"
    },
    "StatusCode": 200
  },
  "sessionQuery": {
    "Count": 1,
    "Items": [
      {
        "expiryDate": {
          "N": "0"
        },
        "sessionId": {
          "S": "123456789"
        }
      }
    ],
    "ScannedCount": 1
  }
}
```