### PR TITLE
BAU: Improvements to the integration tests

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -565,9 +565,6 @@ Outputs:
   NinoIssueCredentialStateMachineArn:
     Description: NINO Issue Credential state machine ARN
     Value: !Ref NinoIssueCredentialStateMachine
-  CommonStackName:
-    Description: Common Stack Name
-    Value: !Ref CommonStackName
   NinoAttemptsTable:
     Description: NinoAttemptsTable table name
     Value: !Ref NinoAttemptsTable

--- a/integration-tests/jest.config.ts
+++ b/integration-tests/jest.config.ts
@@ -6,5 +6,6 @@ export default {
   projects: ["tests/*/jest.config.ts"],
   testMatch: ["<rootDir>/**/*.test.ts"],
   collectCoverage: false,
+  testTimeout: 30_000,
   modulePaths: [],
 } satisfies Config;

--- a/integration-tests/tests/aws/check-session/check-session.test.ts
+++ b/integration-tests/tests/aws/check-session/check-session.test.ts
@@ -1,20 +1,13 @@
 import { describeStack, StackInfo } from "../resources/cloudformation-helper";
-import { clearItems, populateTable } from "../resources/dynamodb-helper";
+import { populateTable } from "../resources/dynamodb-helper";
 import { executeStepFunction } from "../resources/stepfunction-helper";
-import { input as stubInput } from "../resources/session-helper";
+import { clearSession, input as stubInput } from "../resources/session-helper";
 
 const input = stubInput();
 let stack: StackInfo;
 
-beforeAll(async () => {
-  stack = await describeStack();
-});
-
-afterEach(async () => {
-  await clearItems(stack.sessionTableName, {
-    sessionId: input.sessionId,
-  });
-});
+beforeAll(async () => (stack = await describeStack()));
+afterEach(async () => clearSession(stack, input));
 
 it("should return SESSION_OK when session has not expired", async () => {
   await populateTable(stack.sessionTableName, {

--- a/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
@@ -8,8 +8,6 @@ import {
   sessionData,
 } from "../resources/session-helper";
 
-jest.setTimeout(30_000);
-
 const input = stubInput();
 let stack: StackInfo;
 

--- a/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
@@ -1,122 +1,102 @@
-import { stackOutputs } from "../resources/cloudformation-helper";
+import { describeStack, StackInfo } from "../resources/cloudformation-helper";
 import { executeStepFunction } from "../resources/stepfunction-helper";
 import {
   clearItemsFromTables,
   populateTables,
 } from "../resources/dynamodb-helper";
+import { input as stubInput, user as testUser } from "../resources/session-helper";
 
 jest.setTimeout(30_000);
 
-describe("nino-check-happy", () => {
-  const input = {
-    sessionId: "123456789",
-    nino: "AA000003D",
-  };
+const input = stubInput();
+const user = testUser(input);
+let stack: StackInfo;
 
-  const testUser = {
-    nino: "AA000003D",
-    dob: "1948-04-23",
-    firstName: "Jim",
-    lastName: "Ferguson",
-  };
+beforeAll(async () => {
+  stack = await describeStack();
+});
 
-  let sessionTableName: string;
-  let personIdentityTableName: string;
-
-  let output: Partial<{
-    CommonStackName: string;
-    NinoAttemptsTable: string;
-    NinoUsersTable: string;
-    NinoCheckStateMachineArn: string;
-  }>;
-
-  beforeEach(async () => {
-    output = await stackOutputs(process.env.STACK_NAME);
-    sessionTableName = `session-${output.CommonStackName}`;
-    personIdentityTableName = `person-identity-${output.CommonStackName}`;
-
-    await populateTables(
-      {
-        tableName: sessionTableName,
-        items: {
-          sessionId: input.sessionId,
-          expiryDate: 9999999999,
-        },
+beforeEach(async () => {
+  await populateTables(
+    {
+      tableName: stack.sessionTableName,
+      items: {
+        sessionId: input.sessionId,
+        expiryDate: 9999999999,
       },
-      {
-        tableName: personIdentityTableName,
-        items: {
-          sessionId: input.sessionId,
-          nino: input.nino,
-          birthDates: [{ value: testUser.dob }],
-          names: [
-            {
-              nameParts: [
-                {
-                  type: "GivenName",
-                  value: testUser.firstName,
-                },
-                {
-                  type: "FamilyName",
-                  value: testUser.lastName,
-                },
-              ],
-            },
-          ],
-        },
-      }
-    );
-  });
+    },
+    {
+      tableName: stack.personIdentityTableName,
+      items: {
+        sessionId: input.sessionId,
+        nino: input.nino,
+        birthDates: [{ value: user.dob }],
+        names: [
+          {
+            nameParts: [
+              {
+                type: "GivenName",
+                value: user.firstName,
+              },
+              {
+                type: "FamilyName",
+                value: user.lastName,
+              },
+            ],
+          },
+        ],
+      },
+    }
+  );
+});
 
-  afterEach(
-    async () =>
-      await clearItemsFromTables(
-        {
-          tableName: sessionTableName,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: personIdentityTableName,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: output.NinoUsersTable as string,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: output.NinoAttemptsTable as string,
-          items: { id: input.sessionId },
-        }
-      )
+afterEach(async () => {
+  await clearItemsFromTables(
+    {
+      tableName: stack.sessionTableName,
+      items: { sessionId: input.sessionId },
+    },
+    {
+      tableName: stack.personIdentityTableName,
+      items: { sessionId: input.sessionId },
+    },
+    {
+      tableName: stack.outputs.NinoUsersTable as string,
+      items: { sessionId: input.sessionId },
+    },
+    {
+      tableName: stack.outputs.NinoAttemptsTable as string,
+      items: { id: input.sessionId },
+    }
+  );
+});
+
+it("should execute nino step function 1st attempt", async () => {
+  const startExecutionResult = await executeStepFunction(
+    stack.outputs.NinoCheckStateMachineArn as string,
+    input
   );
 
-  it("should execute nino step function 1st attempt", async () => {
-    const startExecutionResult = await executeStepFunction(
-      output.NinoCheckStateMachineArn as string,
-      input
-    );
+  expect(startExecutionResult.output).toBe("{}");
+});
 
-    expect(startExecutionResult.output).toBe("{}");
-  });
+it("should execute nino step function 2nd attempt", async () => {
+  const firstExecutionResult = await executeStepFunction(
+    stack.outputs.NinoCheckStateMachineArn as string,
+    {
+      sessionId: input.sessionId,
+      nino: "AB123003C",
+    }
+  );
 
-  it("should execute nino step function 2nd attempt", async () => {
-    const firstExecutionResult = await executeStepFunction(
-      output.NinoCheckStateMachineArn as string,
-      {
-        sessionId: input.sessionId,
-        nino: "AB123003C",
-      }
-    );
+  const secondExecutionResult = await executeStepFunction(
+    stack.outputs.NinoCheckStateMachineArn as string,
+    input
+  );
 
-    const secondExecutionResult = await executeStepFunction(
-      output.NinoCheckStateMachineArn as string,
-      input
-    );
+  expect(firstExecutionResult.output).toBe(
+    '{"error":"CID returned no record"}'
+  );
 
-    expect(firstExecutionResult.output).toBe(
-      '{"error":"CID returned no record"}'
-    );
-
-    expect(secondExecutionResult.output).toBe("{}");
-  });
+  expect(secondExecutionResult.output).toBe("{}");
 });

--- a/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
@@ -1,75 +1,28 @@
 import { describeStack, StackInfo } from "../resources/cloudformation-helper";
 import { executeStepFunction } from "../resources/stepfunction-helper";
+import { populateTables } from "../resources/dynamodb-helper";
 import {
-  clearItemsFromTables,
-  populateTables,
-} from "../resources/dynamodb-helper";
-import { input as stubInput, user as testUser } from "../resources/session-helper";
+  clearSession,
+  input as stubInput,
+  personIdentityData,
+  sessionData,
+} from "../resources/session-helper";
 
 jest.setTimeout(30_000);
 
 const input = stubInput();
-const user = testUser(input);
 let stack: StackInfo;
 
-beforeAll(async () => {
-  stack = await describeStack();
-});
+beforeAll(async () => (stack = await describeStack()));
 
 beforeEach(async () => {
   await populateTables(
-    {
-      tableName: stack.sessionTableName,
-      items: {
-        sessionId: input.sessionId,
-        expiryDate: 9999999999,
-      },
-    },
-    {
-      tableName: stack.personIdentityTableName,
-      items: {
-        sessionId: input.sessionId,
-        nino: input.nino,
-        birthDates: [{ value: user.dob }],
-        names: [
-          {
-            nameParts: [
-              {
-                type: "GivenName",
-                value: user.firstName,
-              },
-              {
-                type: "FamilyName",
-                value: user.lastName,
-              },
-            ],
-          },
-        ],
-      },
-    }
+    personIdentityData(stack, input),
+    sessionData(stack, input)
   );
 });
 
-afterEach(async () => {
-  await clearItemsFromTables(
-    {
-      tableName: stack.sessionTableName,
-      items: { sessionId: input.sessionId },
-    },
-    {
-      tableName: stack.personIdentityTableName,
-      items: { sessionId: input.sessionId },
-    },
-    {
-      tableName: stack.outputs.NinoUsersTable as string,
-      items: { sessionId: input.sessionId },
-    },
-    {
-      tableName: stack.outputs.NinoAttemptsTable as string,
-      items: { id: input.sessionId },
-    }
-  );
-});
+afterEach(async () => await clearSession(stack, input));
 
 it("should execute nino step function 1st attempt", async () => {
   const startExecutionResult = await executeStepFunction(

--- a/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
@@ -17,8 +17,6 @@ import {
   sessionData,
 } from "../resources/session-helper";
 
-jest.setTimeout(30_000);
-
 const input = stubInput();
 const invalidInput = stubInput("AB123003C");
 const secretsManager = new SecretsManager();

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
@@ -14,8 +14,6 @@ import {
 } from "../resources/session-helper";
 import { describeStack, StackInfo } from "../resources/cloudformation-helper";
 
-jest.setTimeout(30_000);
-
 const input = stubInput();
 const user = testUser(input);
 let stack: StackInfo;

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
@@ -1,218 +1,194 @@
-import { stackOutputs } from "../resources/cloudformation-helper";
 import { executeStepFunction } from "../resources/stepfunction-helper";
 import {
   clearItemsFromTables,
   populateTables,
 } from "../resources/dynamodb-helper";
-
 import {
   getSSMParameter,
   getSSMParameters,
   updateSSMParameters,
 } from "../resources/ssm-param-helper";
+import { describeStack, StackInfo } from "../resources/cloudformation-helper";
+import {
+  input as stubInput,
+  isValidTimestamp,
+  user as testUser,
+} from "../resources/session-helper";
 
 jest.setTimeout(30_000);
 
-describe("nino-issue-credential-happy", () => {
-  const input = {
-    sessionId: "123456789",
-    nino: "AA000003D",
-  };
+const input = stubInput();
+const user = testUser(input);
+let stack: StackInfo;
 
-  const testUser = {
-    nino: "AA000003D",
-    dob: "1948-04-23",
-    firstName: "Jim",
-    lastName: "Ferguson",
-  };
+beforeAll(async () => {
+  stack = await describeStack();
+});
 
-  let sessionTableName: string;
-  let personIdentityTableName: string;
-
-  let output: Partial<{
-    CommonStackName: string;
-    NinoAttemptsTable: string;
-    NinoUsersTable: string;
-    NinoIssueCredentialStateMachineArn: string;
-  }>;
-
-  beforeEach(async () => {
-    output = await stackOutputs(process.env.STACK_NAME);
-    sessionTableName = `session-${output.CommonStackName}`;
-    personIdentityTableName = `person-identity-${output.CommonStackName}`;
-
-    await populateTables(
-      {
-        tableName: output.NinoUsersTable as string,
-        items: {
-          sessionId: "123456789",
-          nino: "AA000003D",
-        },
+beforeEach(async () => {
+  await populateTables(
+    {
+      tableName: stack.outputs.NinoUsersTable as string,
+      items: {
+        sessionId: input.sessionId,
+        nino: input.nino,
       },
-      {
-        tableName: sessionTableName,
-        items: {
-          sessionId: "123456789",
-          accessToken: "Bearer test",
-          authorizationCode: "cd8ff974-d3bc-4422-9b38-a3e5eb24adc0",
-          authorizationCodeExpiryDate: "1698925598",
-          expiryDate: "9999999999",
-          subject: "test",
-        },
+    },
+    {
+      tableName: stack.sessionTableName,
+      items: {
+        sessionId: input.sessionId,
+        accessToken: "Bearer test",
+        authorizationCode: "cd8ff974-d3bc-4422-9b38-a3e5eb24adc0",
+        authorizationCodeExpiryDate: "1698925598",
+        expiryDate: "9999999999",
+        subject: "test",
       },
-      {
-        tableName: personIdentityTableName,
-        items: {
-          sessionId: input.sessionId,
-          nino: input.nino,
-          birthDates: [{ value: testUser.dob }],
-          names: [
-            {
-              nameParts: [
-                {
-                  type: "GivenName",
-                  value: testUser.firstName,
-                },
-                {
-                  type: "FamilyName",
-                  value: testUser.lastName,
-                },
-              ],
-            },
-          ],
-        },
+    },
+    {
+      tableName: stack.personIdentityTableName,
+      items: {
+        sessionId: input.sessionId,
+        nino: input.nino,
+        birthDates: [{ value: user.dob }],
+        names: [
+          {
+            nameParts: [
+              {
+                type: "GivenName",
+                value: user.firstName,
+              },
+              {
+                type: "FamilyName",
+                value: user.lastName,
+              },
+            ],
+          },
+        ],
       },
-      {
-        tableName: output.NinoAttemptsTable as string,
-        items: {
-          id: "123456789",
-          attempts: 1,
-          outcome: "PASS",
-        },
-      }
-    );
-  });
+    },
+    {
+      tableName: stack.outputs.NinoAttemptsTable as string,
+      items: {
+        id: input.sessionId,
+        attempts: 1,
+        outcome: "PASS",
+      },
+    }
+  );
+});
 
-  afterEach(
-    async () =>
-      await clearItemsFromTables(
-        {
-          tableName: sessionTableName,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: personIdentityTableName,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: output.NinoUsersTable as string,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: output.NinoAttemptsTable as string,
-          items: { id: input.sessionId },
-        }
-      )
+afterEach(async () => {
+  await clearItemsFromTables(
+    {
+      tableName: stack.sessionTableName,
+      items: { sessionId: input.sessionId },
+    },
+    {
+      tableName: stack.personIdentityTableName,
+      items: { sessionId: input.sessionId },
+    },
+    {
+      tableName: stack.outputs.NinoUsersTable as string,
+      items: { sessionId: input.sessionId },
+    },
+    {
+      tableName: stack.outputs.NinoAttemptsTable as string,
+      items: { id: input.sessionId },
+    }
+  );
+});
+
+it("should create signed JWT when nino check is successful", async () => {
+  const startExecutionResult = await executeStepFunction(
+    stack.outputs.NinoIssueCredentialStateMachineArn as string,
+    {
+      bearerToken: "Bearer test",
+    }
   );
 
-  it("should create signed JWT when nino check is successful", async () => {
-    const startExecutionResult = await executeStepFunction(
-      output.NinoIssueCredentialStateMachineArn as string,
-      {
-        bearerToken: "Bearer test",
-      }
-    );
+  const verifiableCredentialKmsSigningKeyId = `/${stack.outputs.CommonStackName}/verifiableCredentialKmsSigningKeyId`;
 
-    const verifiableCredentialKmsSigningKeyId = `/${output.CommonStackName}/verifiableCredentialKmsSigningKeyId`;
+  const currentCredentialKmsSigningKeyId = await getSSMParameter(
+    verifiableCredentialKmsSigningKeyId
+  );
 
-    const currentCredentialKmsSigningKeyId = await getSSMParameter(
-      verifiableCredentialKmsSigningKeyId
-    );
+  const token = JSON.parse(startExecutionResult.output as string);
 
-    const token = JSON.parse(startExecutionResult.output as string);
+  const [headerEncoded, payloadEncoded, _] = token.jwt.split(".");
 
-    const [headerEncoded, payloadEncoded, _] = token.jwt.split(".");
+  const header = JSON.parse(atob(headerEncoded));
+  const payload = JSON.parse(atob(payloadEncoded));
 
-    const header = JSON.parse(atob(headerEncoded));
-    const payload = JSON.parse(atob(payloadEncoded));
+  expect(header.typ).toBe("JWT");
+  expect(header.alg).toBe("ES256");
+  expect(header.kid).toBe(currentCredentialKmsSigningKeyId);
 
-    expect(header.typ).toBe("JWT");
-    expect(header.alg).toBe("ES256");
-    expect(header.kid).toBe(currentCredentialKmsSigningKeyId);
+  const evidence = payload.vc.evidence[0];
+  expect(evidence.type).toBe("IdentityCheck");
+  expect(evidence.strengthScore).toBe(2);
+  expect(evidence.validityScore).toBe(2);
+  expect(evidence.checkDetails[0].checkMethod).toBe("data");
+  expect(evidence.checkDetails[0].identityCheckPolicy).toBe("published");
+  expect(evidence.txn).not.toBeNull;
 
-    const evidence = payload.vc.evidence[0];
-    expect(evidence.type).toBe("IdentityCheck");
-    expect(evidence.strengthScore).toBe(2);
-    expect(evidence.validityScore).toBe(2);
-    expect(evidence.checkDetails[0].checkMethod).toBe("data");
-    expect(evidence.checkDetails[0].identityCheckPolicy).toBe("published");
-    expect(evidence.txn).not.toBeNull;
+  const credentialSubject = payload.vc.credentialSubject;
+  expect(credentialSubject.socialSecurityRecord[0].personalNumber).toBe(
+    user.nino
+  );
+  expect(credentialSubject.name[0].nameParts[0].type).toBe("GivenName");
+  expect(credentialSubject.name[0].nameParts[0].value).toBe(user.firstName);
+  expect(credentialSubject.name[0].nameParts[1].type).toBe("FamilyName");
+  expect(credentialSubject.name[0].nameParts[1].value).toBe(user.lastName);
 
-    const credentialSubject = payload.vc.credentialSubject;
-    expect(credentialSubject.socialSecurityRecord[0].personalNumber).toBe(
-      testUser.nino
-    );
-    expect(credentialSubject.name[0].nameParts[0].type).toBe("GivenName");
-    expect(credentialSubject.name[0].nameParts[0].value).toBe(
-      testUser.firstName
-    );
-    expect(credentialSubject.name[0].nameParts[1].type).toBe("FamilyName");
-    expect(credentialSubject.name[0].nameParts[1].value).toBe(
-      testUser.lastName
-    );
+  expect(payload.vc.type[0]).toBe("VerifiableCredential");
+  expect(payload.vc.type[1]).toBe("IdentityCheckCredential");
 
-    expect(payload.vc.type[0]).toBe("VerifiableCredential");
-    expect(payload.vc.type[1]).toBe("IdentityCheckCredential");
+  expect(payload.vc["@context"][0]).toBe(
+    "https://www.w3.org/2018/credentials/v1"
+  );
+  expect(payload.vc["@context"][1]).toBe(
+    "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
+  );
 
-    expect(payload.vc["@context"][0]).toBe(
-      "https://www.w3.org/2018/credentials/v1"
-    );
-    expect(payload.vc["@context"][1]).toBe(
-      "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
-    );
+  expect(payload.sub).not.toBeNull;
+  expect(isValidTimestamp(payload.nbf)).toBe(true);
+  expect(payload.iss).not.toBeNull;
+  expect(isValidTimestamp(payload.exp)).toBe(true);
+  expect(payload.jti).not.toBeNull;
+});
 
-    expect(payload.sub).not.toBeNull;
-    expect(isValidTimestamp(payload.nbf)).toBe(true);
-    expect(payload.iss).not.toBeNull;
-    expect(isValidTimestamp(payload.exp)).toBe(true);
-    expect(payload.jti).not.toBeNull;
-  });
+it("should create the valid expiry date", async () => {
+  const maxJwtTtl = `/${process.env.STACK_NAME}/MaxJwtTtl`;
+  const jwtTtlUnit = `/${process.env.STACK_NAME}/JwtTtlUnit`;
 
-  it("should create the valid expiry date", async () => {
-    const maxJwtTtl = `/${process.env.STACK_NAME}/MaxJwtTtl`;
-    const jwtTtlUnit = `/${process.env.STACK_NAME}/JwtTtlUnit`;
+  const [currentMaxJwtTtl, currentJwtTtlUnit] = await getSSMParameters(
+    `/${process.env.STACK_NAME}/MaxJwtTtl`,
+    `/${process.env.STACK_NAME}/JwtTtlUnit`
+  );
 
-    const [currentMaxJwtTtl, currentJwtTtlUnit] = await getSSMParameters(
-      `/${process.env.STACK_NAME}/MaxJwtTtl`,
-      `/${process.env.STACK_NAME}/JwtTtlUnit`
-    );
+  await updateSSMParameters(
+    { name: maxJwtTtl, value: "5" },
+    { name: jwtTtlUnit, value: "MINUTES" }
+  );
 
-    await updateSSMParameters(
-      { name: maxJwtTtl, value: "5" },
-      { name: jwtTtlUnit, value: "MINUTES" }
-    );
+  const startExecutionResult = await executeStepFunction(
+    stack.outputs.NinoIssueCredentialStateMachineArn as string,
+    {
+      bearerToken: "Bearer test",
+    }
+  );
 
-    const startExecutionResult = await executeStepFunction(
-      output.NinoIssueCredentialStateMachineArn as string,
-      {
-        bearerToken: "Bearer test",
-      }
-    );
+  await updateSSMParameters(
+    { name: maxJwtTtl, value: currentMaxJwtTtl as string },
+    { name: jwtTtlUnit, value: currentJwtTtlUnit as string }
+  );
 
-    await updateSSMParameters(
-      { name: maxJwtTtl, value: currentMaxJwtTtl as string },
-      { name: jwtTtlUnit, value: currentJwtTtlUnit as string }
-    );
+  const token = JSON.parse(startExecutionResult.output as string);
 
-    const token = JSON.parse(startExecutionResult.output as string);
+  const payloadEncoded = token.jwt.split(".")[1];
 
-    const payloadEncoded = token.jwt.split(".")[1];
+  const payload = JSON.parse(atob(payloadEncoded));
 
-    const payload = JSON.parse(atob(payloadEncoded));
-
-    expect(payload.exp).toBe(payload.nbf + 5 * 1000 * 60);
-  });
-
-  const isValidTimestamp = (timestamp: number) =>
-    !isNaN(new Date(timestamp).getTime());
+  expect(payload.exp).toBe(payload.nbf + 5 * 1000 * 60);
 });

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
@@ -66,10 +66,8 @@ it("should create signed JWT when nino check is successful", async () => {
     }
   );
 
-  const verifiableCredentialKmsSigningKeyId = `/${stack.outputs.CommonStackName}/verifiableCredentialKmsSigningKeyId`;
-
   const currentCredentialKmsSigningKeyId = await getSSMParameter(
-    verifiableCredentialKmsSigningKeyId
+    stack.verifiableCredentialKmsSigningKeyId
   );
 
   const token = JSON.parse(startExecutionResult.output as string);

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
@@ -9,8 +9,6 @@ import {
   user as testUser,
 } from "../resources/session-helper";
 
-jest.setTimeout(30_000);
-
 const input = stubInput();
 const user = testUser(input);
 let stack: StackInfo;

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
@@ -1,176 +1,152 @@
-import { stackOutputs } from "../resources/cloudformation-helper";
+import { describeStack, StackInfo } from "../resources/cloudformation-helper";
 import { executeStepFunction } from "../resources/stepfunction-helper";
 import {
   clearItemsFromTables,
   populateTables,
 } from "../resources/dynamodb-helper";
+import {
+  input as stubInput,
+  isValidTimestamp,
+  user as testUser,
+} from "../resources/session-helper";
 
 jest.setTimeout(30_000);
 
-describe("nino-issue-credential-unhappy", () => {
-  const input = {
-    sessionId: "123456789",
-    nino: "AA000003D",
-  };
+const input = stubInput();
+const user = testUser(input);
+let stack: StackInfo;
 
-  const testUser = {
-    nino: "AA000003D",
-    dob: "1948-04-23",
-    firstName: "Jim",
-    lastName: "Ferguson",
-  };
+beforeAll(async () => {
+  stack = await describeStack();
+});
 
-  let sessionTableName: string;
-  let personIdentityTableName: string;
-
-  let output: Partial<{
-    CommonStackName: string;
-    NinoAttemptsTable: string;
-    NinoUsersTable: string;
-    NinoIssueCredentialStateMachineArn: string;
-  }>;
-
-  beforeEach(async () => {
-    output = await stackOutputs(process.env.STACK_NAME);
-    sessionTableName = `session-${output.CommonStackName}`;
-    personIdentityTableName = `person-identity-${output.CommonStackName}`;
-
-    await populateTables(
-      {
-        tableName: output.NinoUsersTable as string,
-        items: {
-          sessionId: "123456789",
-          nino: "AA000003D",
-        },
+beforeEach(async () => {
+  await populateTables(
+    {
+      tableName: stack.outputs.NinoUsersTable as string,
+      items: {
+        sessionId: input.sessionId,
+        nino: input.nino,
       },
-      {
-        tableName: sessionTableName,
-        items: {
-          sessionId: "123456789",
-          accessToken: "Bearer test",
-          authorizationCode: "cd8ff974-d3bc-4422-9b38-a3e5eb24adc0",
-          authorizationCodeExpiryDate: "1698925598",
-          expiryDate: "9999999999",
-          subject: "test",
-        },
+    },
+    {
+      tableName: stack.sessionTableName,
+      items: {
+        sessionId: input.sessionId,
+        accessToken: "Bearer test",
+        authorizationCode: "cd8ff974-d3bc-4422-9b38-a3e5eb24adc0",
+        authorizationCodeExpiryDate: "1698925598",
+        expiryDate: "9999999999",
+        subject: "test",
       },
-      {
-        tableName: personIdentityTableName,
-        items: {
-          sessionId: input.sessionId,
-          nino: input.nino,
-          birthDates: [{ value: testUser.dob }],
-          names: [
-            {
-              nameParts: [
-                {
-                  type: "GivenName",
-                  value: testUser.firstName,
-                },
-                {
-                  type: "FamilyName",
-                  value: testUser.lastName,
-                },
-              ],
-            },
-          ],
-        },
+    },
+    {
+      tableName: stack.personIdentityTableName,
+      items: {
+        sessionId: input.sessionId,
+        nino: input.nino,
+        birthDates: [{ value: user.dob }],
+        names: [
+          {
+            nameParts: [
+              {
+                type: "GivenName",
+                value: user.firstName,
+              },
+              {
+                type: "FamilyName",
+                value: user.lastName,
+              },
+            ],
+          },
+        ],
       },
-      {
-        tableName: output.NinoAttemptsTable as string,
-        items: {
-          id: "123456789",
-          attempts: 2,
-          outcome: "FAIL",
-        },
-      }
-    );
-  });
+    },
+    {
+      tableName: stack.outputs.NinoAttemptsTable as string,
+      items: {
+        id: input.sessionId,
+        attempts: 2,
+        outcome: "FAIL",
+      },
+    }
+  );
+});
 
-  afterEach(
-    async () =>
-      await clearItemsFromTables(
-        {
-          tableName: sessionTableName,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: personIdentityTableName,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: output.NinoUsersTable as string,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: output.NinoAttemptsTable as string,
-          items: { id: input.sessionId },
-        }
-      )
+afterEach(async () => {
+  await clearItemsFromTables(
+    {
+      tableName: stack.sessionTableName,
+      items: { sessionId: input.sessionId },
+    },
+    {
+      tableName: stack.personIdentityTableName,
+      items: { sessionId: input.sessionId },
+    },
+    {
+      tableName: stack.outputs.NinoUsersTable as string,
+      items: { sessionId: input.sessionId },
+    },
+    {
+      tableName: stack.outputs.NinoAttemptsTable as string,
+      items: { id: input.sessionId },
+    }
+  );
+});
+
+it("should fail when nino check is unsuccessful", async () => {
+  const startExecutionResult = await executeStepFunction(
+    stack.outputs.NinoIssueCredentialStateMachineArn as string,
+    {
+      bearerToken: "Bearer test",
+    }
   );
 
-  it("should fail when nino check is unsuccessful", async () => {
-    const startExecutionResult = await executeStepFunction(
-      output.NinoIssueCredentialStateMachineArn as string,
-      {
-        bearerToken: "Bearer test",
-      }
-    );
+  const token = JSON.parse(startExecutionResult.output as string);
 
-    const token = JSON.parse(startExecutionResult.output as string);
+  const [headerEncoded, payloadEncoded, signatureEncoded] =
+    token.jwt.split(".");
 
-    const [headerEncoded, payloadEncoded, signatureEncoded] =
-      token.jwt.split(".");
+  const header = JSON.parse(atob(headerEncoded));
+  const payload = JSON.parse(atob(payloadEncoded));
+  const signature = atob(signatureEncoded);
 
-    const header = JSON.parse(atob(headerEncoded));
-    const payload = JSON.parse(atob(payloadEncoded));
-    const signature = atob(signatureEncoded);
+  expect(header.typ).toBe("JWT");
+  expect(header.alg).toBe("ES256");
+  expect(header.kid).not.toBeNull;
 
-    expect(header.typ).toBe("JWT");
-    expect(header.alg).toBe("ES256");
-    expect(header.kid).not.toBeNull;
+  const evidence = payload.vc.evidence[0];
+  expect(evidence.type).toBe("IdentityCheck");
+  expect(evidence.strengthScore).toBe(2);
+  expect(evidence.validityScore).toBe(0);
+  expect(evidence.failedCheckDetails[0].checkMethod).toBe("data");
+  expect(evidence.ci[0]).toBe("D02");
+  expect(evidence.txn).not.toBeNull;
 
-    const evidence = payload.vc.evidence[0];
-    expect(evidence.type).toBe("IdentityCheck");
-    expect(evidence.strengthScore).toBe(2);
-    expect(evidence.validityScore).toBe(0);
-    expect(evidence.failedCheckDetails[0].checkMethod).toBe("data");
-    expect(evidence.ci[0]).toBe("D02");
-    expect(evidence.txn).not.toBeNull;
+  const credentialSubject = payload.vc.credentialSubject;
+  expect(credentialSubject.socialSecurityRecord[0].personalNumber).toBe(
+    user.nino
+  );
+  expect(credentialSubject.name[0].nameParts[0].type).toBe("GivenName");
+  expect(credentialSubject.name[0].nameParts[0].value).toBe(user.firstName);
+  expect(credentialSubject.name[0].nameParts[1].type).toBe("FamilyName");
+  expect(credentialSubject.name[0].nameParts[1].value).toBe(user.lastName);
 
-    const credentialSubject = payload.vc.credentialSubject;
-    expect(credentialSubject.socialSecurityRecord[0].personalNumber).toBe(
-      testUser.nino
-    );
-    expect(credentialSubject.name[0].nameParts[0].type).toBe("GivenName");
-    expect(credentialSubject.name[0].nameParts[0].value).toBe(
-      testUser.firstName
-    );
-    expect(credentialSubject.name[0].nameParts[1].type).toBe("FamilyName");
-    expect(credentialSubject.name[0].nameParts[1].value).toBe(
-      testUser.lastName
-    );
+  expect(payload.vc.type[0]).toBe("VerifiableCredential");
+  expect(payload.vc.type[1]).toBe("IdentityCheckCredential");
 
-    expect(payload.vc.type[0]).toBe("VerifiableCredential");
-    expect(payload.vc.type[1]).toBe("IdentityCheckCredential");
+  expect(payload.vc["@context"][0]).toBe(
+    "https://www.w3.org/2018/credentials/v1"
+  );
+  expect(payload.vc["@context"][1]).toBe(
+    "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
+  );
 
-    expect(payload.vc["@context"][0]).toBe(
-      "https://www.w3.org/2018/credentials/v1"
-    );
-    expect(payload.vc["@context"][1]).toBe(
-      "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
-    );
+  expect(payload.sub).not.toBeNull;
+  expect(isValidTimestamp(payload.nbf)).toBe(true);
+  expect(payload.iss).not.toBeNull;
+  expect(isValidTimestamp(payload.exp)).toBe(true);
+  expect(payload.jti).not.toBeNull;
 
-    expect(payload.sub).not.toBeNull;
-    expect(isValidTimestamp(payload.nbf)).toBe(true);
-    expect(payload.iss).not.toBeNull;
-    expect(isValidTimestamp(payload.exp)).toBe(true);
-    expect(payload.jti).not.toBeNull;
-
-    expect(signature).not.toBeNull;
-  });
-
-  function isValidTimestamp(timestamp: number): boolean {
-    return !isNaN(new Date(timestamp).getTime());
-  }
+  expect(signature).not.toBeNull;
 });

--- a/integration-tests/tests/aws/resources/cloudformation-helper.ts
+++ b/integration-tests/tests/aws/resources/cloudformation-helper.ts
@@ -7,7 +7,6 @@ import { createSendCommand } from "./aws-helper";
 export type StackInfo = Awaited<ReturnType<typeof describeStack>>;
 
 type Outputs = Partial<{
-  CommonStackName: string;
   NinoAttemptsTable: string;
   NinoUsersTable: string;
   NinoCheckStateMachineArn: string;
@@ -57,6 +56,7 @@ export async function describeStack() {
   return {
     sessionTableName: `session-${commonStackName}`,
     personIdentityTableName: `person-identity-${commonStackName}`,
+    verifiableCredentialKmsSigningKeyId: `/${commonStackName}/verifiableCredentialKmsSigningKeyId`,
     outputs: outputs,
   };
 }

--- a/integration-tests/tests/aws/resources/session-helper.ts
+++ b/integration-tests/tests/aws/resources/session-helper.ts
@@ -1,3 +1,8 @@
+import { clearItemsFromTables } from "./dynamodb-helper";
+import { StackInfo } from "./cloudformation-helper";
+
+type Input = ReturnType<typeof input>;
+
 export const input = (nino?: string) => ({
   sessionId: "123456789",
   nino: nino || "AA000003D",
@@ -12,3 +17,58 @@ export const user = (stateMachineInput = input()) => ({
 
 export const isValidTimestamp = (timestamp: number) =>
   !isNaN(new Date(timestamp).getTime());
+
+export const clearSession = (stack: StackInfo, input: Input) =>
+  clearItemsFromTables(
+    {
+      tableName: stack.sessionTableName,
+      items: { sessionId: input.sessionId },
+    },
+    {
+      tableName: stack.personIdentityTableName,
+      items: { sessionId: input.sessionId },
+    },
+    {
+      tableName: stack.outputs.NinoUsersTable as string,
+      items: { sessionId: input.sessionId },
+    },
+    {
+      tableName: stack.outputs.NinoAttemptsTable as string,
+      items: { id: input.sessionId },
+    }
+  );
+
+export const sessionData = (stack: StackInfo, input: Input) => ({
+  tableName: stack.sessionTableName,
+  items: {
+    sessionId: input.sessionId,
+    expiryDate: 9999999999,
+  },
+});
+
+export const personIdentityData = (
+  stack: StackInfo,
+  input: Input,
+  testUser = user(input)
+) => ({
+  tableName: stack.personIdentityTableName,
+  items: {
+    sessionId: input.sessionId,
+    nino: input.nino,
+    birthDates: [{ value: testUser.dob }],
+    names: [
+      {
+        nameParts: [
+          {
+            type: "GivenName",
+            value: testUser.firstName,
+          },
+          {
+            type: "FamilyName",
+            value: testUser.lastName,
+          },
+        ],
+      },
+    ],
+  },
+});

--- a/integration-tests/tests/aws/resources/session-helper.ts
+++ b/integration-tests/tests/aws/resources/session-helper.ts
@@ -1,0 +1,14 @@
+export const input = (nino?: string) => ({
+  sessionId: "123456789",
+  nino: nino || "AA000003D",
+});
+
+export const user = (stateMachineInput = input()) => ({
+  nino: stateMachineInput.nino,
+  dob: "1948-04-23",
+  firstName: "Jim",
+  lastName: "Ferguson",
+});
+
+export const isValidTimestamp = (timestamp: number) =>
+  !isNaN(new Date(timestamp).getTime());

--- a/integration-tests/tests/mocked/check-session/check-session.test.ts
+++ b/integration-tests/tests/mocked/check-session/check-session.test.ts
@@ -1,8 +1,6 @@
 import { HistoryEvent } from "@aws-sdk/client-sfn";
 import { SfnContainerHelper } from "./sfn-container-helper";
 
-jest.setTimeout(30_000);
-
 describe("check-session", () => {
   let sfnContainer: SfnContainerHelper;
 

--- a/integration-tests/tests/mocked/check-session/check-session.test.ts
+++ b/integration-tests/tests/mocked/check-session/check-session.test.ts
@@ -1,84 +1,100 @@
 import { HistoryEvent } from "@aws-sdk/client-sfn";
 import { SfnContainerHelper } from "./sfn-container-helper";
 
-describe("check-session", () => {
-  let sfnContainer: SfnContainerHelper;
+let sfnContainer: SfnContainerHelper;
 
-  beforeAll(async () => {
-    sfnContainer = new SfnContainerHelper();
+beforeAll(async () => (sfnContainer = new SfnContainerHelper()));
+afterAll(async () => sfnContainer.shutDown());
+
+it("has a step-function docker container running", async () => {
+  expect(sfnContainer.getContainer()).toBeDefined();
+});
+
+describe("happy path tests", () => {
+  it("it should pass when session exists and is not expired", async () => {
+    const input = JSON.stringify({
+      sessionId: "12345",
+    });
+
+    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+      "HappyPath",
+      input
+    );
+
+    const results = await sfnContainer.waitFor(
+      (event: HistoryEvent) =>
+        event?.type === "PassStateExited" &&
+        event?.stateExitedEventDetails?.name === "Session OK",
+      responseStepFunction
+    );
+
+    expect(results[0].stateExitedEventDetails?.output).toEqual(
+      '{"status":"SESSION_OK"}'
+    );
+  });
+});
+
+describe("unhappy path tests", () => {
+  it("it should fail when session does not exist", async () => {
+    const input = JSON.stringify({
+      sessionId: "12345",
+    });
+
+    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+      "NoSessionFound",
+      input
+    );
+
+    const results = await sfnContainer.waitFor(
+      (event: HistoryEvent) =>
+        event?.type === "PassStateExited" &&
+        event?.stateExitedEventDetails?.name === "Err: No session found",
+      responseStepFunction
+    );
+
+    expect(results[0].stateExitedEventDetails?.output).toEqual(
+      '{"status":"SESSION_NOT_FOUND"}'
+    );
   });
 
-  afterAll(async () => sfnContainer.shutDown());
+  it("it should fail when the session has expired", async () => {
+    const input = JSON.stringify({
+      sessionId: "12345",
+    });
 
-  it("has a step-function docker container running", async () => {
-    expect(sfnContainer.getContainer()).toBeDefined();
+    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+      "SessionExpired",
+      input
+    );
+
+    const results = await sfnContainer.waitFor(
+      (event: HistoryEvent) =>
+        event?.type === "PassStateExited" &&
+        event?.stateExitedEventDetails?.name === "Err: Session Expired",
+      responseStepFunction
+    );
+
+    expect(results[0].stateExitedEventDetails?.output).toEqual(
+      '{"status":"SESSION_EXPIRED"}'
+    );
   });
 
-  describe("happy path tests", () => {
-    it("it should pass when session exists and is not expired", async () => {
-      const input = JSON.stringify({
-        sessionId: "12345",
-      });
-      const responseStepFunction =
-        await sfnContainer.startStepFunctionExecution("HappyPath", input);
-      const results = await sfnContainer.waitFor(
-        (event: HistoryEvent) =>
-          event?.type === "PassStateExited" &&
-          event?.stateExitedEventDetails?.name === "Session OK",
-        responseStepFunction
-      );
-      expect(results[0].stateExitedEventDetails?.output).toEqual(
-        '{"status":"SESSION_OK"}'
-      );
-    });
-  });
+  it("it should fail when no sessionId was provided", async () => {
+    const input = JSON.stringify({});
+    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+      "SessionExpired",
+      input
+    );
 
-  describe("unhappy path tests", () => {
-    it("it should fail when session does not exist", async () => {
-      const input = JSON.stringify({
-        sessionId: "12345",
-      });
-      const responseStepFunction =
-        await sfnContainer.startStepFunctionExecution("NoSessionFound", input);
-      const results = await sfnContainer.waitFor(
-        (event: HistoryEvent) =>
-          event?.type === "PassStateExited" &&
-          event?.stateExitedEventDetails?.name === "Err: No session found",
-        responseStepFunction
-      );
-      expect(results[0].stateExitedEventDetails?.output).toEqual(
-        '{"status":"SESSION_NOT_FOUND"}'
-      );
-    });
-    it("it should fail when the session has expired", async () => {
-      const input = JSON.stringify({
-        sessionId: "12345",
-      });
-      const responseStepFunction =
-        await sfnContainer.startStepFunctionExecution("SessionExpired", input);
-      const results = await sfnContainer.waitFor(
-        (event: HistoryEvent) =>
-          event?.type === "PassStateExited" &&
-          event?.stateExitedEventDetails?.name === "Err: Session Expired",
-        responseStepFunction
-      );
-      expect(results[0].stateExitedEventDetails?.output).toEqual(
-        '{"status":"SESSION_EXPIRED"}'
-      );
-    });
-    it("it should fail when no sessionId was provided", async () => {
-      const input = JSON.stringify({});
-      const responseStepFunction =
-        await sfnContainer.startStepFunctionExecution("SessionExpired", input);
-      const results = await sfnContainer.waitFor(
-        (event: HistoryEvent) =>
-          event?.type === "PassStateExited" &&
-          event?.stateExitedEventDetails?.name === "Err: No sessionId provided",
-        responseStepFunction
-      );
-      expect(results[0].stateExitedEventDetails?.output).toEqual(
-        '{"status":"SESSION_NOT_PROVIDED"}'
-      );
-    });
+    const results = await sfnContainer.waitFor(
+      (event: HistoryEvent) =>
+        event?.type === "PassStateExited" &&
+        event?.stateExitedEventDetails?.name === "Err: No sessionId provided",
+      responseStepFunction
+    );
+
+    expect(results[0].stateExitedEventDetails?.output).toEqual(
+      '{"status":"SESSION_NOT_PROVIDED"}'
+    );
   });
 });

--- a/integration-tests/tests/mocked/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/mocked/nino-check/nino-check-happy.test.ts
@@ -1,8 +1,6 @@
 import { HistoryEvent } from "@aws-sdk/client-sfn";
 import { SfnContainerHelper } from "./sfn-container-helper";
 
-jest.setTimeout(60_000);
-
 describe("nino-check-happy", () => {
   let sfnContainer: SfnContainerHelper;
 

--- a/integration-tests/tests/mocked/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/mocked/nino-check/nino-check-happy.test.ts
@@ -1,36 +1,34 @@
 import { HistoryEvent } from "@aws-sdk/client-sfn";
 import { SfnContainerHelper } from "./sfn-container-helper";
 
-describe("nino-check-happy", () => {
-  let sfnContainer: SfnContainerHelper;
+let sfnContainer: SfnContainerHelper;
 
-  beforeAll(async () => {
-    sfnContainer = new SfnContainerHelper();
+beforeAll(async () => (sfnContainer = new SfnContainerHelper()));
+afterAll(async () => sfnContainer.shutDown());
+
+it("has a step-function docker container running", async () => {
+  expect(sfnContainer.getContainer()).toBeDefined();
+});
+
+it.each([
+  ["with no previous attempt", "HappyPathTestNoPreviousAttempt"],
+  ["after 1 failed previous attempt", "HappyPathTestOn2ndAttempt"],
+])("should succeed when called %s", async (_, happyPath: string) => {
+  const input = JSON.stringify({
+    nino: "AA000003D",
+    sessionId: "12345",
   });
 
-  afterAll(async () => sfnContainer.shutDown());
+  const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+    happyPath,
+    input
+  );
 
-  it("has a step-function docker container running", async () => {
-    expect(sfnContainer.getContainer()).toBeDefined();
-  });
+  const results = await sfnContainer.waitFor(
+    (event: HistoryEvent) =>
+      event?.stateExitedEventDetails?.name === "Nino check successful",
+    responseStepFunction
+  );
 
-  it.each([
-    ["with no previous attempt", "HappyPathTestNoPreviousAttempt"],
-    ["after 1 failed previous attempt", "HappyPathTestOn2ndAttempt"],
-  ])("should succeed when called %s", async (_, happyPath: string) => {
-    const input = JSON.stringify({
-      nino: "AA000003D",
-      sessionId: "12345",
-    });
-    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
-      happyPath,
-      input
-    );
-    const results = await sfnContainer.waitFor(
-      (event: HistoryEvent) =>
-        event?.stateExitedEventDetails?.name === "Nino check successful",
-      responseStepFunction
-    );
-    expect(results[0].stateExitedEventDetails?.output).toEqual("{}");
-  });
+  expect(results[0].stateExitedEventDetails?.output).toEqual("{}");
 });

--- a/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
@@ -3,146 +3,160 @@ import { SfnContainerHelper } from "./sfn-container-helper";
 
 jest.setTimeout(60_000);
 
-describe("nino-check-unhappy", () => {
-  let sfnContainer: SfnContainerHelper;
+let sfnContainer: SfnContainerHelper;
 
-  beforeAll(async () => {
-    sfnContainer = new SfnContainerHelper();
+beforeAll(async () => (sfnContainer = new SfnContainerHelper()));
+afterAll(async () => sfnContainer.shutDown());
+
+it("has a step-function docker container running", async () => {
+  expect(sfnContainer.getContainer()).toBeDefined();
+});
+
+it("should fail when session id is invalid", async () => {
+  const input = JSON.stringify({
+    nino: "AA000003D",
+    sessionId: "12345",
   });
 
-  afterAll(async () => sfnContainer.shutDown());
+  const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+    "InValidRequestSessionId",
+    input
+  );
 
-  it("has a step-function docker container running", async () => {
-    expect(sfnContainer.getContainer()).toBeDefined();
+  const results = await sfnContainer.waitFor(
+    (event: HistoryEvent) => event?.type === "ExecutionSucceeded",
+    responseStepFunction
+  );
+
+  expect(results[0].executionSucceededEventDetails?.output).toEqual(
+    '{"error":"Session is not valid or has expired"}'
+  );
+});
+
+it("should fail when there are more than two check attempts", async () => {
+  const input = JSON.stringify({
+    nino: "AA000003D",
+    sessionId: "12345",
   });
 
-  it("should fail when session id is invalid", async () => {
-    const input = JSON.stringify({
-      nino: "AA000003D",
-      sessionId: "12345",
-    });
-    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
-      "InValidRequestSessionId",
-      input
-    );
-    const results = await sfnContainer.waitFor(
-      (event: HistoryEvent) => event?.type === "ExecutionSucceeded",
-      responseStepFunction
-    );
-    expect(results[0].executionSucceededEventDetails?.output).toEqual(
-      '{"error":"Session is not valid or has expired"}'
-    );
+  const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+    "MaximumNumberOfAttemptsExceeded",
+    input
+  );
+
+  const results = await sfnContainer.waitFor(
+    (event: HistoryEvent) =>
+      event?.type === "PassStateExited" &&
+      event?.stateExitedEventDetails?.name === "Err: Attempts exceeded",
+    responseStepFunction
+  );
+
+  expect(results[0].stateExitedEventDetails?.output).toEqual(
+    '{"error":"Maximum number of attempts exceeded"}'
+  );
+});
+
+it("should fail when there is an error while saving details in Nino DB", async () => {
+  const input = JSON.stringify({
+    nino: "AA000003D",
+    sessionId: "12345",
   });
 
-  it("should fail when there are more than two check attempts", async () => {
-    const input = JSON.stringify({
-      nino: "AA000003D",
-      sessionId: "12345",
-    });
-    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
-      "MaximumNumberOfAttemptsExceeded",
-      input
-    );
-    const results = await sfnContainer.waitFor(
-      (event: HistoryEvent) =>
-        event?.type === "PassStateExited" &&
-        event?.stateExitedEventDetails?.name === "Err: Attempts exceeded",
-      responseStepFunction
-    );
-    expect(results[0].stateExitedEventDetails?.output).toEqual(
-      '{"error":"Maximum number of attempts exceeded"}'
-    );
-  });
-  it("should fail when there is an error while saving details in Nino DB", async () => {
-    const input = JSON.stringify({
-      nino: "AA000003D",
-      sessionId: "12345",
-    });
-    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
-      "ErrorSavingInNinoDB",
-      input
-    );
+  const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+    "ErrorSavingInNinoDB",
+    input
+  );
 
-    const results = await sfnContainer.waitFor(
-      (event: HistoryEvent) => event?.type === "ExecutionFailed",
-      responseStepFunction
-    );
-    expect(results[0].executionFailedEventDetails?.cause).toContain(
-      "The conditional request failed (Service: AmazonDynamoDBv2; Status Code: 400"
-    );
+  const results = await sfnContainer.waitFor(
+    (event: HistoryEvent) => event?.type === "ExecutionFailed",
+    responseStepFunction
+  );
+
+  expect(results[0].executionFailedEventDetails?.cause).toContain(
+    "The conditional request failed (Service: AmazonDynamoDBv2; Status Code: 400"
+  );
+});
+
+it("should fail when user cannot be found for the given nino", async () => {
+  const input = JSON.stringify({
+    nino: "AA000003D",
+    sessionId: "12345",
   });
 
-  it("should fail when user cannot be found for the given nino", async () => {
-    const input = JSON.stringify({
-      nino: "AA000003D",
-      sessionId: "12345",
-    });
-    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
-      "UserNotFoundForGivenNino",
-      input
-    );
-    const results = await sfnContainer.waitFor(
-      (event: HistoryEvent) =>
-        event?.type === "PassStateExited" &&
-        event?.stateExitedEventDetails?.name === "Err: No user for nino",
-      responseStepFunction
-    );
-    expect(results[0].stateExitedEventDetails?.output).toEqual(
-      '{"error":"No user found for given nino"}'
-    );
+  const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+    "UserNotFoundForGivenNino",
+    input
+  );
+
+  const results = await sfnContainer.waitFor(
+    (event: HistoryEvent) =>
+      event?.type === "PassStateExited" &&
+      event?.stateExitedEventDetails?.name === "Err: No user for nino",
+    responseStepFunction
+  );
+
+  expect(results[0].stateExitedEventDetails?.output).toEqual(
+    '{"error":"No user found for given nino"}'
+  );
+});
+
+it("should throw an error when url is unavailable", async () => {
+  const input = JSON.stringify({
+    nino: "AA000003D",
+    sessionId: "12345",
   });
 
-  it("should throw an error when url is unavailable", async () => {
-    const input = JSON.stringify({
-      nino: "AA000003D",
-      sessionId: "12345",
-    });
-    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
-      "MatchingLambdaException",
-      input
-    );
+  const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+    "MatchingLambdaException",
+    input
+  );
 
-    const results = await sfnContainer.waitFor(
-      (event: HistoryEvent) => event?.type === "ExecutionFailed",
-      responseStepFunction
-    );
-    expect(results[0].executionFailedEventDetails).toEqual({});
-  });
-  it("should throw an error when token is invalid", async () => {
-    const input = JSON.stringify({
-      nino: "AA000003D",
-      sessionId: "12345",
-    });
-    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
-      "HMRCAuthError",
-      input
-    );
+  const results = await sfnContainer.waitFor(
+    (event: HistoryEvent) => event?.type === "ExecutionFailed",
+    responseStepFunction
+  );
 
-    const results = await sfnContainer.waitFor(
-      (event: HistoryEvent) => event?.type === "ExecutionFailed",
-      responseStepFunction
-    );
-    expect(results[0].executionFailedEventDetails?.cause).toEqual(
-      "Invalid Authentication information provided"
-    );
+  expect(results[0].executionFailedEventDetails).toEqual({});
+});
+
+it("should throw an error when token is invalid", async () => {
+  const input = JSON.stringify({
+    nino: "AA000003D",
+    sessionId: "12345",
   });
 
-  it("should fail when user nino does not match with HMRC DB", async () => {
-    const input = JSON.stringify({
-      nino: "AA000003D",
-      sessionId: "12345",
-    });
-    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
-      "HMRCError",
-      input
-    );
+  const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+    "HMRCAuthError",
+    input
+  );
 
-    const results = await sfnContainer.waitFor(
-      (event: HistoryEvent) => event?.type === "ExecutionSucceeded",
-      responseStepFunction
-    );
-    expect(results[0].executionSucceededEventDetails?.output).toEqual(
-      '{"error":"CID returned no record"}'
-    );
+  const results = await sfnContainer.waitFor(
+    (event: HistoryEvent) => event?.type === "ExecutionFailed",
+    responseStepFunction
+  );
+
+  expect(results[0].executionFailedEventDetails?.cause).toEqual(
+    "Invalid Authentication information provided"
+  );
+});
+
+it("should fail when user nino does not match with HMRC DB", async () => {
+  const input = JSON.stringify({
+    nino: "AA000003D",
+    sessionId: "12345",
   });
+
+  const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+    "HMRCError",
+    input
+  );
+
+  const results = await sfnContainer.waitFor(
+    (event: HistoryEvent) => event?.type === "ExecutionSucceeded",
+    responseStepFunction
+  );
+
+  expect(results[0].executionSucceededEventDetails?.output).toEqual(
+    '{"error":"CID returned no record"}'
+  );
 });

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -3,6 +3,7 @@
     "experimentalDecorators": true,
     "target": "es2022",
     "strict": true,
+    "noEmit": true,
     "preserveConstEnums": true,
     "sourceMap": true,
     "module": "es2022",

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -14,5 +14,6 @@
     "outDir": "./build/",
     "noImplicitAny": true
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "include": ["tests"]
 }


### PR DESCRIPTION
**Add a helper method to get stack information**

- Add a helper to get stack parameters and outputs
- Run the helper method before all tests
- Use the retrieved information in the tests
- Refactor the CloudFormation helper methods to use mapping and `Object.from` to create an object
- Reduce nesting of AWS tests
- Create input and user stubs, and use them in tests
- Remove the duplicate Output type and valid datetime method
  Move these to the new user helper file for reuse

---

- Add a helper method to populate and clear the database tables
- Set the timeout in the config file
- Format mocked tests
- Delete common stack name export, which is not used
- Set the `noEmit` flag on integration tests
  They do not need to be compiled