### PR TITLE
IPS-497: check cri for local dev stack

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -25,9 +25,9 @@ sam deploy --stack-name "$stack_name" \
   --capabilities CAPABILITY_IAM \
   --tags \
   cri:component=ipv-cri-check-hmrc-api \
-  cri:stack-type=dev \
+  cri:stack-type=localdev \
   cri:application=Orange \
   cri:deployment-source=manual \
   --parameter-overrides \
   ${common_stack_name:+CommonStackName=$common_stack_name} \
-  Environment=dev
+  Environment=localdev

--- a/infrastructure/public-api.yaml
+++ b/infrastructure/public-api.yaml
@@ -142,7 +142,7 @@ paths:
       security:
         - api_key:
             Fn::If:
-              - IsDevEnvironment
+              - IsLocalDevEnvironment
               - Ref: AWS::NoValue
               - []
       x-amazon-apigateway-request-validator: "Validate both"

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -12,7 +12,8 @@ Parameters:
   Environment:
     Type: String
     Default: dev
-    AllowedValues: [dev, build, staging, integration, production]
+    AllowedValues: [dev, localdev, build, staging, integration, production]
+    ConstraintDescription: must be dev, localdev, build, staging, integration or production
   CommonStackName:
     Type: String
     Default: common-cri-api
@@ -28,6 +29,9 @@ Conditions:
   EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, ""]]
   IsDevEnvironment: !Equals [!Ref Environment, dev]
+  IsLocalDevEnvironment: !Equals [!Ref Environment, localdev]
+  IsDevLikeEnvironment:
+    !Or [!Condition IsLocalDevEnvironment, !Condition IsDevEnvironment]
   IsProductionEnvironment: !Equals [!Ref Environment, production]
   IsStagingOrIntegrationEnvironment: !Or
     - !Equals [!Ref Environment, staging]
@@ -38,6 +42,7 @@ Mappings:
   MaxJwtTtl:
     Environment:
       dev: 2
+      localdev: 2
       build: 2
       staging: 6
       integration: 6
@@ -47,6 +52,7 @@ Mappings:
   JwtTtlUnit:
     Environment:
       dev: HOURS
+      localdev: HOURS
       build: HOURS
       staging: MONTHS
       integration: MONTHS
@@ -55,6 +61,7 @@ Mappings:
   Dynatrace:
     SecretArn:
       dev: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      localdev: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       build: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       staging: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       integration: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -194,7 +201,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-${PublicNinoCheckApi}-public-AccessLogs
-      RetentionInDays: 30
+      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
 
   PrivateNinoCheckApi:
     Type: AWS::Serverless::Api
@@ -236,15 +243,11 @@ Resources:
             Location: private-api.yaml
       OpenApiVersion: 3.0.1
       EndpointConfiguration:
-        Type: !If [IsDevEnvironment, PRIVATE, PRIVATE]
+        Type: !If [IsLocalDevEnvironment, REGIONAL, PRIVATE]
       Auth:
         ResourcePolicy: !If
-          - IsDevEnvironment
-          - CustomStatements:
-              - Effect: Allow
-                Resource: execute-api:/*
-                Action: execute-api:Invoke
-                Principal: "*"
+          - IsLocalDevEnvironment
+          - !Ref AWS::NoValue
           - CustomStatements:
               - Effect: Allow
                 Resource: execute-api:/*
@@ -255,7 +258,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-${PrivateNinoCheckApi}-private-AccessLogs
-      RetentionInDays: 30
+      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
 
   ExecuteStateMachineRole:
     Type: AWS::IAM::Role
@@ -482,7 +485,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-NinoCheck-state-machine-logs
-      RetentionInDays: 30
+      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
 
   NinoIssueCredentialStateMachine:
     Type: AWS::Serverless::StateMachine
@@ -552,13 +555,13 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-NinoIssueCredential-state-machine-logs
-      RetentionInDays: 30
+      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
 
   CheckSessionStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-CheckSession-state-machine-logs
-      RetentionInDays: 30
+      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
 
 Outputs:
   ApiGatewayId:


### PR DESCRIPTION
## Proposed changes

Added condition into the private-api, so that a developer can spin up a stack in which it is possible to lunch the check-front end CRI on localhost to work in conjunction with a ipv-stub also run on a separate port locally on the dev machine
see: https://govukverify.atlassian.net/wiki/spaces/DID/pages/3206512675/Running+CRI+s+locally

### What changed

Added `localdev` to template and deploy.sh

### Why did it change

DEV has been changed to align closer to the other environments, it used to be used by developer in conjunction with a stack they have deployed however it is also a legimate environment on the pipeline. Creating this new environment `localdev` provides a better separation of intent, where `localdev` is used with the deploy.sh script

### Issue tracking

- [IPS-497](https://govukverify.atlassian.net/browse/IPS-497)


[IPS-497]: https://govukverify.atlassian.net/browse/IPS-497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ