### PR TITLE
BAU: Updated bad NINO value within the tests to match updated Imposter scenario

### DIFF
--- a/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-happy.test.ts
@@ -102,7 +102,7 @@ describe("nino-check-happy", () => {
       output.NinoCheckStateMachineArn as string,
       {
         sessionId: input.sessionId,
-        nino: "AB123003C",
+        nino: "NoCidNino",
       }
     );
 

--- a/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
@@ -145,9 +145,14 @@ describe("nino-check-unhappy", () => {
   });
 
   it("should fail when user NINO does not match with HMRC DB", async () => {
+    const inputWithBadNino = {
+      sessionId: input.sessionId,
+      nino: "NoCidNino",
+    };
+
     const startExecutionResult = await executeStepFunction(
       output.NinoCheckStateMachineArn as string,
-      input
+      inputWithBadNino
     );
 
     expect(startExecutionResult.output).toBe('{"httpStatus":422}');


### PR DESCRIPTION
## Proposed changes

### What changed
The bad nino value in some of the tests.

### Why did it change
The Imposter scenarios had some changes, so these tests needed to be updated to match so that they continue working. 

