### PR TITLE
BAU: Minor fixes to jest config and deployment script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -6,7 +6,7 @@ stack_name="${1:-}"
 common_stack_name="${2:-}"
 
 if ! [[ "$stack_name" ]]; then
-  [[ $(aws whoami --query Arn --output text) =~ \/([^\/\.]+)\. ]] && user="${BASH_REMATCH[1]}" || exit
+  [[ $(aws sts get-caller-identity --query Arn --output text) =~ \/([^\/\.]+)\. ]] && user="${BASH_REMATCH[1]}" || exit
   stack_name="$user-check-hmrc-api"
   echo "» Using stack name '$stack_name'"
 fi

--- a/integration-tests/tests/aws/jest.config.ts
+++ b/integration-tests/tests/aws/jest.config.ts
@@ -3,6 +3,7 @@ import baseConfig from "../../jest.config";
 
 export default {
   ...baseConfig,
+  projects: [],
   displayName: "integration-tests/aws",
   setupFiles: ["<rootDir>/setEnvVars.js"],
 } satisfies Config;

--- a/integration-tests/tests/mocked/jest.config.ts
+++ b/integration-tests/tests/mocked/jest.config.ts
@@ -3,5 +3,6 @@ import baseConfig from "../../jest.config";
 
 export default {
   ...baseConfig,
+  projects: [],
   displayName: "integration-tests/mocked",
 } satisfies Config;


### PR DESCRIPTION
- The `whoami` alias might not be set up by default by the CLI so use the full command instead
- Fix jest config error
Fix the error `Can't find a root directory while resolving a config file path` when running an individual test rather than the whole suite.