### PR TITLE
OJ-2214: Store HMRC response into database

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -274,11 +274,15 @@ Resources:
       TableName: !Sub ${AWS::StackName}-nino-attempts
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
-        - AttributeName: id
+        - AttributeName: sessionId
+          AttributeType: S
+        - AttributeName: timestamp
           AttributeType: S
       KeySchema:
-        - AttributeName: id
+        - AttributeName: sessionId
           KeyType: HASH
+        - AttributeName: timestamp
+          KeyType: RANGE
 
   NinoUsersTable:
     Type: AWS::DynamoDB::Table

--- a/integration-tests/tests/aws/check-session/check-session.test.ts
+++ b/integration-tests/tests/aws/check-session/check-session.test.ts
@@ -4,7 +4,7 @@ import { executeStepFunction } from "../resources/stepfunction-helper";
 
 describe("check-session", () => {
   const input = {
-    sessionId: "123456789",
+    sessionId: "session-test",
   };
 
   let output: Partial<{

--- a/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
@@ -84,7 +84,7 @@ describe("nino-check-happy", () => {
         items: { sessionId: input.sessionId },
       }
     );
-    await clearAttemptsTable(output.NinoAttemptsTable, input.sessionId);
+    await clearAttemptsTable(input.sessionId, output.NinoAttemptsTable);
   });
 
   it("should execute nino step function 1st attempt", async () => {

--- a/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
@@ -10,7 +10,7 @@ jest.setTimeout(30_000);
 
 describe("nino-check-happy", () => {
   const input = {
-    sessionId: "123456789",
+    sessionId: "check-happy",
     nino: "AA000003D",
   };
 

--- a/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
@@ -18,7 +18,7 @@ jest.setTimeout(30_000);
 const secretsManager = new SecretsManager();
 
 const input = {
-  sessionId: "123456789",
+  sessionId: "check-unhappy",
   nino: "AB123003C",
 };
 

--- a/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
@@ -1,6 +1,7 @@
 import { stackOutputs } from "../resources/cloudformation-helper";
 import { executeStepFunction } from "../resources/stepfunction-helper";
 import {
+  clearAttemptsTable,
   clearItems,
   clearItemsFromTables,
   populateTable,
@@ -76,32 +77,33 @@ beforeEach(async () => {
   );
 });
 
-afterEach(
-  async () =>
-    await clearItemsFromTables(
-      {
-        tableName: sessionTableName,
-        items: { sessionId: input.sessionId },
-      },
-      {
-        tableName: personIdentityTableName,
-        items: { sessionId: input.sessionId },
-      },
-      {
-        tableName: output.NinoUsersTable as string,
-        items: { sessionId: input.sessionId },
-      },
-      {
-        tableName: output.NinoAttemptsTable as string,
-        items: { id: input.sessionId },
-      }
-    )
-);
+afterEach(async () => {
+  await clearItemsFromTables(
+    {
+      tableName: sessionTableName,
+      items: { sessionId: input.sessionId },
+    },
+    {
+      tableName: personIdentityTableName,
+      items: { sessionId: input.sessionId },
+    },
+    {
+      tableName: output.NinoUsersTable as string,
+      items: { sessionId: input.sessionId },
+    }
+  );
+  await clearAttemptsTable(output.NinoAttemptsTable, input.sessionId);
+});
 
 it("should fail when there is more than 2 nino check attempts", async () => {
   await populateTable(output.NinoAttemptsTable as string, {
-    id: input.sessionId,
-    attempts: 2,
+    sessionId: input.sessionId,
+    timestamp: Date.now().toString(),
+  });
+
+  await populateTable(output.NinoAttemptsTable as string, {
+    sessionId: input.sessionId,
+    timestamp: Date.now().toString(),
   });
 
   const startExecutionResult = await executeStepFunction(
@@ -146,32 +148,13 @@ it("should fail when session id is invalid", async () => {
   expect(startExecutionResult.status).toBe("SUCCEEDED");
 });
 
-it("should fail when user record already present in nino user table", async () => {
-  await populateTable(output.NinoUsersTable as string, {
-    sessionId: "123456789",
-    nino: "AA000003D",
-  });
-
-  const startExecutionResult = await executeStepFunction(
-    output.NinoCheckStateMachineArn as string,
-    {
-      sessionId: "123456789",
-      nino: "AA000003D",
-    }
-  );
-
-  expect(startExecutionResult.status).toBe("FAILED");
-});
-
 it("should fail when user NINO does not match with HMRC DB", async () => {
   const startExecutionResult = await executeStepFunction(
     output.NinoCheckStateMachineArn as string,
     input
   );
 
-  expect(startExecutionResult.output).toBe(
-    '{"error":"CID returned no record"}'
-  );
+  expect(startExecutionResult.output).toBe('{"httpStatus":"424"}');
 });
 
 describe("NINO check URL is unavailable", () => {

--- a/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
@@ -92,7 +92,7 @@ afterEach(async () => {
       items: { sessionId: input.sessionId },
     }
   );
-  await clearAttemptsTable(output.NinoAttemptsTable, input.sessionId);
+  await clearAttemptsTable(input.sessionId, output.NinoAttemptsTable);
 });
 
 it("should fail when there is more than 2 nino check attempts", async () => {

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
@@ -148,7 +148,7 @@ describe("nino-issue-credential-happy", () => {
         items: { sessionId: input.sessionId },
       }
     );
-    await clearAttemptsTable(output.NinoAttemptsTable, input.sessionId);
+    await clearAttemptsTable(input.sessionId, output.NinoAttemptsTable);
   });
 
   it("should create signed JWT when nino check is successful", async () => {

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
@@ -19,7 +19,7 @@ jest.setTimeout(30_000);
 
 describe("nino-issue-credential-happy", () => {
   const input = {
-    sessionId: "123456789",
+    sessionId: "issue-credential-happy",
     nino: "AA000003D",
   };
 
@@ -84,14 +84,14 @@ describe("nino-issue-credential-happy", () => {
       {
         tableName: output.NinoUsersTable as string,
         items: {
-          sessionId: "123456789",
+          sessionId: input.sessionId,
           nino: "AA000003D",
         },
       },
       {
         tableName: sessionTableName,
         items: {
-          sessionId: "123456789",
+          sessionId: input.sessionId,
           accessToken: "Bearer test",
           authorizationCode: "cd8ff974-d3bc-4422-9b38-a3e5eb24adc0",
           authorizationCodeExpiryDate: "1698925598",
@@ -124,7 +124,8 @@ describe("nino-issue-credential-happy", () => {
       {
         tableName: output.NinoAttemptsTable as string,
         items: {
-          id: "123456789",
+          sessionId: input.sessionId,
+          timestamp: Date.now().toString(),
           attempts: 1,
           outcome: "PASS",
         },

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
@@ -92,7 +92,7 @@ describe("nino-issue-credential-happy", () => {
         tableName: sessionTableName,
         items: {
           sessionId: input.sessionId,
-          accessToken: "Bearer test",
+          accessToken: "Bearer happy",
           authorizationCode: "cd8ff974-d3bc-4422-9b38-a3e5eb24adc0",
           authorizationCodeExpiryDate: "1698925598",
           expiryDate: "9999999999",
@@ -152,7 +152,7 @@ describe("nino-issue-credential-happy", () => {
   });
 
   it("should create signed JWT when nino check is successful", async () => {
-    const startExecutionResult = await getExecutionResult("Bearer test");
+    const startExecutionResult = await getExecutionResult("Bearer happy");
 
     const currentCredentialKmsSigningKeyId = await getSSMParameter(
       `/${output.CommonStackName}/verifiableCredentialKmsSigningKeyId`
@@ -188,7 +188,7 @@ describe("nino-issue-credential-happy", () => {
       { name: jwtTtlUnit, value: "MINUTES" }
     );
 
-    const startExecutionResult = await getExecutionResult("Bearer test");
+    const startExecutionResult = await getExecutionResult("Bearer happy");
 
     await updateSSMParameters(
       { name: maxJwtTtl, value: currentMaxJwtTtl as string },
@@ -210,7 +210,7 @@ describe("nino-issue-credential-happy", () => {
       `/${output.CommonStackName}/clients/ipv-core-stub-aws-build/jwtAuthentication/authenticationAlg`
     )) as string;
 
-    const startExecutionResult = await getExecutionResult("Bearer test");
+    const startExecutionResult = await getExecutionResult("Bearer happy");
     const token = JSON.parse(startExecutionResult.output as string);
     const [header, jwtPayload, signature] = token.jwt.split(".");
 

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
@@ -3,6 +3,7 @@ import { createPublicKey } from "crypto";
 import { stackOutputs } from "../resources/cloudformation-helper";
 import { executeStepFunction } from "../resources/stepfunction-helper";
 import {
+  clearAttemptsTable,
   clearItemsFromTables,
   populateTables,
 } from "../resources/dynamodb-helper";
@@ -131,27 +132,23 @@ describe("nino-issue-credential-happy", () => {
     );
   });
 
-  afterEach(
-    async () =>
-      await clearItemsFromTables(
-        {
-          tableName: sessionTableName,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: personIdentityTableName,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: output.NinoUsersTable as string,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: output.NinoAttemptsTable as string,
-          items: { id: input.sessionId },
-        }
-      )
-  );
+  afterEach(async () => {
+    await clearItemsFromTables(
+      {
+        tableName: sessionTableName,
+        items: { sessionId: input.sessionId },
+      },
+      {
+        tableName: personIdentityTableName,
+        items: { sessionId: input.sessionId },
+      },
+      {
+        tableName: output.NinoUsersTable as string,
+        items: { sessionId: input.sessionId },
+      }
+    );
+    await clearAttemptsTable(output.NinoAttemptsTable, input.sessionId);
+  });
 
   it("should create signed JWT when nino check is successful", async () => {
     const startExecutionResult = await getExecutionResult("Bearer test");

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
@@ -1,6 +1,7 @@
 import { stackOutputs } from "../resources/cloudformation-helper";
 import { executeStepFunction } from "../resources/stepfunction-helper";
 import {
+  clearAttemptsTable,
   clearItemsFromTables,
   populateTables,
 } from "../resources/dynamodb-helper";
@@ -87,27 +88,23 @@ describe("nino-issue-credential-unhappy", () => {
     );
   });
 
-  afterEach(
-    async () =>
-      await clearItemsFromTables(
-        {
-          tableName: sessionTableName,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: personIdentityTableName,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: output.NinoUsersTable as string,
-          items: { sessionId: input.sessionId },
-        },
-        {
-          tableName: output.NinoAttemptsTable as string,
-          items: { id: input.sessionId },
-        }
-      )
-  );
+  afterEach(async () => {
+    await clearItemsFromTables(
+      {
+        tableName: sessionTableName,
+        items: { sessionId: input.sessionId },
+      },
+      {
+        tableName: personIdentityTableName,
+        items: { sessionId: input.sessionId },
+      },
+      {
+        tableName: output.NinoUsersTable as string,
+        items: { sessionId: input.sessionId },
+      }
+    );
+    await clearAttemptsTable(output.NinoAttemptsTable, input.sessionId);
+  });
 
   it("should fail when nino check is unsuccessful", async () => {
     const startExecutionResult = await executeStepFunction(

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
@@ -48,7 +48,7 @@ describe("nino-issue-credential-unhappy", () => {
         tableName: sessionTableName,
         items: {
           sessionId: input.sessionId,
-          accessToken: "Bearer test",
+          accessToken: "Bearer unhappy",
           authorizationCode: "cd8ff974-d3bc-4422-9b38-a3e5eb24adc0",
           authorizationCodeExpiryDate: "1698925598",
           expiryDate: "9999999999",
@@ -111,7 +111,7 @@ describe("nino-issue-credential-unhappy", () => {
     const startExecutionResult = await executeStepFunction(
       output.NinoIssueCredentialStateMachineArn as string,
       {
-        bearerToken: "Bearer test",
+        bearerToken: "Bearer unhappy",
       }
     );
 

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
@@ -104,7 +104,7 @@ describe("nino-issue-credential-unhappy", () => {
         items: { sessionId: input.sessionId },
       }
     );
-    await clearAttemptsTable(output.NinoAttemptsTable, input.sessionId);
+    await clearAttemptsTable(input.sessionId, output.NinoAttemptsTable);
   });
 
   it("should fail when nino check is unsuccessful", async () => {

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
@@ -10,7 +10,7 @@ jest.setTimeout(30_000);
 
 describe("nino-issue-credential-unhappy", () => {
   const input = {
-    sessionId: "123456789",
+    sessionId: "issue-credential-unhappy",
     nino: "AA000003D",
   };
 
@@ -40,14 +40,14 @@ describe("nino-issue-credential-unhappy", () => {
       {
         tableName: output.NinoUsersTable as string,
         items: {
-          sessionId: "123456789",
+          sessionId: input.sessionId,
           nino: "AA000003D",
         },
       },
       {
         tableName: sessionTableName,
         items: {
-          sessionId: "123456789",
+          sessionId: input.sessionId,
           accessToken: "Bearer test",
           authorizationCode: "cd8ff974-d3bc-4422-9b38-a3e5eb24adc0",
           authorizationCodeExpiryDate: "1698925598",
@@ -80,7 +80,8 @@ describe("nino-issue-credential-unhappy", () => {
       {
         tableName: output.NinoAttemptsTable as string,
         items: {
-          id: "123456789",
+          sessionId: input.sessionId,
+          timestamp: Date.now().toString(),
           attempts: 2,
           outcome: "FAIL",
         },

--- a/integration-tests/tests/aws/resources/dynamodb-helper.ts
+++ b/integration-tests/tests/aws/resources/dynamodb-helper.ts
@@ -28,8 +28,8 @@ export const clearItems = (tableName: string, items: Keys) =>
   sendCommand(DeleteCommand, { TableName: tableName, Key: items });
 
 export async function clearAttemptsTable(
-  tableName: string | undefined,
-  sessionId: string
+  sessionId: string,
+  tableName?: string
 ) {
   if (tableName) {
     const query = await sendCommand(QueryCommand, {

--- a/integration-tests/tests/aws/resources/dynamodb-helper.ts
+++ b/integration-tests/tests/aws/resources/dynamodb-helper.ts
@@ -3,6 +3,7 @@ import {
   DeleteCommand,
   DynamoDBDocumentClient,
   PutCommand,
+  QueryCommand,
 } from "@aws-sdk/lib-dynamodb";
 import { createSendCommand } from "./aws-helper";
 
@@ -25,6 +26,29 @@ export const populateTables = (...tableRecords: TableRecords[]) =>
 
 export const clearItems = (tableName: string, items: Keys) =>
   sendCommand(DeleteCommand, { TableName: tableName, Key: items });
+
+export async function clearAttemptsTable(
+  tableName: string | undefined,
+  sessionId: string
+) {
+  if (tableName) {
+    const query = await sendCommand(QueryCommand, {
+      TableName: tableName,
+      KeyConditionExpression: "sessionId = :sessionId",
+      ExpressionAttributeValues: {
+        ":sessionId": sessionId,
+      },
+    });
+    if (query.Items) {
+      query.Items.forEach((item) => {
+        clearItems(tableName, {
+          sessionId: item.sessionId,
+          timestamp: item.timestamp,
+        });
+      });
+    }
+  }
+}
 
 export const clearItemsFromTables = (...tableRecords: TableRecords[]) =>
   Promise.all(

--- a/integration-tests/tests/mocked/nino-check/MockConfigFile.json
+++ b/integration-tests/tests/mocked/nino-check/MockConfigFile.json
@@ -6,13 +6,12 @@
           "Invoke Check Session": "CheckSessionSuccess",
           "Query User Attempts": "DynamoDbQueryNoResult",
           "Create new user attempt": "DynamoDbQueryNoResult",
-          "Increment user attempt": "DynamoDbQueryNoResult",
           "Person Identity Table Name": "PersonIdentityTableSuccess",
           "Query Person Identity Table": "QuerySessionSuccess",
           "Get User Agent and API URL": "GetAPIParametersSuccess",
           "Get OAuth Token": "GetOAuthAccessTokenSuccess",
           "Call Matching API": "CallMatchingAPISuccess",
-          "Update status to PASS": "UpdateStatusToPassSuccess",
+          "Store Successful Attempt": "UpdateStatusToPassSuccess",
           "Fetch Auth Code Expiry": "FetchAuthCodeExpirySuccess",
           "Fetch Session Table Name": "FetchSessionTableNameSuccess",
           "Set Auth Code for Session": "SetAuthCodeSuccess",
@@ -22,13 +21,12 @@
           "Invoke Check Session": "CheckSessionSuccess",
           "Query User Attempts": "QueryUserAttemptSuccessOn2ndTry",
           "Create new user attempt": "DynamoDbQueryNoResult",
-          "Increment user attempt": "DynamoDbQueryNoResult",
           "Person Identity Table Name": "PersonIdentityTableSuccess",
           "Query Person Identity Table": "QuerySessionSuccess",
           "Get User Agent and API URL": "GetAPIParametersSuccess",
           "Get OAuth Token": "GetOAuthAccessTokenSuccess",
           "Call Matching API": "CallMatchingAPISuccess",
-          "Update status to PASS": "UpdateStatusToPassSuccess",
+          "Store Successful Attempt": "UpdateStatusToPassSuccess",
           "Fetch Auth Code Expiry": "FetchAuthCodeExpirySuccess",
           "Fetch Session Table Name": "FetchSessionTableNameSuccess",
           "Set Auth Code for Session": "SetAuthCodeSuccess",
@@ -41,27 +39,10 @@
           "Invoke Check Session": "CheckSessionSuccess",
           "Query User Attempts": "QueryUserAttemptFailureAfterMoreThanTwoAttempts"
         },
-        "ErrorSavingInNinoDB": {
-          "Invoke Check Session": "CheckSessionSuccess",
-          "Query User Attempts": "QueryUserAttemptSuccessOn2ndTry",
-          "Create new user attempt": "DynamoDbQueryNoResult",
-          "Increment user attempt": "DynamoDbQueryNoResult",
-          "Person Identity Table Name": "PersonIdentityTableSuccess",
-          "Query Person Identity Table": "QuerySessionSuccess",
-          "Get User Agent and API URL": "GetAPIParametersSuccess",
-          "Get OAuth Token": "GetOAuthAccessTokenSuccess",
-          "Call Matching API": "CallMatchingAPISuccess",
-          "Update status to PASS": "UpdateStatusToPassSuccess",
-          "Fetch Auth Code Expiry": "FetchAuthCodeExpirySuccess",
-          "Fetch Session Table Name": "FetchSessionTableNameSuccess",
-          "Set Auth Code for Session": "SetAuthCodeSuccess",
-          "Save NINO & sessionId to nino-users table": "SaveNinoFailure"
-        },
         "UserNotFoundForGivenNino": {
           "Invoke Check Session": "CheckSessionSuccess",
           "Query User Attempts": "DynamoDbQueryNoResult",
           "Create new user attempt": "DynamoDbQueryNoResult",
-          "Increment user attempt": "DynamoDbQueryNoResult",
           "Person Identity Table Name": "PersonIdentityTableSuccess",
           "Query Person Identity Table": "DynamoDbQueryNoResult"
         },
@@ -69,7 +50,6 @@
           "Invoke Check Session": "CheckSessionSuccess",
           "Query User Attempts": "DynamoDbQueryNoResult",
           "Create new user attempt": "DynamoDbQueryNoResult",
-          "Increment user attempt": "DynamoDbQueryNoResult",
           "Person Identity Table Name": "PersonIdentityTableSuccess",
           "Query Person Identity Table": "QuerySessionSuccess",
           "Get User Agent and API URL": "GetAPIParametersSuccess",
@@ -80,7 +60,6 @@
           "Invoke Check Session": "CheckSessionSuccess",
           "Query User Attempts": "QueryUserAttemptSuccessOn2ndTry",
           "Create new user attempt": "DynamoDbQueryNoResult",
-          "Increment user attempt": "DynamoDbQueryNoResult",
           "Person Identity Table Name": "PersonIdentityTableSuccess",
           "Query Person Identity Table": "QuerySessionSuccess",
           "Get User Agent and API URL": "GetAPIParametersSuccess",
@@ -91,12 +70,12 @@
           "Invoke Check Session": "CheckSessionSuccess",
           "Query User Attempts": "QueryUserAttemptSuccessOn2ndTry",
           "Create new user attempt": "DynamoDbQueryNoResult",
-          "Increment user attempt": "DynamoDbQueryNoResult",
           "Person Identity Table Name": "PersonIdentityTableSuccess",
           "Query Person Identity Table": "QuerySessionSuccess",
           "Get User Agent and API URL": "GetAPIParametersSuccess",
           "Get OAuth Token": "GetOAuthAccessTokenSuccess",
-          "Call Matching API": "CallMatchingAPIFailNoRecords"
+          "Call Matching API": "CallMatchingAPIFailNoRecords",
+          "Store Failed Match Attempt": "DynamoDbQueryNoResult"
         }
       }
     }
@@ -134,7 +113,7 @@
       "0": {
         "Return": {
           "Payload": {
-            "status": "400",
+            "status": "401",
             "body": {
               "errors": "CID returned no record"
             }
@@ -428,18 +407,7 @@
     "QueryUserAttemptFailureAfterMoreThanTwoAttempts": {
       "0": {
         "Return": {
-          "Count": 1,
-          "Items": [
-            {
-              "id": {
-                "S": "12345"
-              },
-              "attempts": {
-                "N": "2"
-              }
-            }
-          ],
-          "ScannedCount": 1
+          "Count": 2
         }
       }
     },
@@ -454,7 +422,7 @@
       "0": {
         "Return": {
           "Payload": {
-            "status": 200,
+            "status": "200",
             "body": {
               "firstName": "Jim",
               "lastName": "Ferguson",

--- a/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
@@ -53,24 +53,6 @@ describe("nino-check-unhappy", () => {
       '{"error":"Maximum number of attempts exceeded"}'
     );
   });
-  it("should fail when there is an error while saving details in Nino DB", async () => {
-    const input = JSON.stringify({
-      nino: "AA000003D",
-      sessionId: "12345",
-    });
-    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
-      "ErrorSavingInNinoDB",
-      input
-    );
-
-    const results = await sfnContainer.waitFor(
-      (event: HistoryEvent) => event?.type === "ExecutionFailed",
-      responseStepFunction
-    );
-    expect(results[0].executionFailedEventDetails?.cause).toContain(
-      "The conditional request failed (Service: AmazonDynamoDBv2; Status Code: 400"
-    );
-  });
 
   it("should fail when user cannot be found for the given nino", async () => {
     const input = JSON.stringify({
@@ -143,7 +125,7 @@ describe("nino-check-unhappy", () => {
       responseStepFunction
     );
     expect(results[0].executionSucceededEventDetails?.output).toEqual(
-      '{"error":"CID returned no record"}'
+      '{"httpStatus":"424"}'
     );
   });
 });

--- a/lambdas/matching/src/matching-handler.ts
+++ b/lambdas/matching/src/matching-handler.ts
@@ -8,7 +8,7 @@ export class MatchingHandler implements LambdaInterface {
   public async handler(
     event: MatchEvent,
     _context: unknown
-  ): Promise<{ status: number; body: string }> {
+  ): Promise<{ status: string; body: string }> {
     try {
       const response = await fetch(event.apiURL, {
         method: "POST",
@@ -26,12 +26,12 @@ export class MatchingHandler implements LambdaInterface {
       });
       try {
         return {
-          status: response.status,
+          status: response.status.toString(),
           body: await response.json(),
         };
       } catch (error: unknown) {
         return {
-          status: response.status,
+          status: response.status.toString(),
           body: await response.text(),
         };
       }

--- a/lambdas/matching/tests/matching-handler.test.ts
+++ b/lambdas/matching/tests/matching-handler.test.ts
@@ -35,7 +35,7 @@ describe("matching-handler", () => {
       oAuthToken: "123",
     } as MatchEvent;
     const result = await matchingHandler.handler(event, {} as Context);
-    expect(result.status).toBe(200);
+    expect(result.status).toBe("200");
     expect(result.body).toStrictEqual({
       firstName: "Jim",
       lastName: "Ferguson",

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -67,7 +67,7 @@
       "Choices": [
         {
           "Variable": "$.check-attempts-exist.Count",
-          "StringGreaterThanEquals": "2",
+          "NumericGreaterThanEquals": 2,
           "Next": "Err: Attempts exceeded"
         }
       ],
@@ -334,7 +334,7 @@
       "Type": "Pass",
       "End": true,
       "Parameters": {
-        "ValueEnteredInForm": "{\n \"httpStatus\": \"424\" \n}"
+        "httpStatus": "424"
       }
     },
     "Fetch Auth Code Expiry": {

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -196,7 +196,7 @@
         "Payload.$": "$",
         "FunctionName": "${MatchingFunctionArn}"
       },
-      "Next": "Check HTTP Status Code",
+      "Next": "Successful match?",
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
@@ -211,16 +211,16 @@
     "Err: Matching Lambda Exception": {
       "Type": "Fail"
     },
-    "Check HTTP Status Code": {
+    "Successful match?": {
       "Type": "Choice",
       "Choices": [
         {
           "Variable": "$.hmrc_response.payload.status",
-          "NumericEquals": 200,
+          "StringEquals": "200",
           "Next": "Store Successful Attempt"
         }
       ],
-      "Default": "Contains Error?"
+      "Default": "Is Deceased?"
     },
     "Store Successful Attempt": {
       "Type": "Task",
@@ -235,7 +235,7 @@
             "S.$": "$$.State.EnteredTime"
           },
           "status": {
-            "N": "States.Format('{}', $.hmrc_response.payload.status)"
+            "N.$": "$.hmrc_response.payload.status"
           },
           "attempt": {
             "S": "PASS"
@@ -249,24 +249,93 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Variable": "$.hmrc_response.payload.body.errors",
-          "IsPresent": true,
-          "Next": "Err: HMRC error"
+          "And": [
+            {
+              "Variable": "$.hmrc_response.payload.status",
+              "StringEquals": "401"
+            },
+            {
+              "Variable": "$.hmrc_response.payload.body.errors",
+              "IsPresent": true
+            }
+          ],
+          "Next": "Store Failed Match Attempt"
         },
         {
-          "Variable": "$.hmrc_response.payload.body.message",
-          "IsPresent": true,
+          "Variable": "$.hmrc_response.payload.body.code",
+          "StringEquals": "INVALID_CREDENTIALS",
           "Next": "Err: Failed Auth"
         }
       ],
       "Default": "Err: API Error"
     },
-    "Err: HMRC error": {
-      "Type": "Pass",
+    "Store Failed Match Attempt": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:putItem",
       "Parameters": {
-        "error.$": "$.hmrc_response.payload.body.errors"
+        "TableName": "${NinoAttemptsTable}",
+        "Item": {
+          "sessionId": {
+            "S.$": "$$.Execution.Input.sessionId"
+          },
+          "timestamp": {
+            "S.$": "$$.State.EnteredTime"
+          },
+          "status": {
+            "N.$": "$.hmrc_response.payload.status"
+          },
+          "text": {
+            "S.$": "$.hmrc_response.payload.body.errors"
+          },
+          "attempt": {
+            "S": "FAIL"
+          }
+        }
       },
-      "End": true
+      "Next": "Send Retry"
+    },
+    "Is Deceased?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.hmrc_response.payload.status",
+          "StringEquals": "424",
+          "Next": "Store Matched with Deceased Attempt"
+        }
+      ],
+      "Default": "Contains Error?"
+    },
+    "Store Matched with Deceased Attempt": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:putItem",
+      "Parameters": {
+        "TableName": "${NinoAttemptsTable}",
+        "Item": {
+          "sessionId": {
+            "S.$": "$$.Execution.Input.sessionId"
+          },
+          "timestamp": {
+            "S.$": "$$.State.EnteredTime"
+          },
+          "status": {
+            "N.$": "$.hmrc_response.payload.status"
+          },
+          "text": {
+            "S": "Matched with Deceased"
+          },
+          "attempt": {
+            "S": "FAIL"
+          }
+        }
+      },
+      "Next": "Send Retry"
+    },
+    "Send Retry": {
+      "Type": "Pass",
+      "End": true,
+      "Parameters": {
+        "ValueEnteredInForm": "{\n \"httpStatus\": \"424\" \n}"
+      }
     },
     "Fetch Auth Code Expiry": {
       "Type": "Task",
@@ -328,26 +397,15 @@
           "nino": {
             "S.$": "$.hmrc_response.payload.body.nino"
           }
-        },
-        "ConditionExpression": "attribute_not_exists(sessionId)"
+        }
       },
       "Next": "Response Filtering",
-      "ResultPath": "$.saveUser",
-      "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Next": "Err: Saving NINO"
-        }
-      ]
+      "ResultPath": "$.saveUser"
     },
     "Response Filtering": {
       "Type": "Pass",
       "Next": "Nino check successful",
       "Parameters": {}
-    },
-    "Err: Saving NINO": {
-      "Type": "Fail",
-      "CausePath": "$.Cause"
     },
     "Nino check successful": {
       "Type": "Succeed"

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -41,7 +41,7 @@
       "Next": "User has attempts?",
       "Parameters": {
         "TableName": "${NinoAttemptsTable}",
-        "KeyConditionExpression": "id = :value",
+        "KeyConditionExpression": "sessionId = :value",
         "ExpressionAttributeValues": {
           ":value": {
             "S.$": "$.sessionId"
@@ -60,39 +60,18 @@
           "Next": "User has more than 2 attempts?"
         }
       ],
-      "Default": "Create new user attempt"
-    },
-    "Create new user attempt": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::dynamodb:putItem",
-      "Parameters": {
-        "TableName": "${NinoAttemptsTable}",
-        "Item": {
-          "id": {
-            "S.$": "$.sessionId"
-          },
-          "attempts": {
-            "N": "0"
-          },
-          "outcome": {
-            "S": "FAIL"
-          }
-        },
-        "ConditionExpression": "attribute_not_exists(id)"
-      },
-      "Next": "Increment user attempt",
-      "ResultPath": null
+      "Default": "Person Identity Table Name"
     },
     "User has more than 2 attempts?": {
       "Type": "Choice",
       "Choices": [
         {
-          "Variable": "$.check-attempts-exist.Items[0].attempts.N",
+          "Variable": "$.check-attempts-exist.Count",
           "StringGreaterThanEquals": "2",
           "Next": "Err: Attempts exceeded"
         }
       ],
-      "Default": "Increment user attempt"
+      "Default": "Person Identity Table Name"
     },
     "Err: Attempts exceeded": {
       "Type": "Pass",
@@ -100,26 +79,6 @@
       "Parameters": {
         "error": "Maximum number of attempts exceeded"
       }
-    },
-    "Increment user attempt": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::dynamodb:updateItem",
-      "Parameters": {
-        "TableName": "${NinoAttemptsTable}",
-        "Key": {
-          "id": {
-            "S.$": "$.sessionId"
-          }
-        },
-        "UpdateExpression": "ADD attempts :attempts",
-        "ExpressionAttributeValues": {
-          ":attempts": {
-            "N": "1"
-          }
-        }
-      },
-      "Next": "Person Identity Table Name",
-      "ResultPath": null
     },
     "Person Identity Table Name": {
       "Type": "Task",
@@ -258,10 +217,33 @@
         {
           "Variable": "$.hmrc_response.payload.status",
           "NumericEquals": 200,
-          "Next": "Update status to PASS"
+          "Next": "Store Successful Attempt"
         }
       ],
       "Default": "Contains Error?"
+    },
+    "Store Successful Attempt": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:putItem",
+      "Parameters": {
+        "TableName": "${NinoAttemptsTable}",
+        "Item": {
+          "sessionId": {
+            "S.$": "$$.Execution.Input.sessionId"
+          },
+          "timestamp": {
+            "S.$": "$$.State.EnteredTime"
+          },
+          "status": {
+            "N": "States.Format('{}', $.hmrc_response.payload.status)"
+          },
+          "attempt": {
+            "S": "PASS"
+          }
+        }
+      },
+      "Next": "Fetch Auth Code Expiry",
+      "ResultPath": null
     },
     "Contains Error?": {
       "Type": "Choice",
@@ -285,26 +267,6 @@
         "error.$": "$.hmrc_response.payload.body.errors"
       },
       "End": true
-    },
-    "Update status to PASS": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::dynamodb:updateItem",
-      "Parameters": {
-        "TableName": "${NinoAttemptsTable}",
-        "Key": {
-          "id": {
-            "S.$": "$$.Execution.Input.sessionId"
-          }
-        },
-        "UpdateExpression": "SET outcome = :outcome",
-        "ExpressionAttributeValues": {
-          ":outcome": {
-            "S": "PASS"
-          }
-        }
-      },
-      "Next": "Fetch Auth Code Expiry",
-      "ResultPath": null
     },
     "Fetch Auth Code Expiry": {
       "Type": "Task",

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -220,7 +220,7 @@
           "Next": "Store Successful Attempt"
         }
       ],
-      "Default": "Is Deceased?"
+      "Default": "Contains Error?"
     },
     "Store Successful Attempt": {
       "Type": "Task",
@@ -286,42 +286,6 @@
           },
           "text": {
             "S.$": "$.hmrc_response.payload.body.errors"
-          },
-          "attempt": {
-            "S": "FAIL"
-          }
-        }
-      },
-      "Next": "Send Retry"
-    },
-    "Is Deceased?": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.hmrc_response.payload.status",
-          "StringEquals": "424",
-          "Next": "Store Matched with Deceased Attempt"
-        }
-      ],
-      "Default": "Contains Error?"
-    },
-    "Store Matched with Deceased Attempt": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::dynamodb:putItem",
-      "Parameters": {
-        "TableName": "${NinoAttemptsTable}",
-        "Item": {
-          "sessionId": {
-            "S.$": "$$.Execution.Input.sessionId"
-          },
-          "timestamp": {
-            "S.$": "$$.State.EnteredTime"
-          },
-          "status": {
-            "N.$": "$.hmrc_response.payload.status"
-          },
-          "text": {
-            "S": "Matched with Deceased"
           },
           "attempt": {
             "S": "FAIL"

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -220,7 +220,7 @@
               "Next": "Add Type to VC",
               "Parameters": {
                 "TableName": "${NinoAttemptsTable}",
-                "KeyConditionExpression": "id = :value",
+                "KeyConditionExpression": "sessionId = :value",
                 "ExpressionAttributeValues": {
                   ":value": {
                     "S.$": "$.querySession.sessionId"


### PR DESCRIPTION
## Proposed changes

* Updated state machine to save an attempt when they are either successful or if the match fails. The state machine will no longer count any failure (i.e. internal errors) as an attempt.
* Removed unable to save user state as errors are already captured by default. 
* Updated nino-attempts table to include status and text
* Updated attempt checking to be based on number of records
* Updated match-handler.ts to return the status code as a String to allow DynamoDB to save this
* Updated HMRC error block to capture errors correctly in state machine

* Changed tests to use different mock data between them. 

### Issue tracking
- [OJ-2214](https://govukverify.atlassian.net/browse/OJ-2214)


[OJ-2214]: https://govukverify.atlassian.net/browse/OJ-2214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ