### PR TITLE
OJ-2215: Matching Handler to return status code and body

### DIFF
--- a/integration-tests/tests/mocked/nino-check/MockConfigFile.json
+++ b/integration-tests/tests/mocked/nino-check/MockConfigFile.json
@@ -8,7 +8,7 @@
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Increment user attempt": "DynamoDbQueryNoResult",
           "Person Identity Table Name": "PersonIdentityTableSuccess",
-          "Query Session": "QuerySessionSuccess",
+          "Query Person Identity Table": "QuerySessionSuccess",
           "Get User Agent and API URL": "GetAPIParametersSuccess",
           "Get OAuth Token": "GetOAuthAccessTokenSuccess",
           "Call Matching API": "CallMatchingAPISuccess",
@@ -24,7 +24,7 @@
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Increment user attempt": "DynamoDbQueryNoResult",
           "Person Identity Table Name": "PersonIdentityTableSuccess",
-          "Query Session": "QuerySessionSuccess",
+          "Query Person Identity Table": "QuerySessionSuccess",
           "Get User Agent and API URL": "GetAPIParametersSuccess",
           "Get OAuth Token": "GetOAuthAccessTokenSuccess",
           "Call Matching API": "CallMatchingAPISuccess",
@@ -47,7 +47,7 @@
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Increment user attempt": "DynamoDbQueryNoResult",
           "Person Identity Table Name": "PersonIdentityTableSuccess",
-          "Query Session": "QuerySessionSuccess",
+          "Query Person Identity Table": "QuerySessionSuccess",
           "Get User Agent and API URL": "GetAPIParametersSuccess",
           "Get OAuth Token": "GetOAuthAccessTokenSuccess",
           "Call Matching API": "CallMatchingAPISuccess",
@@ -63,7 +63,7 @@
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Increment user attempt": "DynamoDbQueryNoResult",
           "Person Identity Table Name": "PersonIdentityTableSuccess",
-          "Query Session": "DynamoDbQueryNoResult"
+          "Query Person Identity Table": "DynamoDbQueryNoResult"
         },
         "HMRCAuthError": {
           "Invoke Check Session": "CheckSessionSuccess",
@@ -71,7 +71,7 @@
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Increment user attempt": "DynamoDbQueryNoResult",
           "Person Identity Table Name": "PersonIdentityTableSuccess",
-          "Query Session": "QuerySessionSuccess",
+          "Query Person Identity Table": "QuerySessionSuccess",
           "Get User Agent and API URL": "GetAPIParametersSuccess",
           "Get OAuth Token": "GetOAuthAccessTokenSuccess",
           "Call Matching API": "CallMatchingAPIFailAuth"
@@ -82,7 +82,7 @@
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Increment user attempt": "DynamoDbQueryNoResult",
           "Person Identity Table Name": "PersonIdentityTableSuccess",
-          "Query Session": "QuerySessionSuccess",
+          "Query Person Identity Table": "QuerySessionSuccess",
           "Get User Agent and API URL": "GetAPIParametersSuccess",
           "Get OAuth Token": "GetOAuthAccessTokenSuccess",
           "Call Matching API": "CallMatchingAPIInvalidURL"
@@ -93,7 +93,7 @@
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Increment user attempt": "DynamoDbQueryNoResult",
           "Person Identity Table Name": "PersonIdentityTableSuccess",
-          "Query Session": "QuerySessionSuccess",
+          "Query Person Identity Table": "QuerySessionSuccess",
           "Get User Agent and API URL": "GetAPIParametersSuccess",
           "Get OAuth Token": "GetOAuthAccessTokenSuccess",
           "Call Matching API": "CallMatchingAPIFailNoRecords"
@@ -121,8 +121,11 @@
       "0": {
         "Return": {
           "Payload": {
-            "code": "INVALID_CREDENTIALS",
-            "message": "Invalid Authentication information provided"
+            "status": "400",
+            "body": {
+              "code": "INVALID_CREDENTIALS",
+              "message": "Invalid Authentication information provided"
+            }
           }
         }
       }
@@ -131,7 +134,10 @@
       "0": {
         "Return": {
           "Payload": {
-            "errors": "CID returned no record"
+            "status": "400",
+            "body": {
+              "errors": "CID returned no record"
+            }
           }
         }
       }
@@ -448,10 +454,13 @@
       "0": {
         "Return": {
           "Payload": {
-            "firstName": "Jim",
-            "lastName": "Ferguson",
-            "dateOfBirth": "1948-04-23",
-            "nino": "AA000003D"
+            "status": 200,
+            "body": {
+              "firstName": "Jim",
+              "lastName": "Ferguson",
+              "dateOfBirth": "1948-04-23",
+              "nino": "AA000003D"
+            }
           }
         }
       }

--- a/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
@@ -84,7 +84,8 @@ describe("nino-check-unhappy", () => {
     const results = await sfnContainer.waitFor(
       (event: HistoryEvent) =>
         event?.type === "PassStateExited" &&
-        event?.stateExitedEventDetails?.name === "Err: No user found in Person Identity",
+        event?.stateExitedEventDetails?.name ===
+          "Err: No user found in Person Identity",
       responseStepFunction
     );
     expect(results[0].stateExitedEventDetails?.output).toEqual(

--- a/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
@@ -84,7 +84,7 @@ describe("nino-check-unhappy", () => {
     const results = await sfnContainer.waitFor(
       (event: HistoryEvent) =>
         event?.type === "PassStateExited" &&
-        event?.stateExitedEventDetails?.name === "Err: No user for nino",
+        event?.stateExitedEventDetails?.name === "Err: No user found in Person Identity",
       responseStepFunction
     );
     expect(results[0].stateExitedEventDetails?.output).toEqual(

--- a/lambdas/matching/src/matching-handler.ts
+++ b/lambdas/matching/src/matching-handler.ts
@@ -5,7 +5,10 @@ import { MatchEvent } from "./match-event";
 const logger = new Logger();
 
 export class MatchingHandler implements LambdaInterface {
-  public async handler(event: MatchEvent, _context: unknown): Promise<string> {
+  public async handler(
+    event: MatchEvent,
+    _context: unknown
+  ): Promise<{ status: number; body: string }> {
     try {
       const response = await fetch(event.apiURL, {
         method: "POST",
@@ -22,9 +25,15 @@ export class MatchingHandler implements LambdaInterface {
         }),
       });
       try {
-        return await response.json();
+        return {
+          status: response.status,
+          body: await response.json(),
+        };
       } catch (error: unknown) {
-        return await response.text();
+        return {
+          status: response.status,
+          body: await response.text(),
+        };
       }
     } catch (error: unknown) {
       let message;

--- a/lambdas/matching/tests/matching-handler.test.ts
+++ b/lambdas/matching/tests/matching-handler.test.ts
@@ -35,7 +35,7 @@ describe("matching-handler", () => {
       oAuthToken: "123",
     } as MatchEvent;
     const result = await matchingHandler.handler(event, {} as Context);
-    expect(result.status).toEqual(200);
+    expect(result.status).toBe(200);
     expect(result.body).toStrictEqual({
       firstName: "Jim",
       lastName: "Ferguson",

--- a/lambdas/matching/tests/matching-handler.test.ts
+++ b/lambdas/matching/tests/matching-handler.test.ts
@@ -17,6 +17,7 @@ describe("matching-handler", () => {
         dateOfBirth: "1948-04-23",
         nino: "AA000003D",
       }),
+      status: 200,
     });
     const matchingHandler = new MatchingHandler();
     const event = {
@@ -34,7 +35,8 @@ describe("matching-handler", () => {
       oAuthToken: "123",
     } as MatchEvent;
     const result = await matchingHandler.handler(event, {} as Context);
-    expect(result).toStrictEqual({
+    expect(result.status).toEqual(200);
+    expect(result.body).toStrictEqual({
       firstName: "Jim",
       lastName: "Ferguson",
       dateOfBirth: "1948-04-23",

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -123,7 +123,7 @@
     },
     "Person Identity Table Name": {
       "Type": "Task",
-      "Next": "Query Session",
+      "Next": "Query Person Identity Table",
       "Parameters": {
         "Name": "/${CommonStackName}/PersonIdentityTableName"
       },
@@ -133,7 +133,7 @@
       },
       "ResultPath": "$.personIdentityTableName"
     },
-    "Query Session": {
+    "Query Person Identity Table": {
       "Type": "Task",
       "Next": "User Exists?",
       "Parameters": {
@@ -177,7 +177,7 @@
           "Next": "Get User Agent and API URL"
         }
       ],
-      "Default": "Err: No user for nino"
+      "Default": "Err: No user found in Person Identity"
     },
     "Get User Agent and API URL": {
       "Type": "Task",
@@ -192,7 +192,7 @@
       },
       "ResultPath": "$.apiParams"
     },
-    "Err: No user for nino": {
+    "Err: No user found in Person Identity": {
       "Type": "Pass",
       "End": true,
       "Result": {
@@ -237,7 +237,7 @@
         "Payload.$": "$",
         "FunctionName": "${MatchingFunctionArn}"
       },
-      "Next": "Response Validation",
+      "Next": "Check HTTP Status Code",
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
@@ -252,28 +252,12 @@
     "Err: Matching Lambda Exception": {
       "Type": "Fail"
     },
-    "Response Validation": {
+    "Check HTTP Status Code": {
       "Type": "Choice",
       "Choices": [
         {
-          "And": [
-            {
-              "Variable": "$.hmrc_response.payload.firstName",
-              "IsPresent": true
-            },
-            {
-              "Variable": "$.hmrc_response.payload.lastName",
-              "IsPresent": true
-            },
-            {
-              "Variable": "$.hmrc_response.payload.dateOfBirth",
-              "IsPresent": true
-            },
-            {
-              "Variable": "$.hmrc_response.payload.nino",
-              "IsPresent": true
-            }
-          ],
+          "Variable": "$.hmrc_response.payload.status",
+          "NumericEquals": 200,
           "Next": "Update status to PASS"
         }
       ],
@@ -283,12 +267,12 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Variable": "$.hmrc_response.payload.errors",
+          "Variable": "$.hmrc_response.payload.body.errors",
           "IsPresent": true,
           "Next": "Err: HMRC error"
         },
         {
-          "Variable": "$.hmrc_response.payload.message",
+          "Variable": "$.hmrc_response.payload.body.message",
           "IsPresent": true,
           "Next": "Err: Failed Auth"
         }
@@ -298,7 +282,7 @@
     "Err: HMRC error": {
       "Type": "Pass",
       "Parameters": {
-        "error.$": "$.hmrc_response.payload.errors"
+        "error.$": "$.hmrc_response.payload.body.errors"
       },
       "End": true
     },
@@ -380,7 +364,7 @@
             "S.$": "$$.Execution.Input.sessionId"
           },
           "nino": {
-            "S.$": "$.hmrc_response.payload.nino"
+            "S.$": "$.hmrc_response.payload.body.nino"
           }
         },
         "ConditionExpression": "attribute_not_exists(sessionId)"
@@ -412,7 +396,7 @@
     },
     "Err: Failed Auth": {
       "Type": "Fail",
-      "CausePath": "$.hmrc_response.payload.message"
+      "CausePath": "$.hmrc_response.payload.body.message"
     }
   }
 }


### PR DESCRIPTION
## Proposed changes

### What changed
matching-handler.ts and state machine to accompany changes.

Renamed some of the states to be correct e.g. "Query Session" is now "Query Person Identity Table". These are so the states are clearly and accurately describing what they are doing. 

### Why did it change
We need the status code back from HMRC as part of the CRI functionality. 

### Issue tracking
- [OJ-2215](https://govukverify.atlassian.net/browse/OJ-2215)


[OJ-2215]: https://govukverify.atlassian.net/browse/OJ-2215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ