### PR TITLE
OJ-1960: Update dev deployment script from the templates repo & fix SonarCloud permissions issue

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -12,7 +12,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Run pre-commit
-        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@fab13cb0e145fa98f1ca3fb7737fd2de1a34b4e3
+        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@d233e5a687f5c816b19bb25991d5709658b29ebc
         with:
           all-files: true
 

--- a/.github/workflows/clean-up-deployments.yml
+++ b/.github/workflows/clean-up-deployments.yml
@@ -26,7 +26,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: Get stale preview stacks
-        uses: govuk-one-login/github-actions/sam/get-stale-stacks@fab13cb0e145fa98f1ca3fb7737fd2de1a34b4e3
+        uses: govuk-one-login/github-actions/sam/get-stale-stacks@d233e5a687f5c816b19bb25991d5709658b29ebc
         with:
           threshold-days: 14
           stack-name-filter: preview-check-hmrc-api
@@ -37,7 +37,7 @@ jobs:
           env-var-name: STACKS
 
       - name: Delete stacks
-        uses: govuk-one-login/github-actions/sam/delete-stacks@fab13cb0e145fa98f1ca3fb7737fd2de1a34b4e3
+        uses: govuk-one-login/github-actions/sam/delete-stacks@d233e5a687f5c816b19bb25991d5709658b29ebc
         with:
           stack-names: ${{ env.STACKS }}
           verbose: true

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Get stack name
-        uses: govuk-one-login/github-actions/beautify-branch-name@fab13cb0e145fa98f1ca3fb7737fd2de1a34b4e3
+        uses: govuk-one-login/github-actions/beautify-branch-name@d233e5a687f5c816b19bb25991d5709658b29ebc
         id: get-stack-name
         with:
           usage: Stack name
@@ -29,7 +29,7 @@ jobs:
           verbose: false
 
       - name: Delete stack
-        uses: govuk-one-login/github-actions/sam/delete-stacks@fab13cb0e145fa98f1ca3fb7737fd2de1a34b4e3
+        uses: govuk-one-login/github-actions/sam/delete-stacks@d233e5a687f5c816b19bb25991d5709658b29ebc
         with:
           stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -24,7 +24,7 @@ jobs:
       artifact-name: ${{ steps.build.outputs.artifact-name }}
     steps:
       - name: Build SAM application
-        uses: govuk-one-login/github-actions/sam/build-application@fab13cb0e145fa98f1ca3fb7737fd2de1a34b4e3
+        uses: govuk-one-login/github-actions/sam/build-application@d233e5a687f5c816b19bb25991d5709658b29ebc
         id: build
         with:
           template: infrastructure/template.yaml
@@ -47,7 +47,7 @@ jobs:
       stack-name: ${{ steps.deploy.outputs.stack-name }}
     steps:
       - name: Deploy stack
-        uses: govuk-one-login/github-actions/sam/deploy-stack@fab13cb0e145fa98f1ca3fb7737fd2de1a34b4e3
+        uses: govuk-one-login/github-actions/sam/deploy-stack@d233e5a687f5c816b19bb25991d5709658b29ebc
         id: deploy
         with:
           sam-deployment-bucket: ${{ vars.DEPLOYMENT_ARTIFACTS_BUCKET }}

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run a SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@fab13cb0e145fa98f1ca3fb7737fd2de1a34b4e3
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@d233e5a687f5c816b19bb25991d5709658b29ebc
         with:
           coverage-artifact: ${{ needs.unit-tests.outputs.coverage-artifact }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,6 +40,6 @@ jobs:
       security-events: write
     steps:
       - name: Run a CodeQL scan
-        uses: govuk-one-login/github-actions/code-quality/codeql@fab13cb0e145fa98f1ca3fb7737fd2de1a34b4e3
+        uses: govuk-one-login/github-actions/code-quality/codeql@d233e5a687f5c816b19bb25991d5709658b29ebc
         with:
           languages: javascript-typescript

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "npm run unit --",
     "test:coverage": "npm run unit -- --coverage",
     "sam:validate": "cd infrastructure && sam validate && sam validate --lint",
-    "sam:build": "sam build --template infrastructure/template.yaml --cached --parallel"
+    "sam:build": "npm run sam:validate && sam build --template infrastructure/template.yaml --cached --parallel"
   },
   "dependencies": {
     "@aws-lambda-powertools/commons": "1.14.2",


### PR DESCRIPTION
Update the dev deployment script

- Apply formatting
- Add tags to deployed stacks
- Use an S3 prefix
- Use the region from the environment, or use the default value if it's not set
- Set the -u flag to fail if any variable is missing a value
- Remove unused and invalid parameter overrides
- Validate the SAM template before building it

Use the latest shared GitHub Actions
- Pull in the fix to the SonarCloud permissions issue