### PR TITLE
OJ-2121: Adding a retry the API call Lambda

### DIFF
--- a/integration-tests/tests/mocked/nino-check/MockConfigFile.json
+++ b/integration-tests/tests/mocked/nino-check/MockConfigFile.json
@@ -15,6 +15,15 @@
           "Set Auth Code for Session": "SetAuthCodeSuccess",
           "Save NINO & sessionId to nino-users table": "SaveNinoSuccess"
         },
+        "APIFailRetryFailTest": {
+          "Invoke Check Session": "CheckSessionSuccess",
+          "Fetch SSM Parameters": "FetchSSMParamsSuccess",
+          "Query User Attempts": "DynamoDbQueryNoResult",
+          "Create new user attempt": "DynamoDbQueryNoResult",
+          "Query Person Identity Table": "QuerySessionSuccess",
+          "Get OAuth Token": "GetOAuthAccessTokenSuccess",
+          "Call Matching API": "CallMatchingAPIRetryThenFail"
+        },
         "DeceasedTest": {
           "Invoke Check Session": "CheckSessionSuccess",
           "Fetch SSM Parameters": "FetchSSMParamsSuccess",
@@ -114,6 +123,22 @@
               "lastName": "Ferguson",
               "dateOfBirth": "1948-04-23",
               "nino": "AA000003D"
+            }
+          }
+        }
+      }
+    },
+    "CallMatchingAPIRetryThenFail": {
+      "0-2": {
+        "Throw": {
+          "Error": "InternalServerException",
+          "Cause": "dummy-cause"
+        },
+        "3": {
+          "Return": {
+            "Payload": {
+              "status": "dummy-status",
+              "body": "dummy-error"
             }
           }
         }

--- a/integration-tests/tests/mocked/nino-check/MockConfigFile.json
+++ b/integration-tests/tests/mocked/nino-check/MockConfigFile.json
@@ -2,6 +2,19 @@
   "StateMachines": {
     "nino_check": {
       "TestCases": {
+        "APIFailRetrySuccessTest": {
+          "Invoke Check Session": "CheckSessionSuccess",
+          "Fetch SSM Parameters": "FetchSSMParamsSuccess",
+          "Query User Attempts": "DynamoDbQueryNoResult",
+          "Create new user attempt": "DynamoDbQueryNoResult",
+          "Query Person Identity Table": "QuerySessionSuccess",
+          "Get OAuth Token": "GetOAuthAccessTokenSuccess",
+          "Call Matching API": "CallMatchingAPIRetryThenSuccess",
+          "Store Successful Attempt": "UpdateStatusToPassSuccess",
+          "Fetch Auth Code Expiry": "FetchAuthCodeExpirySuccess",
+          "Set Auth Code for Session": "SetAuthCodeSuccess",
+          "Save NINO & sessionId to nino-users table": "SaveNinoSuccess"
+        },
         "DeceasedTest": {
           "Invoke Check Session": "CheckSessionSuccess",
           "Fetch SSM Parameters": "FetchSSMParamsSuccess",
@@ -85,6 +98,27 @@
     }
   },
   "MockedResponses": {
+    "CallMatchingAPIRetryThenSuccess": {
+      "0-1": {
+        "Throw": {
+          "Error": "InternalServerException",
+          "Cause": "dummy-cause"
+        }
+      },
+      "2": {
+        "Return": {
+          "Payload": {
+            "status": "200",
+            "body": {
+              "firstName": "Jim",
+              "lastName": "Ferguson",
+              "dateOfBirth": "1948-04-23",
+              "nino": "AA000003D"
+            }
+          }
+        }
+      }
+    },
     "FetchSSMParamsSuccess": {
       "0": {
         "Return": {

--- a/integration-tests/tests/mocked/nino-check/makefile
+++ b/integration-tests/tests/mocked/nino-check/makefile
@@ -89,3 +89,10 @@ APIFailRetrySuccessTest:
 	--state-machine ${STATE_MACHINE_ARN}#APIFailRetrySuccessTest \
 	--input '{ "sessionId": "12345", "nino": "AA000003D" }' \
 	--no-cli-pager
+APIFailRetryFailTest:
+	aws stepfunctions start-execution \
+	--endpoint http://localhost:8083 \
+	--name happyPathExecution \
+	--state-machine ${STATE_MACHINE_ARN}#APIFailRetryFailTest \
+	--input '{ "sessionId": "12345", "nino": "AA000003D" }' \
+	--no-cli-pager

--- a/integration-tests/tests/mocked/nino-check/makefile
+++ b/integration-tests/tests/mocked/nino-check/makefile
@@ -82,3 +82,10 @@ hmrcError:
 	--state-machine ${STATE_MACHINE_ARN}#HMRCError \
 	--input '{ "sessionId": "12345", "nino": "AA000003D" }' \
 	--no-cli-pager
+APIFailRetrySuccessTest:
+	aws stepfunctions start-execution \
+	--endpoint http://localhost:8083 \
+	--name happyPathExecution \
+	--state-machine ${STATE_MACHINE_ARN}#APIFailRetrySuccessTest \
+	--input '{ "sessionId": "12345", "nino": "AA000003D" }' \
+	--no-cli-pager

--- a/integration-tests/tests/mocked/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/mocked/nino-check/nino-check-happy.test.ts
@@ -16,6 +16,25 @@ describe("nino-check-happy", () => {
     expect(sfnContainer.getContainer()).toBeDefined();
   });
 
+  it("should pass after the hmrc api fails on 2 attempts but succeeds on the third retry", async () => {
+    const input = JSON.stringify({
+      nino: "AA000003D",
+      sessionId: "12345",
+    });
+    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+      "APIFailRetrySuccessTest",
+      input
+    );
+    const results = await sfnContainer.waitFor(
+      (event: HistoryEvent) =>
+        event?.stateExitedEventDetails?.name === "Nino check successful",
+      responseStepFunction
+    );
+    expect(results[0].stateExitedEventDetails?.output).toEqual(
+      '{"httpStatus":200}'
+    );
+  });
+
   it.each([
     ["with no previous attempt", "HappyPathTestNoPreviousAttempt"],
     ["after 1 failed previous attempt", "HappyPathTestOn2ndAttempt"],

--- a/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
@@ -144,4 +144,21 @@ describe("nino-check-unhappy", () => {
       '{"httpStatus":422}'
     );
   });
+
+  it("should fail when the call matching api lambda fails after exponential retries", async () => {
+    const input = JSON.stringify({
+      nino: "AA000003D",
+      sessionId: "12345",
+    });
+    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+      "APIFailRetryFailTest",
+      input
+    );
+
+    const results = await sfnContainer.waitFor(
+      (event: HistoryEvent) => event?.type === "ExecutionFailed",
+      responseStepFunction
+    );
+    expect(results[0].executionSucceededEventDetails?.output).toBe(undefined);
+  });
 });

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -204,7 +204,15 @@
       "ResultSelector": {
         "payload.$": "$.Payload"
       },
-      "ResultPath": "$.hmrc_response"
+      "ResultPath": "$.hmrc_response",
+      "Retry": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "BackoffRate": 2,
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3
+        }
+      ]
     },
     "Err: Matching Lambda Exception": {
       "Type": "Fail"


### PR DESCRIPTION
## Proposed changes

### What changed and why
* The "Call Matching API" state now has a retry mechanism. This is so that we have a soft-retry on failures before failing. 
* Added mocked unit tests

### Issue tracking

- [OJ-2121](https://govukverify.atlassian.net/browse/OJ-2121)
