### PR TITLE
OJ-2045: add default region config for AWS Integration test

### DIFF
--- a/integration-tests/tests/aws/jest.config.aws.ts
+++ b/integration-tests/tests/aws/jest.config.aws.ts
@@ -4,4 +4,5 @@ import baseConfig from "../../jest.config";
 export default {
   ...baseConfig,
   displayName: "integration-tests/aws",
+  setupFiles: ["<rootDir>/setEnvVars.js"],
 } satisfies Config;

--- a/integration-tests/tests/aws/setEnvVars.js
+++ b/integration-tests/tests/aws/setEnvVars.js
@@ -1,0 +1,1 @@
+process.env.AWS_REGION = "eu-west-2";


### PR DESCRIPTION
## Proposed changes

One less environment variable to specify, when running AWS integration test locally

### What changed

Add `setEnvVars.js`
with region value specified

- [OJ-2045](https://govukverify.atlassian.net/browse/OJ-2045)

[OJ-2045]: https://govukverify.atlassian.net/browse/OJ-2045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ