### PR TITLE
BAU: Removed unused NinoAttemptsTable

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -268,18 +268,6 @@ Resources:
         - !Ref PermissionsBoundary
         - !Ref AWS::NoValue
 
-  NinoAttemptsTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      TableName: !Sub ${AWS::StackName}-nino-attempts
-      BillingMode: PAY_PER_REQUEST
-      AttributeDefinitions:
-        - AttributeName: id
-          AttributeType: S
-      KeySchema:
-        - AttributeName: id
-          KeyType: HASH
-
   UserAttemptsTable:
     Type: AWS::DynamoDB::Table
     Properties:

--- a/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
@@ -26,7 +26,7 @@ describe("nino-check-happy", () => {
 
   let output: Partial<{
     CommonStackName: string;
-    NinoAttemptsTable: string;
+    UserAttemptsTable: string;
     NinoUsersTable: string;
     NinoCheckStateMachineArn: string;
   }>;
@@ -84,7 +84,7 @@ describe("nino-check-happy", () => {
         items: { sessionId: input.sessionId },
       }
     );
-    await clearAttemptsTable(input.sessionId, output.NinoAttemptsTable);
+    await clearAttemptsTable(input.sessionId, output.UserAttemptsTable);
   });
 
   it("should execute nino step function 1st attempt", async () => {

--- a/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
@@ -31,7 +31,7 @@ const testUser = {
 
 let output: Partial<{
   CommonStackName: string;
-  NinoAttemptsTable: string;
+  UserAttemptsTable: string;
   NinoUsersTable: string;
   NinoCheckStateMachineArn: string;
 }>;
@@ -92,16 +92,16 @@ afterEach(async () => {
       items: { sessionId: input.sessionId },
     }
   );
-  await clearAttemptsTable(input.sessionId, output.NinoAttemptsTable);
+  await clearAttemptsTable(input.sessionId, output.UserAttemptsTable);
 });
 
 it("should fail when there is more than 2 nino check attempts", async () => {
-  await populateTable(output.NinoAttemptsTable as string, {
+  await populateTable(output.UserAttemptsTable as string, {
     sessionId: input.sessionId,
     timestamp: Date.now().toString(),
   });
 
-  await populateTable(output.NinoAttemptsTable as string, {
+  await populateTable(output.UserAttemptsTable as string, {
     sessionId: input.sessionId,
     timestamp: Date.now().toString(),
   });

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
@@ -70,7 +70,7 @@ describe("nino-issue-credential-happy", () => {
 
   let output: Partial<{
     CommonStackName: string;
-    NinoAttemptsTable: string;
+    UserAttemptsTable: string;
     NinoUsersTable: string;
     NinoIssueCredentialStateMachineArn: string;
   }>;
@@ -122,7 +122,7 @@ describe("nino-issue-credential-happy", () => {
         },
       },
       {
-        tableName: output.NinoAttemptsTable as string,
+        tableName: output.UserAttemptsTable as string,
         items: {
           sessionId: input.sessionId,
           timestamp: Date.now().toString(),
@@ -148,7 +148,7 @@ describe("nino-issue-credential-happy", () => {
         items: { sessionId: input.sessionId },
       }
     );
-    await clearAttemptsTable(input.sessionId, output.NinoAttemptsTable);
+    await clearAttemptsTable(input.sessionId, output.UserAttemptsTable);
   });
 
   it("should create signed JWT when nino check is successful", async () => {

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
@@ -26,7 +26,7 @@ describe("nino-issue-credential-unhappy", () => {
 
   let output: Partial<{
     CommonStackName: string;
-    NinoAttemptsTable: string;
+    UserAttemptsTable: string;
     NinoUsersTable: string;
     NinoIssueCredentialStateMachineArn: string;
   }>;
@@ -78,7 +78,7 @@ describe("nino-issue-credential-unhappy", () => {
         },
       },
       {
-        tableName: output.NinoAttemptsTable as string,
+        tableName: output.UserAttemptsTable as string,
         items: {
           sessionId: input.sessionId,
           timestamp: Date.now().toString(),
@@ -104,7 +104,7 @@ describe("nino-issue-credential-unhappy", () => {
         items: { sessionId: input.sessionId },
       }
     );
-    await clearAttemptsTable(input.sessionId, output.NinoAttemptsTable);
+    await clearAttemptsTable(input.sessionId, output.UserAttemptsTable);
   });
 
   it("should fail when nino check is unsuccessful", async () => {

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -40,7 +40,7 @@
       "Type": "Task",
       "Next": "User has attempts?",
       "Parameters": {
-        "TableName": "${NinoAttemptsTable}",
+        "TableName": "${UserAttemptsTable}",
         "KeyConditionExpression": "sessionId = :value",
         "ExpressionAttributeValues": {
           ":value": {
@@ -226,7 +226,7 @@
       "Type": "Task",
       "Resource": "arn:aws:states:::dynamodb:putItem",
       "Parameters": {
-        "TableName": "${NinoAttemptsTable}",
+        "TableName": "${UserAttemptsTable}",
         "Item": {
           "sessionId": {
             "S.$": "$$.Execution.Input.sessionId"
@@ -273,7 +273,7 @@
       "Type": "Task",
       "Resource": "arn:aws:states:::dynamodb:putItem",
       "Parameters": {
-        "TableName": "${NinoAttemptsTable}",
+        "TableName": "${UserAttemptsTable}",
         "Item": {
           "sessionId": {
             "S.$": "$$.Execution.Input.sessionId"

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -219,7 +219,7 @@
               "Type": "Task",
               "Next": "Add Type to VC",
               "Parameters": {
-                "TableName": "${NinoAttemptsTable}",
+                "TableName": "${UserAttemptsTable}",
                 "KeyConditionExpression": "sessionId = :value",
                 "ExpressionAttributeValues": {
                   ":value": {


### PR DESCRIPTION
## Proposed changes
Removed NinoAttemptsTable from CF and updated tests to use the new UserAttemptsTable

### Why did it change
It was renamed to UserAttemptsTable
