### PR TITLE
OJ-2161: Update check-session state machine to return clientId

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -382,7 +382,6 @@ Resources:
     Type: AWS::Serverless::StateMachine
     Properties:
       Type: EXPRESS
-      Name: !Sub ${AWS::StackName}-CheckSession
       DefinitionUri: ../step-functions/check_session.asl.json
       DefinitionSubstitutions:
         CurrentTimeFunctionArn: !GetAtt CurrentTimeFunction.Arn
@@ -411,7 +410,6 @@ Resources:
     Type: AWS::Serverless::StateMachine
     Properties:
       Type: EXPRESS
-      Name: !Sub ${AWS::StackName}-NinoCheck
       DefinitionUri: ../step-functions/nino_check.asl.json
       DefinitionSubstitutions:
         CheckSessionStateMachineArn: !Ref CheckSessionStateMachine
@@ -486,7 +484,6 @@ Resources:
     Type: AWS::Serverless::StateMachine
     Properties:
       Type: EXPRESS
-      Name: !Sub ${AWS::StackName}-NinoIssueCredential
       DefinitionUri: ../step-functions/nino_issue_credential.asl.json
       DefinitionSubstitutions:
         CiMappingFunctionArn: !GetAtt CiMappingFunction.Arn

--- a/integration-tests/tests/aws/check-session/check-session.test.ts
+++ b/integration-tests/tests/aws/check-session/check-session.test.ts
@@ -29,6 +29,7 @@ describe("check-session", () => {
     await populateTable(sessionTableName, {
       sessionId: input.sessionId,
       expiryDate: 9999999999,
+      clientId: "exampleClientId",
     });
 
     const startExecutionResult = await executeStepFunction(
@@ -38,7 +39,22 @@ describe("check-session", () => {
 
     const result = JSON.parse(startExecutionResult.output || "");
     expect(result.status).toBe("SESSION_OK");
-    expect(result.clientId).toBeDefined();
+    expect(result.clientId).toBe("exampleClientId");
+  });
+
+  it("should throw an error when there is no clientId present within the session table", async () => {
+    await populateTable(sessionTableName, {
+      sessionId: input.sessionId,
+      expiryDate: 9999999999,
+    });
+
+    const startExecutionResult = await executeStepFunction(
+      output.CheckSessionStateMachineArn as string,
+      input
+    );
+
+    const result = JSON.parse(startExecutionResult.output || "");
+    expect(result.status).toBeDefined();
   });
 
   it("should return SESSION_NOT_FOUND when sessionId does not exist", async () => {

--- a/integration-tests/tests/aws/check-session/check-session.test.ts
+++ b/integration-tests/tests/aws/check-session/check-session.test.ts
@@ -36,7 +36,9 @@ describe("check-session", () => {
       input
     );
 
-    expect(startExecutionResult.output).toBe('{"status":"SESSION_OK"}');
+    const result = JSON.parse(startExecutionResult.output || "");
+    expect(result.status).toBe("SESSION_OK");
+    expect(result.clientId).toBeDefined();
   });
 
   it("should return SESSION_NOT_FOUND when sessionId does not exist", async () => {

--- a/integration-tests/tests/aws/check-session/check-session.test.ts
+++ b/integration-tests/tests/aws/check-session/check-session.test.ts
@@ -53,8 +53,7 @@ describe("check-session", () => {
       input
     );
 
-    const result = JSON.parse(startExecutionResult.output || "");
-    expect(result.status).toBeDefined();
+    expect(startExecutionResult.output).toBeUndefined();
   });
 
   it("should return SESSION_NOT_FOUND when sessionId does not exist", async () => {

--- a/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
@@ -42,6 +42,7 @@ describe("nino-check-happy", () => {
         items: {
           sessionId: input.sessionId,
           expiryDate: 9999999999,
+          clientId: "exampleClientId",
         },
       },
       {

--- a/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
@@ -51,6 +51,7 @@ describe("nino-check-unhappy", () => {
         items: {
           sessionId: input.sessionId,
           expiryDate: 9999999999,
+          clientId: "exampleClientId",
         },
       },
       {

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-happy.test.ts
@@ -97,6 +97,7 @@ describe("nino-issue-credential-happy", () => {
           authorizationCodeExpiryDate: "1698925598",
           expiryDate: "9999999999",
           subject: "test",
+          clientId: "exampleClientId",
         },
       },
       {

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential-unhappy.test.ts
@@ -42,6 +42,7 @@ describe("nino-issue-credential-unhappy", () => {
         items: {
           sessionId: input.sessionId,
           nino: "AA000003D",
+          clientId: "exampleClientId",
         },
       },
       {

--- a/integration-tests/tests/mocked/check-session/MockConfigFile.json
+++ b/integration-tests/tests/mocked/check-session/MockConfigFile.json
@@ -33,6 +33,9 @@
             {
               "expiryDate": {
                 "N": "2695828259"
+              },
+              "clientId": {
+                "S": "exampleClientId"
               }
             }
           ]

--- a/integration-tests/tests/mocked/check-session/check-session.test.ts
+++ b/integration-tests/tests/mocked/check-session/check-session.test.ts
@@ -1,7 +1,7 @@
 import { HistoryEvent } from "@aws-sdk/client-sfn";
 import { SfnContainerHelper } from "./sfn-container-helper";
 
-jest.setTimeout(30_000);
+jest.setTimeout(60_000);
 
 describe("check-session", () => {
   let sfnContainer: SfnContainerHelper;
@@ -30,7 +30,7 @@ describe("check-session", () => {
         responseStepFunction
       );
       expect(results[0].stateExitedEventDetails?.output).toEqual(
-        '{"status":"SESSION_OK"}'
+        '{"status":"SESSION_OK","clientId":"exampleClientId"}'
       );
     });
   });

--- a/step-functions/check_session.asl.json
+++ b/step-functions/check_session.asl.json
@@ -85,7 +85,8 @@
       "Type": "Pass",
       "End": true,
       "Parameters": {
-        "status": "SESSION_OK"
+        "status": "SESSION_OK",
+        "clientId.$": "$.sessionQuery.items[0].clientId.S"
       }
     },
     "Err: No sessionId provided": {


### PR DESCRIPTION
## Proposed changes

### What changed
The check-session state machine's .ASL file has been updated to return the clientId from the session table. 

As part of this PR, the name attribute has been removed from the state machine definition within the template.yaml. This is because we are running into a name length limit so by removing this attribute AWS will manage this for us. 

### Why did it change
The nino-check state machine requires a clientId.

The check-session state machine queries the session table which contains the clientId so to avoid re-querying the session table again, we are going to return it in the check-session state machine.

### Issue tracking
- [OJ-2161](https://govukverify.atlassian.net/browse/OJ-2161)


[OJ-2161]: https://govukverify.atlassian.net/browse/OJ-2161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ