### PR TITLE
OJ-2113: Updated state machine to use CI from mapping

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -489,6 +489,7 @@ Resources:
       Name: !Sub ${AWS::StackName}-NinoIssueCredential
       DefinitionUri: ../step-functions/nino_issue_credential.asl.json
       DefinitionSubstitutions:
+        CiMappingFunctionArn: !GetAtt CiMappingFunction.Arn
         TimeFunctionArn: !GetAtt TimeFunction.Arn
         CredentialSubjectFunctionArn: !GetAtt CredentialSubjectFunction.Arn
         UserAttemptsTable: !Ref UserAttemptsTable
@@ -504,6 +505,8 @@ Resources:
         IncludeExecutionData: True
         Level: ALL
       Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref CiMappingFunction
         - LambdaInvokePolicy:
             FunctionName: !Ref TimeFunction
         - LambdaInvokePolicy:

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
@@ -82,8 +82,17 @@ describe("nino-issue-credential-unhappy", () => {
         items: {
           sessionId: input.sessionId,
           timestamp: Date.now().toString(),
-          attempts: 2,
-          outcome: "FAIL",
+          attempt: "FAIL",
+          text: "DOB does not match CID",
+        },
+      },
+      {
+        tableName: output.UserAttemptsTable as string,
+        items: {
+          sessionId: input.sessionId,
+          timestamp: (Date.now() + 1).toString(),
+          attempt: "FAIL",
+          text: "DOB does not match CID",
         },
       }
     );
@@ -133,7 +142,7 @@ describe("nino-issue-credential-unhappy", () => {
     expect(evidence.strengthScore).toBe(2);
     expect(evidence.validityScore).toBe(0);
     expect(evidence.failedCheckDetails[0].checkMethod).toBe("data");
-    expect(evidence.ci[0]).toBe("D02");
+    expect(evidence.ci[0]).toBeDefined();
     expect(evidence.txn).not.toBeNull;
 
     const credentialSubject = payload.vc.credentialSubject;

--- a/lambdas/ci-mapping/src/ci-mapping-event-validator.ts
+++ b/lambdas/ci-mapping/src/ci-mapping-event-validator.ts
@@ -1,0 +1,48 @@
+import {
+  allMappedHmrcErrors,
+  flattenCommaSepInput,
+  isCiHmrcErrorsMappingValid,
+} from "./utils/ci-mapping-util";
+
+export const HMRC_ERRORS_ABSENT = "Hmrc errors absent in CiMappingEvent";
+export interface CiMappingEvent {
+  ci_mapping: string[];
+  hmrc_errors: string[];
+}
+
+export const validateInputs = (event: CiMappingEvent) => {
+  const ci_mappings = getCiMapping(event?.ci_mapping);
+  const hmrc_errors = getInputHmrcErrors(event.hmrc_errors);
+
+  const hmrcErrorIsNotMapped = (hmrcError: string) =>
+    !allMappedHmrcErrors(ci_mappings).includes(hmrcError);
+
+  const allHmrcErrorsUnMatched = hmrc_errors.every(hmrcErrorIsNotMapped);
+  const someHmrcErrorsUnMatched = hmrc_errors.some(hmrcErrorIsNotMapped);
+
+  if (!isCiHmrcErrorsMappingValid(ci_mappings)) {
+    throw new Error("ci_mapping format is invalid");
+  } else if (allHmrcErrorsUnMatched) {
+    throw new Error("No matching hmrc_error for any ci_mapping");
+  } else if (someHmrcErrorsUnMatched) {
+    throw new Error("Not all items in hmrc_errors have matching ci_mapping");
+  }
+
+  return { ci_mappings, hmrc_errors };
+};
+
+const getCiMapping = (ci_mapping?: string[]) => {
+  if (ci_mapping && ci_mapping.length > 0) {
+    return ci_mapping;
+  }
+  throw new Error("ci_mapping cannot be undefined in CiMappingEvent");
+};
+
+const getInputHmrcErrors = (hmrc_errors: string[] = []) => {
+  if (hmrc_errors.length === 0) {
+    throw new Error(HMRC_ERRORS_ABSENT);
+  }
+  return hmrc_errors.reduce((result, hmrc_error) => {
+    return result.concat(flattenCommaSepInput(hmrc_error));
+  }, [] as string[]);
+};

--- a/lambdas/ci-mapping/src/ci-mapping-event.ts
+++ b/lambdas/ci-mapping/src/ci-mapping-event.ts
@@ -1,4 +1,4 @@
 export interface CiMappingEvent {
-  ci_mapping: string;
-  hmrc_errors: string;
+  ci_mapping: string[];
+  hmrc_errors: string[];
 }

--- a/lambdas/ci-mapping/src/ci-mapping-event.ts
+++ b/lambdas/ci-mapping/src/ci-mapping-event.ts
@@ -1,4 +1,0 @@
-export interface CiMappingEvent {
-  ci_mapping: string[];
-  hmrc_errors: string[];
-}

--- a/lambdas/ci-mapping/src/ci-mapping-handler.ts
+++ b/lambdas/ci-mapping/src/ci-mapping-handler.ts
@@ -25,7 +25,9 @@ function getCIsForHmrcErrors(event: CiMappingEvent): Array<string> {
       event.ci_mapping.flatMap((ci) => {
         const [ciKey, ciValue] = ci.split(":");
         return event.hmrc_errors
-          .flatMap((error) => error.split(",").map((e) => e.trim()))
+          .flatMap((hmrc_error) =>
+            hmrc_error.split(",").map((hmrc_error) => hmrc_error.trim())
+          )
           .filter((hmrcError) => ciKey.includes(hmrcError))
           .map(() => ciValue);
       })

--- a/lambdas/ci-mapping/src/ci-mapping-handler.ts
+++ b/lambdas/ci-mapping/src/ci-mapping-handler.ts
@@ -20,13 +20,12 @@ export class CiMappingHandler implements LambdaInterface {
 }
 
 function getCIsForHmrcErrors(event: CiMappingEvent): Array<string> {
-  const hmrcErrors = event.hmrc_errors.split(",");
-  const ciMappings = event.ci_mapping.split("||");
   return Array.from(
     new Set(
-      ciMappings.flatMap((ci) => {
+      event.ci_mapping.flatMap((ci) => {
         const [ciKey, ciValue] = ci.split(":");
-        return hmrcErrors
+        return event.hmrc_errors
+          .flatMap((error) => error.split(",").map((e) => e.trim()))
           .filter((hmrcError) => ciKey.includes(hmrcError))
           .map(() => ciValue);
       })

--- a/lambdas/ci-mapping/src/utils/ci-mapping-util.ts
+++ b/lambdas/ci-mapping/src/utils/ci-mapping-util.ts
@@ -1,0 +1,31 @@
+export type HmrcErrsCiRecord = Record<"mappedHmrcErrors" | "ciValue", string>;
+
+export const deduplicateValues = (values: string[]): string[] =>
+  Array.from(new Set(values));
+
+export const getHmrcErrsCiRecord = (pair: string): HmrcErrsCiRecord => {
+  const [key, value] = pair.split(":");
+  return {
+    mappedHmrcErrors: key,
+    ciValue: value,
+  };
+};
+export const allMappedHmrcErrors = (mappings: string[]) =>
+  mappings
+    .map((mapping) => getHmrcErrsCiRecord(mapping).mappedHmrcErrors)
+    .join(",");
+
+export const isCiHmrcErrorsMappingValid = (mappings: string[]) =>
+  mappings.every((mapping) => {
+    const record = getHmrcErrsCiRecord(mapping);
+    return (
+      record.mappedHmrcErrors !== "" &&
+      record.ciValue !== undefined &&
+      record.ciValue.trim() !== ""
+    );
+  });
+
+export const flattenCommaSepInput = (CommaSepInput: string) =>
+  CommaSepInput.split(",").flatMap((comma_sep_string) =>
+    comma_sep_string.split(",").map((value) => value.trim())
+  );

--- a/lambdas/ci-mapping/tests/ci-mapping-event-validator.test.ts
+++ b/lambdas/ci-mapping/tests/ci-mapping-event-validator.test.ts
@@ -1,0 +1,117 @@
+import {
+  CiMappingEvent,
+  validateInputs,
+} from "../src/ci-mapping-event-validator";
+
+describe("ci-mapping-event-validator", () => {
+  describe("validateInputs", () => {
+    const ci_mapping = [
+      "aaaa:ci_1",
+      "bbbb,cccc,dddd:ci_2",
+      "eeee,ffff,gggg:ci_3",
+    ];
+    it("should return successfully when CiMappingEvent is valid", () => {
+      expect(
+        validateInputs({
+          ci_mapping,
+          hmrc_errors: ["aaaa"],
+        })
+      ).toEqual({
+        ci_mappings: ci_mapping,
+        hmrc_errors: ["aaaa"],
+      });
+    });
+
+    it("throws error, no matching hmrc_error for any ci_mapping", () => {
+      expect(() =>
+        validateInputs({
+          ci_mapping,
+          hmrc_errors: ["not-a-mapped-error"],
+        })
+      ).toThrow("No matching hmrc_error for any ci_mapping");
+    });
+
+    it("throws an error, not all items in hmrc_errors have matching ci_mapping", () => {
+      expect(() =>
+        validateInputs({
+          ci_mapping,
+          hmrc_errors: ["aaaa", "not-a-mapped-error"],
+        })
+      ).toThrow("Not all items in hmrc_errors have matching ci_mapping");
+    });
+
+    describe("CiMappingEvent has an empty, blank or undefined component", () => {
+      it("throws error, ci_mapping cannot be undefined given CiMappingEvent is an empty object", () => {
+        expect(() => validateInputs({} as CiMappingEvent)).toThrow(
+          "ci_mapping cannot be undefined"
+        );
+      });
+
+      it("throws ci_mapping cannot be undefined, given both ci_mapping and hmrc errors array are empty", () => {
+        expect(() =>
+          validateInputs({
+            ci_mapping: [],
+            hmrc_errors: [],
+          })
+        ).toThrow("ci_mapping cannot be undefined");
+      });
+
+      it.each([undefined, [], ""])(
+        "throws hmrc errors absent in CiMappingEvent given only hmrc errors array is %s and a valid ci_mapping",
+        (actual) => {
+          expect(() =>
+            validateInputs({
+              ci_mapping,
+              hmrc_errors: actual as unknown as string[],
+            })
+          ).toThrow("Hmrc errors absent in CiMappingEvent");
+        }
+      );
+
+      it.each([undefined, [], ""])(
+        "throws ci_mapping cannot be undefined, given valid hmrc error and ci_mapping is %s",
+        (actual) => {
+          expect(() =>
+            validateInputs({
+              ci_mapping: actual as unknown as string[],
+              hmrc_errors: ["aaaa"],
+            })
+          ).toThrow("ci_mapping cannot be undefined");
+        }
+      );
+    });
+
+    describe("Given ci_mapping format is invalid", () => {
+      it("throws error when ci entries that are colon separated are without hmrc error key but with a CI value", async () => {
+        expect(() =>
+          validateInputs({
+            ci_mapping: [":Ci_1"],
+            hmrc_errors: [""],
+          })
+        ).toThrow("ci_mapping format is invalid");
+      });
+
+      it("throws error with ci entries that are colon separated with a hmrc error key but without a CI value", async () => {
+        expect(() =>
+          validateInputs({
+            ci_mapping: ["err1:"],
+            hmrc_errors: [""],
+          })
+        ).toThrow("ci_mapping format is invalid");
+      });
+
+      it("throws error given ci entries that are not colon separated", async () => {
+        expect(() =>
+          validateInputs({
+            ci_mapping: [
+              "aaaa,ci_1",
+              "bbbb,cccc,dddd;ci_2",
+              "eeee,ffff,gggg/ci_3",
+            ],
+            hmrc_errors: ["aaaa"],
+          })
+        ).toThrow("ci_mapping format is invalid");
+      });
+    });
+  });
+});

--- a/lambdas/ci-mapping/tests/ci-mapping-handler.test.ts
+++ b/lambdas/ci-mapping/tests/ci-mapping-handler.test.ts
@@ -1,6 +1,6 @@
 import { CiMappingHandler } from "../src/ci-mapping-handler";
 import { Context } from "aws-lambda";
-import { CiMappingEvent } from "../src/ci-mapping-event";
+import { CiMappingEvent } from "../src/ci-mapping-event-validator";
 
 const testCiMapping = [
   "aaaa:ci_1",
@@ -22,7 +22,7 @@ describe("ci-mapping-handler", () => {
   });
 
   it.each([[["bbbb"], [["cccc"]]]])(
-    "should not return ci_2 for input '%s'",
+    "should return ci_2 for input '%s'",
     async (input) => {
       const event = {
         ci_mapping: testCiMapping,
@@ -54,7 +54,7 @@ describe("ci-mapping-handler", () => {
   it("should return multiple CIs when input contains different groups", async () => {
     const event = {
       ci_mapping: testCiMapping,
-      hmrc_errors: ["aaaa,gggg"],
+      hmrc_errors: ["gggg,aaaa,gggg"],
     } as CiMappingEvent;
     const ciMappingHandler = new CiMappingHandler();
 
@@ -63,10 +63,36 @@ describe("ci-mapping-handler", () => {
     expect(result).toEqual(["ci_1", "ci_3"]);
   });
 
+  it("should return multiple CIs when input contains different groups with spaces around hmrc errors", async () => {
+    const event = {
+      ci_mapping: testCiMapping,
+      hmrc_errors: [" aaaa , gggg "],
+    } as CiMappingEvent;
+    const ciMappingHandler = new CiMappingHandler();
+
+    const result = await ciMappingHandler.handler(event, {} as Context);
+
+    expect(result).toEqual(["ci_1", "ci_3"]);
+  });
+
+  it("should return multiple CIs when input contains different groups with spaces CI mapping components", async () => {
+    const event = {
+      ci_mapping: [
+        " aaaa:ci_1",
+        "bbbb,cccc,dddd: ci_2",
+        " eeee , ffff , gggg : ci_3 ",
+      ],
+      hmrc_errors: ["aaaa ,gggg"],
+    } as CiMappingEvent;
+    const ciMappingHandler = new CiMappingHandler();
+
+    const result = await ciMappingHandler.handler(event, {} as Context);
+
+    expect(result).toEqual(["ci_1", "ci_3"]);
+  });
   it("should not produce a CI if there are no hmrc_errors", async () => {
     const event = {
       ci_mapping: testCiMapping,
-      hmrc_errors: [],
     } as CiMappingEvent;
     const ciMappingHandler = new CiMappingHandler();
 
@@ -75,7 +101,7 @@ describe("ci-mapping-handler", () => {
     expect(result).toEqual([]);
   });
 
-  it("should throw an error when no matching hmrc_error for any ci_mapping", async () => {
+  it("throws error, no matching hmrc_error for any ci_mapping", async () => {
     const event = {
       ci_mapping: testCiMapping,
       hmrc_errors: ["not-a-mapped-error"],
@@ -84,20 +110,67 @@ describe("ci-mapping-handler", () => {
 
     await expect(
       ciMappingHandler.handler(event, {} as Context)
-    ).rejects.toThrowError("No matching hmrc_error for any ci_mapping");
+    ).rejects.toThrow("No matching hmrc_error for any ci_mapping");
   });
 
-  it("should throw an error when not all items in hmrc_errors have matching ci_mapping", async () => {
+  it("throws error, not all items in hmrc_errors have matching ci_mapping", async () => {
     const event = {
       ci_mapping: testCiMapping,
-      hmrc_errors: ["not-a-mapped-error", "aaaa"],
+      hmrc_errors: ["aaaa", "not-a-mapped-error"],
     } as CiMappingEvent;
     const ciMappingHandler = new CiMappingHandler();
 
     await expect(
       ciMappingHandler.handler(event, {} as Context)
-    ).rejects.toThrowError(
-      "Not all items in hmrc_errors have matching ci_mapping"
+    ).rejects.toThrow("Not all items in hmrc_errors have matching ci_mapping");
+  });
+  describe("Given CI mapping format is Invalid", () => {
+    it("throws error when entries that are colon separated with hmrc error key and without matching ci value", async () => {
+      const event = {
+        ci_mapping: ["aaaa:"],
+        hmrc_errors: ["aaaa"],
+      } as CiMappingEvent;
+      const ciMappingHandler = new CiMappingHandler();
+
+      await expect(
+        ciMappingHandler.handler(event, {} as Context)
+      ).rejects.toThrow("ci_mapping format is invalid");
+    });
+    it("throws error with ci entries that are colon separated and has a CI value without hmrc error key", async () => {
+      const event = {
+        ci_mapping: [":Ci_1"],
+        hmrc_errors: [""],
+      } as CiMappingEvent;
+      const ciMappingHandler = new CiMappingHandler();
+
+      await expect(
+        ciMappingHandler.handler(event, {} as Context)
+      ).rejects.toThrow("ci_mapping format is invalid");
+    });
+    it("throws error for ci entries containing anything other than colon separators", async () => {
+      const event = {
+        ci_mapping: ["aaaa,ci_1", "bbbb,cccc,dddd;ci_2", "eeee,ffff,gggg/ci_3"],
+        hmrc_errors: ["aaaa"],
+      } as CiMappingEvent;
+      const ciMappingHandler = new CiMappingHandler();
+
+      await expect(
+        ciMappingHandler.handler(event, {} as Context)
+      ).rejects.toThrow("ci_mapping format is invalid");
+    });
+    it.each([undefined, "", []])(
+      "throws error, ci mapping is undefined, given %s as input",
+      async (actual) => {
+        const event = {
+          ci_mapping: actual,
+          hmrc_errors: ["aaaa"],
+        } as unknown as CiMappingEvent;
+        const ciMappingHandler = new CiMappingHandler();
+
+        await expect(
+          ciMappingHandler.handler(event, {} as Context)
+        ).rejects.toThrow("ci_mapping cannot be undefined");
+      }
     );
   });
 });

--- a/lambdas/ci-mapping/tests/ci-mapping-handler.test.ts
+++ b/lambdas/ci-mapping/tests/ci-mapping-handler.test.ts
@@ -2,13 +2,17 @@ import { CiMappingHandler } from "../src/ci-mapping-handler";
 import { Context } from "aws-lambda";
 import { CiMappingEvent } from "../src/ci-mapping-event";
 
-const testCiMapping = "aaaa:ci_1||bbbb,cccc,dddd:ci_2||eeee,ffff,gggg:ci_3";
+const testCiMapping = [
+  "aaaa:ci_1",
+  "bbbb,cccc,dddd:ci_2",
+  "eeee,ffff,gggg:ci_3",
+];
 
 describe("ci-mapping-handler", () => {
   it("should return the correct CI for a given input", async () => {
     const event = {
       ci_mapping: testCiMapping,
-      hmrc_errors: "aaaa",
+      hmrc_errors: ["aaaa"],
     } as CiMappingEvent;
     const ciMappingHandler = new CiMappingHandler();
 
@@ -17,24 +21,36 @@ describe("ci-mapping-handler", () => {
     expect(result).toEqual(["ci_1"]);
   });
 
-  it.each(["bbbb", "cccc"])("should return correct CI value", async (input) => {
-    const event = {
-      ci_mapping: testCiMapping,
-      hmrc_errors: input,
-    } as CiMappingEvent;
-    const ciMappingHandler = new CiMappingHandler();
-
-    const result = await ciMappingHandler.handler(event, {} as Context);
-
-    expect(result).toEqual(["ci_2"]);
-  });
-
-  it.each(["eeee", "eeee,ffff", "eeee,ffff,gggg", "ffff", "gggg", "eeee,gggg"])(
-    "should return correct CI value in the same group for when errors",
-    async (input) => {
+  it.each([["bbbb"], ["cccc"]])(
+    "should return correct CI value",
+    async ([input]) => {
       const event = {
         ci_mapping: testCiMapping,
-        hmrc_errors: input,
+        hmrc_errors: [input],
+      } as CiMappingEvent;
+      const ciMappingHandler = new CiMappingHandler();
+
+      const result = await ciMappingHandler.handler(event, {} as Context);
+
+      expect(result).toEqual(["ci_2"]);
+    }
+  );
+
+  it.each([
+    [
+      "eeee",
+      ["eeee", "ffff"],
+      ["eeee", "ffff", "gggg"],
+      ["ffff"],
+      ["gggg"],
+      ["eeee", "gggg"],
+    ],
+  ])(
+    "should return correct CI value in the same group for when errors",
+    async ([input]) => {
+      const event = {
+        ci_mapping: testCiMapping,
+        hmrc_errors: [input],
       } as CiMappingEvent;
       const ciMappingHandler = new CiMappingHandler();
 
@@ -47,7 +63,7 @@ describe("ci-mapping-handler", () => {
   it("should return multiple CIs when they are different", async () => {
     const event = {
       ci_mapping: testCiMapping,
-      hmrc_errors: "aaaa,gggg",
+      hmrc_errors: ["aaaa,gggg"],
     } as CiMappingEvent;
     const ciMappingHandler = new CiMappingHandler();
 

--- a/lambdas/ci-mapping/tests/utils/ci-mapping-utils.test.ts
+++ b/lambdas/ci-mapping/tests/utils/ci-mapping-utils.test.ts
@@ -1,0 +1,77 @@
+import {
+  allMappedHmrcErrors,
+  deduplicateValues,
+  getHmrcErrsCiRecord,
+  isCiHmrcErrorsMappingValid,
+} from "../../src/utils/ci-mapping-util";
+
+describe("ci-mapping-utils", () => {
+  const goodHmrcErrsCiRecordStringOne = "hmrc-error1,hmrc error2:Ci_1";
+  const goodHmrcErrsCiRecordStringTwo = "bbbb,cccc,dddd:ci_2";
+  const goodHmrcErrsCiRecordStringThree = "eeee,ffff,gggg:ci_3";
+
+  const ci_mapping = [
+    goodHmrcErrsCiRecordStringOne,
+    goodHmrcErrsCiRecordStringTwo,
+    goodHmrcErrsCiRecordStringThree,
+  ];
+  describe("deduplicate values", () => {
+    const test_cis = ["ci_1", "ci_2", "ci_3"];
+    it("should remove duplicates from inputs", () => {
+      expect(deduplicateValues(["ci_1", "ci_2", "ci_1", "ci_3"])).toEqual(
+        test_cis
+      );
+    });
+
+    it("should return input same input array, when no duplicates exist", () => {
+      expect(deduplicateValues(test_cis)).toEqual(test_cis);
+    });
+  });
+
+  describe("get hmrc errors record", () => {
+    it("should return an HmrcErrsCiRecord with hmrcErrors and ciValue", () => {
+      expect(getHmrcErrsCiRecord(goodHmrcErrsCiRecordStringOne)).toEqual({
+        mappedHmrcErrors: "hmrc-error1,hmrc error2",
+        ciValue: "Ci_1",
+      });
+    });
+  });
+
+  describe("allMappedHmrcErrors", () => {
+    it("should extract all hmrc errors in CiMapping into a comma list of the errors", () => {
+      expect(allMappedHmrcErrors(ci_mapping)).toBe(
+        "hmrc-error1,hmrc error2,bbbb,cccc,dddd,eeee,ffff,gggg"
+      );
+    });
+  });
+
+  describe("is Ci Hmrc Errors Mapping Valid", () => {
+    const badHmrcErrsWithoutCiRecordInString = "hmrc-error1,hmrc error2:";
+    const badWithoutHmrcErrsCiRecordInString = ":ci_2";
+    const bad_ci_mapping = [
+      goodHmrcErrsCiRecordStringOne,
+      badWithoutHmrcErrsCiRecordInString,
+      goodHmrcErrsCiRecordStringTwo,
+      badHmrcErrsWithoutCiRecordInString,
+    ];
+    it("should return true given a valid ci_mapping", () => {
+      expect(isCiHmrcErrorsMappingValid(ci_mapping)).toBe(true);
+    });
+
+    it("should return false given invalid ci_mapping without CI component in string", () => {
+      expect(
+        isCiHmrcErrorsMappingValid([badHmrcErrsWithoutCiRecordInString])
+      ).toBe(false);
+    });
+
+    it("should return false given invalid ci_mapping without hmrc error component in string", () => {
+      expect(
+        isCiHmrcErrorsMappingValid([badWithoutHmrcErrsCiRecordInString])
+      ).toBe(false);
+    });
+
+    it("should return false given invalid ci_mapping that has some good Hmrc Errors CiRecord String", () => {
+      expect(isCiHmrcErrorsMappingValid(bad_ci_mapping)).toBe(false);
+    });
+  });
+});

--- a/lambdas/ci-mapping/tests/utils/ci-mapping-utils.test.ts
+++ b/lambdas/ci-mapping/tests/utils/ci-mapping-utils.test.ts
@@ -1,7 +1,7 @@
 import {
-  allMappedHmrcErrors,
   deduplicateValues,
   getHmrcErrsCiRecord,
+  allMappedHmrcErrors,
   isCiHmrcErrorsMappingValid,
 } from "../../src/utils/ci-mapping-util";
 

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -213,17 +213,21 @@
           }
         },
         {
-          "StartAt": "Fetch User NINO Attempts",
+          "StartAt": "Fetch Failed Attempts",
           "States": {
-            "Fetch User NINO Attempts": {
+            "Fetch Failed Attempts": {
               "Type": "Task",
               "Next": "Add Type to VC",
               "Parameters": {
                 "TableName": "${UserAttemptsTable}",
                 "KeyConditionExpression": "sessionId = :value",
+                "FilterExpression": "attempt = :attempt",
                 "ExpressionAttributeValues": {
                   ":value": {
                     "S.$": "$.querySession.sessionId"
+                  },
+                  ":attempt": {
+                    "S": "FAIL"
                   }
                 }
               },
@@ -248,14 +252,36 @@
                 {
                   "Or": [
                     {
-                      "Variable": "$.check-attempts-exist.Items[0].outcome.S",
-                      "StringEquals": "FAIL"
+                      "Variable": "$.check-attempts-exist.Count",
+                      "NumericGreaterThanEquals": 2
                     }
                   ],
-                  "Next": "Create Evidence (Failed)"
+                  "Next": "Fetch Contra Indicator Mappings"
                 }
               ],
               "Default": "Create Evidence (Pass)"
+            },
+            "Fetch Contra Indicator Mappings": {
+              "Type": "Task",
+              "Next": "Fetch CI",
+              "Parameters": {
+                "Name": "/check-hmrc-cri-api/contraindicationMappings"
+              },
+              "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
+              "ResultPath": "$.ci_mapping"
+            },
+            "Fetch CI": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "${CiMappingFunctionArn}",
+                "Payload": {
+                  "ci_mapping.$": "States.StringSplit($.ci_mapping.Parameter.Value,'||')",
+                  "hmrc_errors.$": "$.check-attempts-exist.Items[*].text.S"
+                }
+              },
+              "Next": "Create Evidence (Failed)",
+              "ResultPath": "$.ci_lambda_output"
             },
             "Create Evidence (Failed)": {
               "Type": "Pass",
@@ -271,7 +297,7 @@
                         "checkMethod": "data"
                       }
                     ],
-                    "ci": ["D02"]
+                    "ci.$": "$.ci_lambda_output.Payload"
                   }
                 ]
               },

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -268,7 +268,10 @@
                 "Name": "/check-hmrc-cri-api/contraindicationMappings"
               },
               "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
-              "ResultPath": "$.ci_mapping"
+              "ResultPath": "$.ci_mapping",
+              "ResultSelector": {
+                "value.$": "$.Parameter.Value"
+              }
             },
             "Fetch CI": {
               "Type": "Task",
@@ -276,7 +279,7 @@
               "Parameters": {
                 "FunctionName": "${CiMappingFunctionArn}",
                 "Payload": {
-                  "ci_mapping.$": "States.StringSplit($.ci_mapping.Parameter.Value,'||')",
+                  "ci_mapping.$": "States.StringSplit($.ci_mapping.value,'||')",
                   "hmrc_errors.$": "$.check-attempts-exist.Items[*].text.S"
                 }
               },


### PR DESCRIPTION
## Proposed changes

### What changed
* State Machine uses the ci-mapping-function to generate CI codes

### Why did it change
So that we no longer have the dummy CI in the VC but instead use a real one that uses the HMRC response.

### Issue tracking
- [OJ-2113](https://govukverify.atlassian.net/browse/OJ-2113)


[OJ-2113]: https://govukverify.atlassian.net/browse/OJ-2113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ