### PR TITLE
BAU: Update deployment workflows and script

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -12,7 +12,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Run pre-commit
-        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           all-files: true
 

--- a/.github/workflows/clean-up-deployments.yml
+++ b/.github/workflows/clean-up-deployments.yml
@@ -26,7 +26,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: Get stale preview stacks
-        uses: govuk-one-login/github-actions/sam/get-stale-stacks@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/sam/get-stale-stacks@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           threshold-days: 14
           stack-name-filter: preview-check-hmrc-api
@@ -38,7 +38,7 @@ jobs:
 
       - name: Delete stacks
         if: ${{ env.STACKS != null }}
-        uses: govuk-one-login/github-actions/sam/delete-stacks@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/sam/delete-stacks@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           stack-names: ${{ env.STACKS }}
           verbose: true

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Get stack name
-        uses: govuk-one-login/github-actions/beautify-branch-name@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/beautify-branch-name@cd7d35dde348251237efbbaee5345e95adef0321
         id: get-stack-name
         with:
           usage: Stack name
@@ -29,7 +29,7 @@ jobs:
           verbose: false
 
       - name: Delete stack
-        uses: govuk-one-login/github-actions/sam/delete-stacks@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/sam/delete-stacks@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -59,7 +59,7 @@ jobs:
           artifact-path: .aws-sam/build
           artifact-name: ${{ needs.build.outputs.artifact-name }}
           tags: |
-            cri:component=check-hmrc-api
+            cri:component=ipv-cri-check-hmrc-api
             cri:stack-type=preview
             cri:application=Orange
             cri:deployment-source=github-actions

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -64,5 +64,4 @@ jobs:
             cri:application=Orange
             cri:deployment-source=github-actions
           parameters: |
-            CodeSigningEnabled=false
             Environment=dev

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -20,15 +20,12 @@ jobs:
     name: Build SAM app
     runs-on: ubuntu-latest
     permissions: {}
-    outputs:
-      artifact-name: ${{ steps.build.outputs.artifact-name }}
     steps:
       - name: Build SAM application
-        uses: govuk-one-login/github-actions/sam/build-application@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/sam/build-application@cd7d35dde348251237efbbaee5345e95adef0321
         id: build
         with:
           template: infrastructure/template.yaml
-          artifact-name: check-hmrc-api
           cache-key: check-hmrc-api
           pull-repository: true
 
@@ -47,17 +44,16 @@ jobs:
       stack-name: ${{ steps.deploy.outputs.stack-name }}
     steps:
       - name: Deploy stack
-        uses: govuk-one-login/github-actions/sam/deploy-stack@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/sam/deploy-stack@cd7d35dde348251237efbbaee5345e95adef0321
         id: deploy
         with:
           sam-deployment-bucket: ${{ vars.DEPLOYMENT_ARTIFACTS_BUCKET }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
           stack-name-prefix: preview-check-hmrc-api
+          cache-key: check-hmrc-api
           s3-prefix: preview
           pull-repository: true
           delete-failed-stack: true
-          artifact-path: .aws-sam/build
-          artifact-name: ${{ needs.build.outputs.artifact-name }}
           tags: |
             cri:component=ipv-cri-check-hmrc-api
             cri:stack-type=preview

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -44,4 +44,4 @@ jobs:
         with:
           name: ${{ inputs.coverage-artifact }}
           retention-days: 3
-          path: coverage
+          path: coverage/lcov.info

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -26,7 +26,7 @@ jobs:
     needs: unit-tests
     runs-on: ubuntu-latest
     steps:
-      - name: Run a SonarCloud scan
+      - name: Run SonarCloud scan
         uses: govuk-one-login/github-actions/code-quality/sonarcloud@d233e5a687f5c816b19bb25991d5709658b29ebc
         with:
           coverage-artifact: ${{ needs.unit-tests.outputs.coverage-artifact }}
@@ -39,7 +39,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - name: Run a CodeQL scan
+      - name: Run CodeQL scan
         uses: govuk-one-login/github-actions/code-quality/codeql@d233e5a687f5c816b19bb25991d5709658b29ebc
         with:
           languages: javascript-typescript

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           coverage-artifact: ${{ needs.unit-tests.outputs.coverage-artifact }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,6 +40,6 @@ jobs:
       security-events: write
     steps:
       - name: Run CodeQL scan
-        uses: govuk-one-login/github-actions/code-quality/codeql@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/code-quality/codeql@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           languages: javascript-typescript

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
+cd "$(dirname "${BASH_SOURCE[0]}")"
 set -eu
 
 stack_name="${1:-}"
 common_stack_name="${2:-}"
 
 if ! [[ "$stack_name" ]]; then
-  echo "😱 Stack name expected as first argument, e.g. ./deploy.sh pdv-matching-user1"
-  exit 1
+  [[ $(aws whoami --query Arn --output text) =~ \/([^\/\.]+)\. ]] && user="${BASH_REMATCH[1]}" || exit
+  stack_name="$user-check-hmrc-api"
+  echo "» Using stack name '$stack_name'"
 fi
 
 sam validate -t infrastructure/template.yaml
@@ -22,7 +24,7 @@ sam deploy --stack-name "$stack_name" \
   --region "${AWS_REGION:-eu-west-2}" \
   --capabilities CAPABILITY_IAM \
   --tags \
-  cri:component=check-hmrc-api \
+  cri:component=ipv-cri-check-hmrc-api \
   cri:stack-type=dev \
   cri:application=Orange \
   cri:deployment-source=manual \

--- a/integration-tests/jest.config.ci.ts
+++ b/integration-tests/jest.config.ci.ts
@@ -3,5 +3,5 @@ import baseConfig from "./jest.config";
 
 export default {
   ...baseConfig,
-  reporters: [["github-actions", { silent: false }], "default"],
+  reporters: [["github-actions", { silent: false }], "summary"],
 } satisfies Config;

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -9,6 +9,7 @@
     "test:all": "npm run unit:all --",
     "test:aws": "npm run unit:aws --",
     "test:mocked": "npm run unit:mocked --",
+    "deploy": "../deploy.sh",
     "compile": "tsc"
   },
   "dependencies": {},

--- a/jest.config.base.ts
+++ b/jest.config.base.ts
@@ -1,4 +1,4 @@
-import { Config } from "jest";
+import type { Config } from "jest";
 
 export default {
   preset: "ts-jest",

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,4 @@
-import { Config } from "jest";
+import type { Config } from "jest";
 
 export default {
   projects: ["lambdas/*/jest.config.ts"],

--- a/lambdas/credential-subject/jest.config.ts
+++ b/lambdas/credential-subject/jest.config.ts
@@ -1,4 +1,4 @@
-import { Config } from "jest";
+import type { Config } from "jest";
 import baseConfig from "../../jest.config.base";
 
 export default {

--- a/lambdas/credential-subject/package.json
+++ b/lambdas/credential-subject/package.json
@@ -7,6 +7,7 @@
     "unit": "jest --silent",
     "test": "npm run unit --",
     "test:coverage": "npm run unit -- --coverage",
+    "deploy": "../../deploy.sh",
     "compile": "tsc"
   },
   "dependencies": {}

--- a/lambdas/issue-credential/jest.config.ts
+++ b/lambdas/issue-credential/jest.config.ts
@@ -1,4 +1,4 @@
-import { Config } from "jest";
+import type { Config } from "jest";
 import baseConfig from "../../jest.config.base";
 
 export default {

--- a/lambdas/issue-credential/package.json
+++ b/lambdas/issue-credential/package.json
@@ -7,6 +7,7 @@
     "unit": "jest --silent",
     "test": "npm run unit --",
     "test:coverage": "npm run unit -- --coverage",
+    "deploy": "../../deploy.sh",
     "compile": "tsc"
   },
   "dependencies": {}

--- a/lambdas/jwt-signer/jest.config.ts
+++ b/lambdas/jwt-signer/jest.config.ts
@@ -1,4 +1,4 @@
-import { Config } from "jest";
+import type { Config } from "jest";
 import baseConfig from "../../jest.config.base";
 
 export default {

--- a/lambdas/jwt-signer/package.json
+++ b/lambdas/jwt-signer/package.json
@@ -7,6 +7,7 @@
     "unit": "jest --silent",
     "test": "npm run unit --",
     "test:coverage": "npm run unit -- --coverage",
+    "deploy": "../../deploy.sh",
     "compile": "tsc"
   },
   "dependencies": {

--- a/lambdas/matching/jest.config.ts
+++ b/lambdas/matching/jest.config.ts
@@ -1,4 +1,4 @@
-import { Config } from "jest";
+import type { Config } from "jest";
 import baseConfig from "../../jest.config.base";
 
 export default {

--- a/lambdas/matching/package.json
+++ b/lambdas/matching/package.json
@@ -7,6 +7,7 @@
     "unit": "jest --silent",
     "test": "npm run unit --",
     "test:coverage": "npm run unit -- --coverage",
+    "deploy": "../../deploy.sh",
     "compile": "tsc"
   },
   "dependencies": {}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "npm run unit --",
     "test:coverage": "npm run unit -- --coverage",
     "sam:validate": "cd infrastructure && sam validate && sam validate --lint",
-    "sam:build": "npm run sam:validate && sam build --template infrastructure/template.yaml --cached --parallel"
+    "sam:build": "npm run sam:validate && sam build --template infrastructure/template.yaml --cached --parallel",
+    "deploy": "./deploy.sh"
   },
   "dependencies": {
     "@aws-lambda-powertools/commons": "1.14.2",


### PR DESCRIPTION
- Remove unused SAM parameter from the Preview workflow
- Use the summary reporter for GitHub Actions
- Only archive the coverage report file for SonarCloud
- Use the latest shared GitHub Actions
  Use the SAM build cache instead of the artifact to improve performance.

**Update the deployment script to enable easy deployment to dev**

- Derive stack name from the user's name and the CRI name if the name is not provided to the script

- Add a deploy script to the package.json files so a stack can be quickly deployed from anywhere in the repo by simply running `npm run deploy`