### PR TITLE
OJ-2156: Respond with correct status codes

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -142,20 +142,15 @@ paths:
             statusCode: 200
             responseTemplates:
               application/json: |
-                #set($resp = $util.parseJson($input.body))
-                #set($params = $util.parseJson($resp.output))
-                #foreach($paramName in $params.keySet())
-                #if($paramName == 'error')
-                #set($err = true)
-                #end
-                #end
-                #if($err == true)
-                #set($context.responseOverride.status = 400)
-                #elseif($resp.status == "FAILED")
+                #set($response = $util.parseJson($input.body))
+                #set($output = $util.parseJson($response.output))
+                #if($response.status == "FAILED")
                 #set($context.responseOverride.status = 500)
-                $resp.cause
+                #elseif($output.httpStatus)
+                #set($context.responseOverride.status = $output.httpStatus)
+                #else
+                #set($context.responseOverride.status = 200)
                 #end
-                $resp.output
 
 components:
   parameters:

--- a/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
@@ -93,7 +93,7 @@ describe("nino-check-happy", () => {
       input
     );
 
-    expect(startExecutionResult.output).toBe("{}");
+    expect(startExecutionResult.output).toBe('{"httpStatus":200}');
   });
 
   it("should execute nino step function 2nd attempt", async () => {
@@ -110,8 +110,8 @@ describe("nino-check-happy", () => {
       input
     );
 
-    expect(firstExecutionResult.output).toBe('{"httpStatus":"424"}');
+    expect(firstExecutionResult.output).toBe('{"httpStatus":422}');
 
-    expect(secondExecutionResult.output).toBe("{}");
+    expect(secondExecutionResult.output).toBe('{"httpStatus":200}');
   });
 });

--- a/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
@@ -15,192 +15,190 @@ import { SecretsManager } from "@aws-sdk/client-secrets-manager";
 
 jest.setTimeout(30_000);
 
-const secretsManager = new SecretsManager();
+describe("nino-check-unhappy", () => {
+  const secretsManager = new SecretsManager();
 
-const input = {
-  sessionId: "check-unhappy",
-  nino: "AB123003C",
-};
+  const input = {
+    sessionId: "check-unhappy",
+    nino: "AB123003C",
+  };
 
-const testUser = {
-  nino: "AB123003C",
-  dob: "1948-04-23",
-  firstName: "Jim",
-  lastName: "Ferguson",
-};
+  const testUser = {
+    nino: "AB123003C",
+    dob: "1948-04-23",
+    firstName: "Jim",
+    lastName: "Ferguson",
+  };
 
-let output: Partial<{
-  CommonStackName: string;
-  UserAttemptsTable: string;
-  NinoUsersTable: string;
-  NinoCheckStateMachineArn: string;
-}>;
+  let output: Partial<{
+    CommonStackName: string;
+    UserAttemptsTable: string;
+    NinoUsersTable: string;
+    NinoCheckStateMachineArn: string;
+  }>;
 
-let sessionTableName: string;
-let personIdentityTableName: string;
+  let sessionTableName: string;
+  let personIdentityTableName: string;
 
-beforeEach(async () => {
-  output = await stackOutputs(process.env.STACK_NAME);
-  sessionTableName = `session-${output.CommonStackName}`;
-  personIdentityTableName = `person-identity-${output.CommonStackName}`;
+  beforeEach(async () => {
+    output = await stackOutputs(process.env.STACK_NAME);
+    sessionTableName = `session-${output.CommonStackName}`;
+    personIdentityTableName = `person-identity-${output.CommonStackName}`;
 
-  await populateTables(
-    {
-      tableName: sessionTableName,
-      items: {
-        sessionId: input.sessionId,
-        expiryDate: 9999999999,
+    await populateTables(
+      {
+        tableName: sessionTableName,
+        items: {
+          sessionId: input.sessionId,
+          expiryDate: 9999999999,
+        },
       },
-    },
-    {
-      tableName: personIdentityTableName,
-      items: {
-        sessionId: input.sessionId,
-        nino: input.nino,
-        birthDates: [{ value: testUser.dob }],
-        names: [
-          {
-            nameParts: [
-              {
-                type: "GivenName",
-                value: testUser.firstName,
-              },
-              {
-                type: "FamilyName",
-                value: testUser.lastName,
-              },
-            ],
-          },
-        ],
+      {
+        tableName: personIdentityTableName,
+        items: {
+          sessionId: input.sessionId,
+          nino: input.nino,
+          birthDates: [{ value: testUser.dob }],
+          names: [
+            {
+              nameParts: [
+                {
+                  type: "GivenName",
+                  value: testUser.firstName,
+                },
+                {
+                  type: "FamilyName",
+                  value: testUser.lastName,
+                },
+              ],
+            },
+          ],
+        },
+      }
+    );
+  });
+
+  afterEach(async () => {
+    await clearItemsFromTables(
+      {
+        tableName: sessionTableName,
+        items: { sessionId: input.sessionId },
       },
-    }
-  );
-});
-
-afterEach(async () => {
-  await clearItemsFromTables(
-    {
-      tableName: sessionTableName,
-      items: { sessionId: input.sessionId },
-    },
-    {
-      tableName: personIdentityTableName,
-      items: { sessionId: input.sessionId },
-    },
-    {
-      tableName: output.NinoUsersTable as string,
-      items: { sessionId: input.sessionId },
-    }
-  );
-  await clearAttemptsTable(input.sessionId, output.UserAttemptsTable);
-});
-
-it("should fail when there is more than 2 nino check attempts", async () => {
-  await populateTable(output.UserAttemptsTable as string, {
-    sessionId: input.sessionId,
-    timestamp: Date.now().toString(),
+      {
+        tableName: personIdentityTableName,
+        items: { sessionId: input.sessionId },
+      },
+      {
+        tableName: output.NinoUsersTable as string,
+        items: { sessionId: input.sessionId },
+      }
+    );
+    await clearAttemptsTable(input.sessionId, output.UserAttemptsTable);
   });
 
-  await populateTable(output.UserAttemptsTable as string, {
-    sessionId: input.sessionId,
-    timestamp: Date.now().toString(),
-  });
+  it("should fail when there is more than 2 nino check attempts", async () => {
+    await populateTable(output.UserAttemptsTable as string, {
+      sessionId: input.sessionId,
+      timestamp: Date.now().toString(),
+    });
 
-  const startExecutionResult = await executeStepFunction(
-    output.NinoCheckStateMachineArn as string,
-    input
-  );
+    await populateTable(output.UserAttemptsTable as string, {
+      sessionId: input.sessionId,
+      timestamp: Date.now().toString(),
+    });
 
-  expect(startExecutionResult.output).toBe(
-    '{"error":"Maximum number of attempts exceeded"}'
-  );
-});
-
-it("should fail when there is no user present for given nino", async () => {
-  await clearItems(personIdentityTableName, {
-    sessionId: input.sessionId,
-  });
-
-  const startExecutionResult = await executeStepFunction(
-    output.NinoCheckStateMachineArn as string,
-    input
-  );
-
-  expect(startExecutionResult.output).toBe(
-    '{"error":"No user found for given nino"}'
-  );
-});
-
-it("should fail when session id is invalid", async () => {
-  await clearItems(sessionTableName, {
-    sessionId: input.sessionId,
-  });
-
-  const startExecutionResult = await executeStepFunction(
-    output.NinoCheckStateMachineArn as string,
-    input
-  );
-
-  expect(startExecutionResult.output).toBe(
-    '{"error":"Session is not valid or has expired"}'
-  );
-
-  expect(startExecutionResult.status).toBe("SUCCEEDED");
-});
-
-it("should fail when user NINO does not match with HMRC DB", async () => {
-  const startExecutionResult = await executeStepFunction(
-    output.NinoCheckStateMachineArn as string,
-    input
-  );
-
-  expect(startExecutionResult.output).toBe('{"httpStatus":"424"}');
-});
-
-describe("NINO check URL is unavailable", () => {
-  const urlParameterName = `/${process.env.STACK_NAME}/NinoCheckUrl`;
-  let currentURL: string;
-
-  beforeAll(async () => {
-    currentURL = (await getSSMParameter(urlParameterName)) as string;
-    await updateSSMParameter(urlParameterName, "bad-url");
-  });
-
-  afterAll(async () => await updateSSMParameter(urlParameterName, currentURL));
-
-  it("should throw an error when URL is unavailable", async () => {
     const startExecutionResult = await executeStepFunction(
       output.NinoCheckStateMachineArn as string,
       input
     );
 
-    expect(startExecutionResult.status).toEqual("FAILED");
+    expect(startExecutionResult.output).toBe('{"httpStatus":200}');
   });
-});
 
-describe("HMRC bearer token is invalid", () => {
-  beforeAll(
-    async () =>
-      await secretsManager.updateSecret({
-        SecretId: "HMRCBearerToken",
-        SecretString: "badToken",
-      })
-  );
+  it("should fail when there is no user present for given nino", async () => {
+    await clearItems(personIdentityTableName, {
+      sessionId: input.sessionId,
+    });
 
-  afterAll(
-    async () =>
-      await secretsManager.updateSecret({
-        SecretId: "HMRCBearerToken",
-        SecretString: "goodToken",
-      })
-  );
-
-  it("should throw an error when token is invalid", async () => {
     const startExecutionResult = await executeStepFunction(
       output.NinoCheckStateMachineArn as string,
       input
     );
 
-    expect(startExecutionResult.status).toEqual("FAILED");
+    expect(startExecutionResult.output).toBe('{"httpStatus":500}');
+  });
+
+  it("should fail when session id is invalid", async () => {
+    await clearItems(sessionTableName, {
+      sessionId: input.sessionId,
+    });
+
+    const startExecutionResult = await executeStepFunction(
+      output.NinoCheckStateMachineArn as string,
+      input
+    );
+
+    expect(startExecutionResult.output).toBe('{"httpStatus":400}');
+
+    expect(startExecutionResult.status).toBe("SUCCEEDED");
+  });
+
+  it("should fail when user NINO does not match with HMRC DB", async () => {
+    const startExecutionResult = await executeStepFunction(
+      output.NinoCheckStateMachineArn as string,
+      input
+    );
+
+    expect(startExecutionResult.output).toBe('{"httpStatus":422}');
+  });
+
+  describe("NINO check URL is unavailable", () => {
+    const urlParameterName = `/${process.env.STACK_NAME}/NinoCheckUrl`;
+    let currentURL: string;
+
+    beforeAll(async () => {
+      currentURL = (await getSSMParameter(urlParameterName)) as string;
+      await updateSSMParameter(urlParameterName, "bad-url");
+    });
+
+    afterAll(
+      async () => await updateSSMParameter(urlParameterName, currentURL)
+    );
+
+    it("should throw an error when URL is unavailable", async () => {
+      const startExecutionResult = await executeStepFunction(
+        output.NinoCheckStateMachineArn as string,
+        input
+      );
+
+      expect(startExecutionResult.status).toEqual("FAILED");
+    });
+  });
+
+  describe("HMRC bearer token is invalid", () => {
+    beforeAll(
+      async () =>
+        await secretsManager.updateSecret({
+          SecretId: "HMRCBearerToken",
+          SecretString: "badToken",
+        })
+    );
+
+    afterAll(
+      async () =>
+        await secretsManager.updateSecret({
+          SecretId: "HMRCBearerToken",
+          SecretString: "goodToken",
+        })
+    );
+
+    it("should throw an error when token is invalid", async () => {
+      const startExecutionResult = await executeStepFunction(
+        output.NinoCheckStateMachineArn as string,
+        input
+      );
+
+      expect(startExecutionResult.status).toEqual("FAILED");
+    });
   });
 });

--- a/integration-tests/tests/mocked/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/mocked/nino-check/nino-check-happy.test.ts
@@ -34,7 +34,7 @@ describe("nino-check-happy", () => {
       responseStepFunction
     );
     expect(results[0].stateExitedEventDetails?.output).toEqual(
-      '{"httpStatus": 200}'
+      '{"httpStatus":200}'
     );
   });
 });

--- a/integration-tests/tests/mocked/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/mocked/nino-check/nino-check-happy.test.ts
@@ -33,6 +33,8 @@ describe("nino-check-happy", () => {
         event?.stateExitedEventDetails?.name === "Nino check successful",
       responseStepFunction
     );
-    expect(results[0].stateExitedEventDetails?.output).toEqual("{}");
+    expect(results[0].stateExitedEventDetails?.output).toEqual(
+      '{"httpStatus": 200}'
+    );
   });
 });

--- a/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
@@ -50,7 +50,7 @@ describe("nino-check-unhappy", () => {
       responseStepFunction
     );
     expect(results[0].stateExitedEventDetails?.output).toEqual(
-      '{"error":"Maximum number of attempts exceeded"}'
+      '{"httpStatus": 200}'
     );
   });
 
@@ -71,7 +71,7 @@ describe("nino-check-unhappy", () => {
       responseStepFunction
     );
     expect(results[0].stateExitedEventDetails?.output).toEqual(
-      '{"error":"No user found for given nino"}'
+      '{"httpStatus": 500}'
     );
   });
 

--- a/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
@@ -30,7 +30,7 @@ describe("nino-check-unhappy", () => {
       responseStepFunction
     );
     expect(results[0].executionSucceededEventDetails?.output).toEqual(
-      '{"error":"Session is not valid or has expired"}'
+      '{"httpStatus":400}'
     );
   });
 
@@ -50,7 +50,7 @@ describe("nino-check-unhappy", () => {
       responseStepFunction
     );
     expect(results[0].stateExitedEventDetails?.output).toEqual(
-      '{"httpStatus": 200}'
+      '{"httpStatus":200}'
     );
   });
 
@@ -71,7 +71,7 @@ describe("nino-check-unhappy", () => {
       responseStepFunction
     );
     expect(results[0].stateExitedEventDetails?.output).toEqual(
-      '{"httpStatus": 500}'
+      '{"httpStatus":500}'
     );
   });
 
@@ -105,9 +105,7 @@ describe("nino-check-unhappy", () => {
       (event: HistoryEvent) => event?.type === "ExecutionFailed",
       responseStepFunction
     );
-    expect(results[0].executionFailedEventDetails?.cause).toEqual(
-      "Invalid Authentication information provided"
-    );
+    expect(results[0].executionFailedEventDetails?.cause).toBe(undefined);
   });
 
   it("should fail when user nino does not match with HMRC DB", async () => {
@@ -125,7 +123,7 @@ describe("nino-check-unhappy", () => {
       responseStepFunction
     );
     expect(results[0].executionSucceededEventDetails?.output).toEqual(
-      '{"httpStatus":"424"}'
+      '{"httpStatus":422}'
     );
   });
 });

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -33,7 +33,7 @@
       "Type": "Pass",
       "End": true,
       "Parameters": {
-        "error": "Session is not valid or has expired"
+        "httpStatus": 400
       }
     },
     "Query User Attempts": {
@@ -77,7 +77,7 @@
       "Type": "Pass",
       "End": true,
       "Parameters": {
-        "error": "Maximum number of attempts exceeded"
+        "httpStatus": 200
       }
     },
     "Person Identity Table Name": {
@@ -154,11 +154,8 @@
     "Err: No user found in Person Identity": {
       "Type": "Pass",
       "End": true,
-      "Result": {
-        "error": "No user found for given nino"
-      },
       "Parameters": {
-        "error": "No user for given nino found"
+        "httpStatus": 500
       }
     },
     "Get OAuth Token": {
@@ -298,7 +295,7 @@
       "Type": "Pass",
       "End": true,
       "Parameters": {
-        "httpStatus": "424"
+        "httpStatus": 422
       }
     },
     "Fetch Auth Code Expiry": {
@@ -369,18 +366,18 @@
     "Response Filtering": {
       "Type": "Pass",
       "Next": "Nino check successful",
-      "Parameters": {}
+      "Parameters": {
+        "httpStatus": 200
+      }
     },
     "Nino check successful": {
       "Type": "Succeed"
     },
     "Err: API Error": {
-      "Type": "Fail",
-      "CausePath": "$.hmrc_response.payload"
+      "Type": "Fail"
     },
     "Err: Failed Auth": {
-      "Type": "Fail",
-      "CausePath": "$.hmrc_response.payload.body.message"
+      "Type": "Fail"
     }
   }
 }


### PR DESCRIPTION
## Proposed changes

### What changed
State machine has been changed to respond with specified `httpStatus` codes.
VTL in the private-api has been updated to use the `httpStatus` output of the state machine
Tests have been updated to reflect these changes

### Issue tracking
- [OJ-2156](https://govukverify.atlassian.net/browse/OJ-2156)


[OJ-2156]: https://govukverify.atlassian.net/browse/OJ-2156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ