### PR TITLE
BAU: Remove private API duplication in the SAM template

### DIFF
--- a/.github/workflows/clean-up-deployments.yml
+++ b/.github/workflows/clean-up-deployments.yml
@@ -11,7 +11,7 @@ permissions:
   id-token: write
   contents: read
 
-concurrency: deploy-development-${{ github.head_ref || github.ref_name }}
+concurrency: cleanup-dev-${{ github.head_ref || github.ref_name }}
 
 jobs:
   delete-stacks:
@@ -37,6 +37,7 @@ jobs:
           env-var-name: STACKS
 
       - name: Delete stacks
+        if: ${{ env.STACKS != null }}
         uses: govuk-one-login/github-actions/sam/delete-stacks@d233e5a687f5c816b19bb25991d5709658b29ebc
         with:
           stack-names: ${{ env.STACKS }}

--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ To run the tests against a stack deployed in AWS, authenticate to the correct ac
 
 `STACK_NAME=<stack-name> npm run test:aws --workspace integration-tests`
 
-You can omit the `--workspace` parameter if the current working directory is `integration-tests`
+_You can omit the `--workspace` parameter if the current working directory is `integration-tests`._
 
 ### Mocked
 
-Mocked are not true integration-test, all AWS service integrations are mocked, it is a
-a step function path flow test which checks all paths through step function states, tasks and mocked service integrations are wired as expected and correctly.
+In mocked tests, all AWS service integrations are mocked, and only the step function path flow is checked to verify all
+the paths through step function states. Tasks and mocked service integrations are wired to return the expected responses.
 
 These tests run locally on your system and need the Docker agent to be running in the background before the execution begins.
 
 To run the mocked step function tests run
 `npm run test:mocked --workspace integration-tests`
 
-You can omit the `--workspace` parameter if the current working directory is `integration-tests`.\_
+_You can omit the `--workspace` parameter if the current working directory is `integration-tests`._
 
 ### MAKE
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,7 @@
 set -eu
 
 stack_name="${1:-}"
+common_stack_name="${2:-}"
 
 if ! [[ "$stack_name" ]]; then
   echo "😱 Stack name expected as first argument, e.g. ./deploy.sh pdv-matching-user1"
@@ -26,4 +27,5 @@ sam deploy --stack-name "$stack_name" \
   cri:application=Orange \
   cri:deployment-source=manual \
   --parameter-overrides \
+  ${common_stack_name:+CommonStackName=$common_stack_name} \
   Environment=dev

--- a/infrastructure/public-api.yaml
+++ b/infrastructure/public-api.yaml
@@ -89,9 +89,9 @@ paths:
       security:
         - api_key:
             Fn::If:
-              - IsNotDevEnvironment
-              - []
+              - IsDevEnvironment
               - Ref: AWS::NoValue
+              - []
       x-amazon-apigateway-request-validator: "Validate both"
       x-amazon-apigateway-integration:
         httpMethod: "POST"
@@ -142,9 +142,9 @@ paths:
       security:
         - api_key:
             Fn::If:
-              - IsNotDevEnvironment
-              - []
+              - IsDevEnvironment
               - Ref: AWS::NoValue
+              - []
       x-amazon-apigateway-request-validator: "Validate both"
       x-amazon-apigateway-integration:
         httpMethod: "POST"

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -28,7 +28,6 @@ Conditions:
   EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, ""]]
   IsDevEnvironment: !Equals [!Ref Environment, dev]
-  IsNotDevEnvironment: !Not [!Condition IsDevEnvironment]
   IsProductionEnvironment: !Equals [!Ref Environment, production]
   IsStagingOrIntegrationEnvironment: !Or
     - !Equals [!Ref Environment, staging]
@@ -101,22 +100,6 @@ Globals:
           - SecretArn: !FindInMap [Dynatrace, SecretArn, !Ref Environment]
 
 Resources:
-  JwtSignerFunction:
-    Type: AWS::Serverless::Function
-    Metadata:
-      BuildMethod: esbuild
-      BuildProperties:
-        Sourcemap: true
-    Properties:
-      Handler: lambdas/jwt-signer/src/jwt-signer-handler.lambdaHandler
-      CodeSigningConfigArn:
-        !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
-      Policies:
-        - Statement:
-            Effect: Allow
-            Action: kms:Sign
-            Resource: !ImportValue core-infrastructure-CriVcSigningKey1Arn
-
   UserAgent:
     Type: AWS::SSM::Parameter
     Properties:
@@ -165,7 +148,6 @@ Resources:
         - LoggingLevel: INFO
           ResourcePath: "/*"
           HttpMethod: "*"
-          # Disable data trace in production to avoid logging customer sensitive information
           DataTraceEnabled: true
           MetricsEnabled: true
           ThrottlingRateLimit: 200
@@ -188,12 +170,12 @@ Resources:
       Name: !Sub ${AWS::StackName}-public
       StageName: !Ref Environment
       DefinitionBody:
-        openapi: 3.1.0
+        openapi: 3.0.1
         Fn::Transform:
           Name: AWS::Include
           Parameters:
-            Location: ./public-api.yaml
-      OpenApiVersion: 3.1.0
+            Location: public-api.yaml
+      OpenApiVersion: 3.0.1
       EndpointConfiguration:
         Type: REGIONAL
 
@@ -203,63 +185,14 @@ Resources:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PublicNinoCheckApi}-public-AccessLogs
       RetentionInDays: 30
 
-  DevOnlyNinoCheckApi:
+  PrivateNinoCheckApi:
     Type: AWS::Serverless::Api
-    Condition: IsDevEnvironment
     Properties:
-      Description: Private Dev NINO Check CRI API
+      Description: Private NINO Check CRI API
       MethodSettings:
         - LoggingLevel: INFO
           ResourcePath: "/*"
           HttpMethod: "*"
-          DataTraceEnabled: true
-          MetricsEnabled: true
-          ThrottlingRateLimit: 200
-          ThrottlingBurstLimit: 400
-      AccessLogSetting:
-        DestinationArn: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${DevOnlyNinoCheckApiAccessLogGroup}
-        Format:
-          Fn::ToJsonString:
-            requestId: $context.requestId
-            ip: $context.identity.sourceIp
-            requestTime: $context.requestTime
-            httpMethod: $context.httpMethod
-            path: $context.path
-            routeKey: $context.routeKey
-            status: $context.status
-            protocol: $context.protocol
-            responseLatency: $context.responseLatency
-            responseLength: $context.responseLength
-      TracingEnabled: true
-      Name: !Sub ${AWS::StackName}-dev-only-private
-      StageName: !Ref Environment
-      DefinitionBody:
-        openapi: 3.1.0
-        Fn::Transform:
-          Name: AWS::Include
-          Parameters:
-            Location: ./private-api.yaml
-      OpenApiVersion: 3.1.0
-      EndpointConfiguration:
-        Type: REGIONAL
-
-  DevOnlyNinoCheckApiAccessLogGroup:
-    Type: AWS::Logs::LogGroup
-    Condition: IsDevEnvironment
-    Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${DevOnlyNinoCheckApi}-dev-only-AccessLogs
-      RetentionInDays: 30
-
-  PrivateNinoCheckApi:
-    Type: AWS::Serverless::Api
-    Condition: IsNotDevEnvironment
-    Properties:
-      Description: Private NINO check CRI API
-      MethodSettings:
-        - ResourcePath: "/*"
-          LoggingLevel: INFO
-          HttpMethod: "*"
-          # Disable data trace in production to avoid logging customer sensitive information
           DataTraceEnabled: true
           MetricsEnabled: true
           ThrottlingRateLimit: 200
@@ -282,28 +215,29 @@ Resources:
       Name: !Sub ${AWS::StackName}-private
       StageName: !Ref Environment
       DefinitionBody:
-        openapi: 3.0.1 # workaround to get `sam validate` to work
+        openapi: 3.0.1
         paths: # workaround to get `sam validate` to work
           /never-created:
-            options: {} # workaround to get `sam validate` to work
+            options: {}
         Fn::Transform:
           Name: AWS::Include
           Parameters:
-            Location: ./private-api.yaml
+            Location: private-api.yaml
       OpenApiVersion: 3.0.1
       EndpointConfiguration:
-        Type: PRIVATE
+        Type: !If [IsDevEnvironment, REGIONAL, PRIVATE]
       Auth:
-        ResourcePolicy:
-          CustomStatements:
-            - Action: execute-api:Invoke
-              Effect: Allow
-              Principal: "*"
-              Resource: "execute-api:/*"
+        ResourcePolicy: !If
+          - IsDevEnvironment
+          - !Ref AWS::NoValue
+          - CustomStatements:
+              - Effect: Allow
+                Resource: execute-api:/*
+                Action: execute-api:Invoke
+                Principal: "*"
 
   PrivateNinoCheckApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
-    Condition: IsNotDevEnvironment
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PrivateNinoCheckApi}-private-AccessLogs
       RetentionInDays: 30
@@ -357,6 +291,22 @@ Resources:
       KeySchema:
         - AttributeName: sessionId
           KeyType: HASH
+
+  JwtSignerFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Sourcemap: true
+    Properties:
+      Handler: lambdas/jwt-signer/src/jwt-signer-handler.lambdaHandler
+      CodeSigningConfigArn:
+        !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+      Policies:
+        - Statement:
+            Effect: Allow
+            Action: kms:Sign
+            Resource: !ImportValue core-infrastructure-CriVcSigningKey1Arn
 
   MatchingFunction:
     Type: AWS::Serverless::Function
@@ -597,16 +547,13 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-ApiGatewayId
   PublicApiGatewayId:
-    Description: API GatewayID of the public Address CRI API
+    Description: API Gateway ID of the public Address CRI API
     Value: !Ref PublicNinoCheckApi
     Export:
       Name: !Sub ${AWS::StackName}-PublicApiGatewayId
   PrivateApiGatewayId:
-    Description: API GatewayID of the private Address CRI API
-    Value: !If
-      - IsNotDevEnvironment
-      - !Ref PrivateNinoCheckApi
-      - !Ref DevOnlyNinoCheckApi
+    Description: API Gateway ID of the private Address CRI API
+    Value: !Ref PrivateNinoCheckApi
     Export:
       Name: !Sub ${AWS::StackName}-PrivateApiGatewayId
   NinoCheckStateMachineArn:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -153,7 +153,7 @@ Resources:
           ThrottlingRateLimit: 200
           ThrottlingBurstLimit: 400
       AccessLogSetting:
-        DestinationArn: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${PublicNinoCheckApiAccessLogGroup}
+        DestinationArn: !GetAtt PublicNinoCheckApiAccessLogGroup.Arn
         Format:
           Fn::ToJsonString:
             requestId: $context.requestId
@@ -198,7 +198,7 @@ Resources:
           ThrottlingRateLimit: 200
           ThrottlingBurstLimit: 400
       AccessLogSetting:
-        DestinationArn: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${PrivateNinoCheckApiAccessLogGroup}
+        DestinationArn: !GetAtt PrivateNinoCheckApiAccessLogGroup.Arn
         Format:
           Fn::ToJsonString:
             requestId: $context.requestId
@@ -464,7 +464,7 @@ Resources:
   NinoCheckStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/vendedlogs/states/aws/apigateway/${AWS::StackName}-NinoCheck-state-machine-logs
+      LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-NinoCheck-state-machine-logs
       RetentionInDays: 30
 
   NinoIssueCredentialStateMachine:
@@ -537,7 +537,7 @@ Resources:
   CheckSessionStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-CheckSession-state-machine-logs
+      LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-CheckSession-state-machine-logs
       RetentionInDays: 30
 
 Outputs:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -448,8 +448,8 @@ Resources:
               - ssm:GetParameters
               - ssm:GetParameter
             Resource:
-              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/NinoCheckUrl
-              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/UserAgent
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${NinoCheckUrl}
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${UserAgent}
               - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName
               - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName
         - Statement:
@@ -509,8 +509,8 @@ Resources:
               - ssm:GetParameters
               - ssm:GetParameter
             Resource:
-              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaxJwtTtl
-              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/JwtTtlUnit
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${MaxJwtTtlParameter}
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${JwtTtlUnitParameter}
               - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiableCredentialKmsSigningKeyId
               - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName
               - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -182,7 +182,7 @@ Resources:
   PublicNinoCheckApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PublicNinoCheckApi}-public-AccessLogs
+      LogGroupName: !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-${PublicNinoCheckApi}-public-AccessLogs
       RetentionInDays: 30
 
   PrivateNinoCheckApi:
@@ -239,7 +239,7 @@ Resources:
   PrivateNinoCheckApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PrivateNinoCheckApi}-private-AccessLogs
+      LogGroupName: !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-${PrivateNinoCheckApi}-private-AccessLogs
       RetentionInDays: 30
 
   ExecuteStateMachineRole:
@@ -531,13 +531,13 @@ Resources:
   NinoIssueCredentialLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/vendedlogs/states/aws/apigateway/${AWS::StackName}-NinoIssueCredential-state-machine-logs
+      LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-NinoIssueCredential-state-machine-logs
       RetentionInDays: 30
 
   CheckSessionStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/vendedlogs/states/aws/apigateway/${AWS::StackName}-CheckSession-state-machine-logs
+      LogGroupName: !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-CheckSession-state-machine-logs
       RetentionInDays: 30
 
 Outputs:


### PR DESCRIPTION
**Remove private API duplication from the SAM template**

The private and "dev only" APIs are the same except for two properties - use the dev env condition to set the correct values for those properties instead of duplicating the whole API block and using complex logic to select the correct ARN for the output.

- Delete the "dev only" API as it is just the private API in dev mode (no auth and type is regional instead of private)

- Use the IsDevEnvironment condition, and remove IsNotDevEnvironment since it's not necessary

- Set the correct OpenAPI version in the resources - we use 3.0.1 (not 3.1.0, which is not supported by CF)

- Use the `GetAtt` function to get the ARNs of the log groups

- Use consistent group name prefixes for different services

---

Allow custom common stack name when deploying a local stack

Add a second optional argument that can be passed to the deploy.sh script to specify a custom common stack name to override the default from the template.

---

- Fix bad formatting in README
- Add more clarity to the description of integration tests.