### PR TITLE
BAU: Change regional to private for `PrivateNinoCheckApi`

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -236,7 +236,7 @@ Resources:
             Location: private-api.yaml
       OpenApiVersion: 3.0.1
       EndpointConfiguration:
-        Type: !If [IsDevEnvironment, REGIONAL, PRIVATE]
+        Type: !If [IsDevEnvironment, PRIVATE, PRIVATE]
       Auth:
         ResourcePolicy: !If
           - IsDevEnvironment


### PR DESCRIPTION
### What changed
The private API in dev has been changed back to private from regional. 

This is because it's causing issues in the core stub causing the stub to return a HTTP 500. 
