### PR TITLE
OJ-2345: Create /abandon endpoint

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -151,6 +151,48 @@ paths:
                 #else
                 #set($context.responseOverride.status = 200)
                 #end
+  /abandon:
+    post:
+      summary: "IP address of the client."
+      parameters:
+        - $ref: "#/components/parameters/SessionHeader"
+      x-amazon-apigateway-request-validator: "Validate both"
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+        "500":
+          description: Internal Server Error
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        passthroughBehavior: "when_no_templates"
+        type: "aws"
+        credentials:
+          Fn::Sub: ${ExecuteStateMachineRole.Arn}
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:states:action/StartSyncExecution
+        requestTemplates:
+          application/json:
+            Fn::Sub: |-
+              {
+                "input": "{\"sessionId\": \"$input.params('session-id').trim()\"}",
+                "stateMachineArn": "${AbandonStateMachine.Arn}"
+              }
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: |
+                #set($response = $util.parseJson($input.body))
+                #set($output = $util.parseJson($response.output))
+                #if($response.status == "FAILED")
+                #set($context.responseOverride.status = 500)
+                #elseif($output.httpStatus)
+                #set($context.responseOverride.status = $output.httpStatus)
+                #else
+                #set($context.responseOverride.status = 200)
+                #end
 
 components:
   parameters:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -489,6 +489,50 @@ Resources:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-NinoCheck-state-machine-logs
       RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
 
+  AbandonStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Type: EXPRESS
+      DefinitionUri: ../step-functions/abandon.asl.json
+      DefinitionSubstitutions:
+        CheckSessionStateMachineArn: !Ref CheckSessionStateMachine
+        CommonStackName: !Ref CommonStackName
+        SsmParametersFunction: !Ref SsmParametersFunction
+      Logging:
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt AbandonStateMachineLogGroup.Arn
+        IncludeExecutionData: True
+        Level: ALL
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref SsmParametersFunction
+        - DynamoDBReadPolicy:
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+        - DynamoDBWritePolicy:
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+        - Statement:
+            Effect: Allow
+            Action:
+              - states:StartSyncExecution
+              - states:StartExecution
+            Resource:
+              - !Ref CheckSessionStateMachine
+        - Statement:
+            Effect: Allow
+            Action: logs:*
+            Resource: "*"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+
+  AbandonStateMachineLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-Abandon-state-machine-logs
+      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+
   NinoIssueCredentialStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
@@ -577,7 +621,6 @@ Outputs:
   SsmParametersFunctionArn:
     Description: SsmParameters Lambda Function ARN
     Value: !GetAtt SsmParametersFunction.Arn
-
   ApiGatewayId:
     Description: API GatewayID of the Nino Check HMRC CRI API
     Value: !Ref PublicNinoCheckApi
@@ -611,3 +654,6 @@ Outputs:
   NinoUsersTable:
     Description: NinoUsersTable table name
     Value: !Ref NinoUsersTable
+  AbandonStateMachineArn:
+    Description: Abandon state machine ARN
+    Value: !Ref AbandonStateMachine

--- a/integration-tests/tests/aws/abandon/abandon.test.ts
+++ b/integration-tests/tests/aws/abandon/abandon.test.ts
@@ -29,7 +29,7 @@ describe("abandon", () => {
     });
   });
 
-  it("it should remove the authorizationCode when session exists", async () => {
+  it("should remove the authorizationCode when session exists", async () => {
     await populateTable(sessionTableName, {
       sessionId: input.sessionId,
       expiryDate: 9999999999,

--- a/integration-tests/tests/aws/abandon/abandon.test.ts
+++ b/integration-tests/tests/aws/abandon/abandon.test.ts
@@ -1,0 +1,62 @@
+import { stackOutputs } from "../resources/cloudformation-helper";
+import {
+  clearItems,
+  getItemByKey,
+  populateTable,
+} from "../resources/dynamodb-helper";
+import { executeStepFunction } from "../resources/stepfunction-helper";
+
+describe("abandon", () => {
+  const input = {
+    sessionId: "abandon-test",
+  };
+
+  let output: Partial<{
+    CommonStackName: string;
+    AbandonStateMachineArn: string;
+  }>;
+
+  let sessionTableName: string;
+
+  beforeAll(async () => {
+    output = await stackOutputs(process.env.STACK_NAME);
+    sessionTableName = `session-${output.CommonStackName}`;
+  });
+
+  afterEach(async () => {
+    await clearItems(sessionTableName, {
+      sessionId: input.sessionId,
+    });
+  });
+
+  it("it should remove the authorizationCode when session exists", async () => {
+    await populateTable(sessionTableName, {
+      sessionId: input.sessionId,
+      expiryDate: 9999999999,
+      clientId: "exampleClientId",
+      authorizationCode: "9999999999",
+      authorizationCodeExpiryDate: "9999999999",
+    });
+
+    const startExecutionResult = await executeStepFunction(
+      output.AbandonStateMachineArn as string,
+      input
+    );
+
+    const sessionRecord = await getItemByKey(sessionTableName, {
+      sessionId: input.sessionId,
+    });
+
+    expect(startExecutionResult.output).toBe("{}");
+    expect(sessionRecord.Item?.authorizationCode).toBeUndefined();
+    expect(sessionRecord.Item?.authorizationCodeExpiryDate).toBe(0);
+  });
+
+  it("should return a 400 when session does not exist", async () => {
+    const startExecutionResult = await executeStepFunction(
+      output.AbandonStateMachineArn as string,
+      input
+    );
+    expect(startExecutionResult.output).toBe('{"httpStatus":400}');
+  });
+});

--- a/integration-tests/tests/aws/resources/dynamodb-helper.ts
+++ b/integration-tests/tests/aws/resources/dynamodb-helper.ts
@@ -2,6 +2,7 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DeleteCommand,
   DynamoDBDocumentClient,
+  GetCommand,
   PutCommand,
   QueryCommand,
 } from "@aws-sdk/lib-dynamodb";
@@ -15,6 +16,9 @@ const sendCommand = createSendCommand(() =>
     new DynamoDBClient({ region: process.env.AWS_REGION })
   )
 );
+
+export const getItemByKey = (tableName: string, key: Keys) =>
+  sendCommand(GetCommand, { TableName: tableName, Key: key });
 
 export const populateTable = (tableName: string, items: Keys) =>
   sendCommand(PutCommand, { TableName: tableName, Item: items });

--- a/integration-tests/tests/mocked/abandon/MockConfigFile.json
+++ b/integration-tests/tests/mocked/abandon/MockConfigFile.json
@@ -1,0 +1,49 @@
+{
+  "StateMachines": {
+    "abandon": {
+      "TestCases": {
+        "Happy": {
+          "Invoke Check Session": "SessionFound",
+          "Fetch SSM Parameters": "FetchSSMParameters",
+          "Clear Auth Code": "ClearAuthCode"
+        },
+        "NoSessionFound": {
+          "Invoke Check Session": "NoSessionFound"
+        }
+      }
+    }
+  },
+  "MockedResponses": {
+    "SessionFound": {
+      "0": {
+        "Return": {
+          "Output": "{\"status\": \"SESSION_OK\", \"clientId\": \"dummy-client-id\"}"
+        }
+      }
+    },
+    "NoSessionFound": {
+      "0": {
+        "Return": {
+          "Output": "{\"status\": \"SESSION_NOT_FOUND\"}"
+        }
+      }
+    },
+    "FetchSSMParameters": {
+      "0": {
+        "Return": {
+          "Payload": [
+            {
+              "Name": "/common-cri-api/SessionTableName",
+              "Value": "session-common-cri-api"
+            }
+          ]
+        }
+      }
+    },
+    "ClearAuthCode": {
+      "0": {
+        "Return": {}
+      }
+    }
+  }
+}

--- a/integration-tests/tests/mocked/abandon/abandon.test.ts
+++ b/integration-tests/tests/mocked/abandon/abandon.test.ts
@@ -17,7 +17,7 @@ describe("abandon", () => {
   });
 
   describe("happy path tests", () => {
-    it("it should pass when session exists", async () => {
+    it("should pass when session exists", async () => {
       const input = JSON.stringify({
         sessionId: "12345",
       });
@@ -32,7 +32,7 @@ describe("abandon", () => {
   });
 
   describe("unhappy path tests", () => {
-    it("it should fail when session does not exist", async () => {
+    it("should fail when session does not exist", async () => {
       const input = JSON.stringify({
         sessionId: "12345",
       });

--- a/integration-tests/tests/mocked/abandon/abandon.test.ts
+++ b/integration-tests/tests/mocked/abandon/abandon.test.ts
@@ -1,0 +1,52 @@
+import { HistoryEvent } from "@aws-sdk/client-sfn";
+import { SfnContainerHelper } from "./sfn-container-helper";
+
+jest.setTimeout(60_000);
+
+describe("abandon", () => {
+  let sfnContainer: SfnContainerHelper;
+
+  beforeAll(async () => {
+    sfnContainer = new SfnContainerHelper();
+  });
+
+  afterAll(async () => sfnContainer.shutDown());
+
+  it("has a step-function docker container running", async () => {
+    expect(sfnContainer.getContainer()).toBeDefined();
+  });
+
+  describe("happy path tests", () => {
+    it("it should pass when session exists", async () => {
+      const input = JSON.stringify({
+        sessionId: "12345",
+      });
+      const responseStepFunction =
+        await sfnContainer.startStepFunctionExecution("Happy", input);
+      const results = await sfnContainer.waitFor(
+        (event: HistoryEvent) => event?.type == "ExecutionSucceeded",
+        responseStepFunction
+      );
+      expect(results[0].executionSucceededEventDetails?.output).toBe("{}");
+    });
+  });
+
+  describe("unhappy path tests", () => {
+    it("it should fail when session does not exist", async () => {
+      const input = JSON.stringify({
+        sessionId: "12345",
+      });
+      const responseStepFunction =
+        await sfnContainer.startStepFunctionExecution("NoSessionFound", input);
+      const results = await sfnContainer.waitFor(
+        (event: HistoryEvent) =>
+          event?.type === "PassStateExited" &&
+          event?.stateExitedEventDetails?.name === "Err: Invalid Session",
+        responseStepFunction
+      );
+      expect(results[0].stateExitedEventDetails?.output).toBe(
+        '{"httpStatus":400}'
+      );
+    });
+  });
+});

--- a/integration-tests/tests/mocked/abandon/docker-compose.yaml
+++ b/integration-tests/tests/mocked/abandon/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+  step_function_local:
+    container_name: "abandon-state-machine"
+    image: amazon/aws-stepfunctions-local
+    ports:
+      - "8084:8083"
+    environment:
+      AWS_SECRET_ACCESS_KEY: "local" # pragma: allowlist secret
+      SFN_MOCK_CONFIG: "/home/stepfunctionslocal/MockConfigFile.json"
+      AWS_DEFAULT_REGION: "local"
+      AWS_ACCESS_KEY_ID: "local"
+    volumes:
+      - ./MockConfigFile.json:/home/stepfunctionslocal/MockConfigFile.json

--- a/integration-tests/tests/mocked/abandon/makefile
+++ b/integration-tests/tests/mocked/abandon/makefile
@@ -1,0 +1,28 @@
+STATE_MACHINE_NAME=abandon
+STATE_MACHINE_DEFINITION_FILE=file://../../../../step-functions/${STATE_MACHINE_NAME}.asl.json
+STATE_MACHINE_ARN=arn:aws:states:local:123456789012:stateMachine:${STATE_MACHINE_NAME}
+STATE_MACHINE_EXECUTION_ARN=arn:aws:states:local:123456789012:execution:${STATE_MACHINE_NAME}
+
+run:
+	docker compose up -d --force-recreate
+create:
+	aws stepfunctions create-state-machine \
+	--endpoint-url http://localhost:8084 \
+	--definition ${STATE_MACHINE_DEFINITION_FILE} \
+	--name ${STATE_MACHINE_NAME} \
+	--role-arn "arn:aws:iam::123456789012:role/DummyRole" \
+	--no-cli-pager
+happy:
+	aws stepfunctions start-execution \
+	--endpoint http://localhost:8084 \
+	--name happy \
+	--state-machine ${STATE_MACHINE_ARN}#Happy \
+	--input '{ "sessionId": "12345" }' \
+	--no-cli-pager
+NoSessionFound:
+	aws stepfunctions start-execution \
+	--endpoint http://localhost:8084 \
+	--name NoSessionFound \
+	--state-machine ${STATE_MACHINE_ARN}#NoSessionFound \
+	--input '{ "sessionId": "12345" }' \
+	--no-cli-pager

--- a/integration-tests/tests/mocked/abandon/sfn-constants.ts
+++ b/integration-tests/tests/mocked/abandon/sfn-constants.ts
@@ -1,0 +1,19 @@
+import fs from "fs";
+import path from "path";
+
+const STATE_MACHINE_FILE = path.join(
+  __dirname,
+  "../../../../step-functions/abandon.asl.json"
+);
+
+export const StepFunctionConstants = {
+  mockFileHostPath: path.join(__dirname, "./MockConfigFile.json"),
+  mockFileContainerPath: "/home/stepfunctionslocal/MockConfigFile.json",
+  DUMMY_ROLE: "arn:aws:iam::123456789012:role/DummyRole",
+  STATE_MACHINE_ASL: fs.readFileSync(STATE_MACHINE_FILE).toString(),
+  STATE_MACHINE_NAME: "abandon",
+  AWS_ACCOUNT_ID: "123456789012",
+  AWS_DEFAULT_REGION: "local",
+  AWS_ACCESS_KEY_ID: "local",
+  AWS_SECRET_ACCESS_KEY: "local", //pragma: allowlist secret
+};

--- a/integration-tests/tests/mocked/abandon/sfn-container-helper.ts
+++ b/integration-tests/tests/mocked/abandon/sfn-container-helper.ts
@@ -1,0 +1,271 @@
+import {
+  CreateStateMachineCommand,
+  DescribeStateMachineCommand,
+  DescribeStateMachineCommandOutput,
+  ExecutionDoesNotExist,
+  GetExecutionHistoryCommand,
+  GetExecutionHistoryCommandOutput,
+  HistoryEvent,
+  SFNClient,
+  StartExecutionCommand,
+  StartExecutionCommandOutput,
+  StateMachineType,
+} from "@aws-sdk/client-sfn";
+import { StartedTestContainer, GenericContainer } from "testcontainers";
+import fs from "fs";
+import path from "path";
+import { StepFunctionConstants } from "./sfn-constants";
+
+const MAX_RETRIES = 10;
+
+export class SfnContainerHelper {
+  private sfnClient: Promise<SFNClient>;
+  private composeEnvironment: Promise<StartedTestContainer>;
+
+  public constructor(
+    private readonly mockContent?: string,
+    private tempFilePath?: string
+  ) {
+    this.composeEnvironment = Promise.resolve(this.createTestContainer());
+    this.sfnClient = Promise.resolve(this.createSfnClient());
+  }
+
+  public getContainer = async () => {
+    const container = await this.composeEnvironment;
+    if (this.mockContent) {
+      this.tempFilePath = this.getFileForPartialMock();
+      await this.copyFileToContainer(container, this.tempFilePath);
+    } else {
+      await this.copyFileToContainer(container);
+    }
+    // (await container.logs())
+    // .on("data", line => console.log(line))
+    // .on("err", line => console.error(line))
+    // .on("end", () => console.log("Stream closed"));
+    return container;
+  };
+
+  getFileForPartialMock = () => {
+    if (!this.mockContent)
+      throw Error("MockContent not supplied for partial mockconfigfile");
+
+    this.tempFilePath = path.join(__dirname, "tempFile.json");
+    fs.writeFileSync(this.tempFilePath, this.mockContent, "utf-8");
+    return this.tempFilePath;
+  };
+
+  private releasePartialMockConfigfile() {
+    if (this.tempFilePath) {
+      fs.unlinkSync(this.tempFilePath);
+    }
+  }
+
+  private async copyFileToContainer(
+    container: StartedTestContainer,
+    source?: string
+  ) {
+    const copyConfig = [
+      {
+        source: source || StepFunctionConstants.mockFileHostPath,
+        target: StepFunctionConstants.mockFileContainerPath,
+      },
+    ];
+    await container.copyFilesToContainer(copyConfig);
+  }
+  public shutDown = async () => {
+    await (await this.composeEnvironment)?.stop();
+    this.releasePartialMockConfigfile();
+  };
+
+  public startStepFunctionExecution = async (
+    testName: string,
+    stepFunctionInput: string,
+    stateMachine?: DescribeStateMachineCommandOutput
+  ): Promise<StartExecutionCommandOutput> => {
+    const stateMachineArn = `${
+      (await this.createStateMachine(this.sfnClient, stateMachine))
+        .stateMachineArn as string
+    }#${testName}`;
+    return await (
+      await this.sfnClient
+    ).send(
+      new StartExecutionCommand({
+        stateMachineArn,
+        input: stepFunctionInput,
+      })
+    );
+  };
+  public waitFor = async (
+    criteria: (event: HistoryEvent) => boolean,
+    executionResponse: StartExecutionCommandOutput,
+    sfnClient: Promise<SFNClient> = this.sfnClient
+  ): Promise<HistoryEvent[]> => {
+    const executionHistoryResult = await this.untilExecutionCompletes(
+      await sfnClient,
+      executionResponse
+    );
+    return executionHistoryResult?.events?.filter(criteria) as HistoryEvent[];
+  };
+  sleep = (milliseconds: number) =>
+    Promise.resolve((resolve: (arg: string) => unknown) =>
+      setTimeout(() => {
+        resolve(""), milliseconds;
+      })
+    );
+
+  createSfnClient = async (): Promise<SFNClient> => {
+    const container = await this.getContainer();
+    return new SFNClient({
+      endpoint: `http://${container.getHost()}:${container.getMappedPort(
+        8083
+      )}`,
+      credentials: {
+        accessKeyId:
+          process.env.AWS_ACCESS_KEY_ID ||
+          StepFunctionConstants.AWS_ACCESS_KEY_ID,
+        secretAccessKey:
+          process.env.AWS_SECRET_ACCESS_KEY ||
+          StepFunctionConstants.AWS_SECRET_ACCESS_KEY,
+        sessionToken: process.env.AWS_SESSION_TOKEN || "local",
+      },
+      region:
+        process.env.AWS_DEFAULT_REGION ||
+        StepFunctionConstants.AWS_DEFAULT_REGION,
+      disableHostPrefix: true,
+    });
+  };
+
+  createTestContainer = async (): Promise<StartedTestContainer> => {
+    const container = await new GenericContainer(
+      "amazon/aws-stepfunctions-local"
+    )
+      .withEnvironment({
+        AWS_SECRET_ACCESS_KEY:
+          process.env.AWS_SECRET_ACCESS_KEY ||
+          StepFunctionConstants.AWS_SECRET_ACCESS_KEY,
+        AWS_ACCOUNT_ID:
+          process.env.AWS_ACCOUNT_ID || StepFunctionConstants.AWS_ACCOUNT_ID,
+        SFN_MOCK_CONFIG:
+          process.env.SFN_MOCK_CONFIG ||
+          StepFunctionConstants.mockFileContainerPath,
+        AWS_DEFAULT_REGION: process.env.AWS_DEFAULT_REGION || "local",
+        AWS_ACCESS_KEY_ID:
+          process.env.AWS_ACCESS_KEY_ID ||
+          StepFunctionConstants.AWS_ACCESS_KEY_ID,
+        AWS_SESSION_TOKEN: process.env.AWS_SESSION_TOKEN || "local",
+      })
+      .withExposedPorts(8083)
+      .withStartupTimeout(10_000)
+      .start();
+
+    this.sleep(10_000);
+    return container;
+  };
+  createStateMachine = async (
+    sfnClient: Promise<SFNClient>,
+    stateMachine?: DescribeStateMachineCommandOutput
+  ) => {
+    const createStateMachineResponse = await (
+      await sfnClient
+    ).send(
+      new CreateStateMachineCommand({
+        name: stateMachine?.name || StepFunctionConstants.STATE_MACHINE_NAME,
+        definition:
+          stateMachine?.definition || StepFunctionConstants.STATE_MACHINE_ASL,
+        roleArn:
+          process.env.STATE_MACHINE_ROLE || StepFunctionConstants.DUMMY_ROLE,
+        type: StateMachineType.STANDARD,
+      })
+    );
+    return createStateMachineResponse;
+  };
+
+  untilExecutionCompletes = async (
+    sfnClient: SFNClient,
+    executionResponse: StartExecutionCommandOutput,
+    retries = MAX_RETRIES
+  ): Promise<GetExecutionHistoryCommandOutput> => {
+    try {
+      const historyResponse = await this.getExecutionHistory(
+        sfnClient,
+        executionResponse.executionArn
+      );
+      if (this.executionState(historyResponse, "ExecutionSucceeded")) {
+        return historyResponse;
+      }
+      if (retries > 0) {
+        await this.sleep(1_000);
+        return this.untilExecutionCompletes(
+          sfnClient,
+          executionResponse,
+          retries - 1
+        );
+      }
+      throw new Error(`Execution did not complete successfully`);
+    } catch (error: unknown) {
+      if (
+        error instanceof ExecutionDoesNotExist &&
+        error.name === "ExecutionDoesNotExist" &&
+        retries > 0
+      ) {
+        await this.sleep(1_000);
+        return this.untilExecutionCompletes(
+          sfnClient,
+          executionResponse,
+          retries - 1
+        );
+      } else {
+        await this.sleep(1_000);
+        return this.untilExecutionCompletes(
+          sfnClient,
+          executionResponse,
+          retries - 1
+        );
+      }
+    }
+  };
+  getExecutionHistory = async (
+    sfnClient: SFNClient,
+    executionArn?: string
+  ): Promise<GetExecutionHistoryCommandOutput> => {
+    return await sfnClient.send(
+      new GetExecutionHistoryCommand({
+        executionArn,
+      })
+    );
+  };
+  executionState = (
+    history: GetExecutionHistoryCommandOutput,
+    state: string
+  ): boolean => {
+    return (
+      history?.events?.filter((event) => event.type === state).length === 1
+    );
+  };
+  describeStepFunction = async (): Promise<
+    DescribeStateMachineCommandOutput | undefined
+  > => {
+    try {
+      const sfnClient = Promise.resolve(
+        new SFNClient({
+          region: process.env.AWS_DEFAULT_REGION,
+          disableHostPrefix: true,
+        })
+      );
+      return await (
+        await sfnClient
+      ).send(
+        new DescribeStateMachineCommand({
+          stateMachineArn:
+            process.env.STATE_MACHINE_ARN ||
+            ((await this.createStateMachine(sfnClient))
+              .stateMachineArn as string),
+        })
+      );
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        return Promise.resolve(undefined);
+      }
+    }
+  };
+}

--- a/integration-tests/tests/mocked/abandon/sfn-container-helper.ts
+++ b/integration-tests/tests/mocked/abandon/sfn-container-helper.ts
@@ -1,7 +1,6 @@
 import {
   CreateStateMachineCommand,
-  DescribeStateMachineCommand,
-  DescribeStateMachineCommandOutput,
+  CreateStateMachineCommandOutput,
   ExecutionDoesNotExist,
   GetExecutionHistoryCommand,
   GetExecutionHistoryCommandOutput,
@@ -11,109 +10,79 @@ import {
   StartExecutionCommandOutput,
   StateMachineType,
 } from "@aws-sdk/client-sfn";
-import { StartedTestContainer, GenericContainer } from "testcontainers";
-import fs from "fs";
-import path from "path";
+import { GenericContainer, StartedTestContainer } from "testcontainers";
 import { StepFunctionConstants } from "./sfn-constants";
 
 const MAX_RETRIES = 10;
+
+enum ExecutionStatus {
+  success = "ExecutionSucceeded",
+  fail = "ExecutionFailed",
+}
 
 export class SfnContainerHelper {
   private sfnClient: Promise<SFNClient>;
   private composeEnvironment: Promise<StartedTestContainer>;
 
-  public constructor(
-    private readonly mockContent?: string,
-    private tempFilePath?: string
-  ) {
-    this.composeEnvironment = Promise.resolve(this.createTestContainer());
-    this.sfnClient = Promise.resolve(this.createSfnClient());
+  constructor() {
+    this.composeEnvironment = this.createTestContainer();
+    this.sfnClient = this.createSfnClient();
   }
 
-  public getContainer = async () => {
+  public async getContainer(): Promise<StartedTestContainer> {
     const container = await this.composeEnvironment;
-    if (this.mockContent) {
-      this.tempFilePath = this.getFileForPartialMock();
-      await this.copyFileToContainer(container, this.tempFilePath);
-    } else {
-      await this.copyFileToContainer(container);
-    }
-    // (await container.logs())
-    // .on("data", line => console.log(line))
-    // .on("err", line => console.error(line))
-    // .on("end", () => console.log("Stream closed"));
+    this.copyFileToContainer(container);
     return container;
-  };
-
-  getFileForPartialMock = () => {
-    if (!this.mockContent)
-      throw Error("MockContent not supplied for partial mockconfigfile");
-
-    this.tempFilePath = path.join(__dirname, "tempFile.json");
-    fs.writeFileSync(this.tempFilePath, this.mockContent, "utf-8");
-    return this.tempFilePath;
-  };
-
-  private releasePartialMockConfigfile() {
-    if (this.tempFilePath) {
-      fs.unlinkSync(this.tempFilePath);
-    }
   }
 
-  private async copyFileToContainer(
-    container: StartedTestContainer,
-    source?: string
-  ) {
-    const copyConfig = [
-      {
-        source: source || StepFunctionConstants.mockFileHostPath,
-        target: StepFunctionConstants.mockFileContainerPath,
-      },
-    ];
-    await container.copyFilesToContainer(copyConfig);
+  public async shutDown(): Promise<void> {
+    const container = await this.composeEnvironment;
+    await container.stop();
   }
-  public shutDown = async () => {
-    await (await this.composeEnvironment)?.stop();
-    this.releasePartialMockConfigfile();
-  };
 
-  public startStepFunctionExecution = async (
+  public async startStepFunctionExecution(
     testName: string,
-    stepFunctionInput: string,
-    stateMachine?: DescribeStateMachineCommandOutput
-  ): Promise<StartExecutionCommandOutput> => {
+    stepFunctionInput: string
+  ): Promise<StartExecutionCommandOutput> {
     const stateMachineArn = `${
-      (await this.createStateMachine(this.sfnClient, stateMachine))
-        .stateMachineArn as string
+      (await this.createStateMachine()).stateMachineArn as string
     }#${testName}`;
-    return await (
-      await this.sfnClient
-    ).send(
+    return (await this.sfnClient).send(
       new StartExecutionCommand({
         stateMachineArn,
         input: stepFunctionInput,
       })
     );
-  };
-  public waitFor = async (
+  }
+
+  public async waitFor(
     criteria: (event: HistoryEvent) => boolean,
     executionResponse: StartExecutionCommandOutput,
     sfnClient: Promise<SFNClient> = this.sfnClient
-  ): Promise<HistoryEvent[]> => {
+  ): Promise<HistoryEvent[]> {
     const executionHistoryResult = await this.untilExecutionCompletes(
       await sfnClient,
       executionResponse
     );
     return executionHistoryResult?.events?.filter(criteria) as HistoryEvent[];
-  };
-  sleep = (milliseconds: number) =>
-    Promise.resolve((resolve: (arg: string) => unknown) =>
-      setTimeout(() => {
-        resolve(""), milliseconds;
-      })
-    );
+  }
 
-  createSfnClient = async (): Promise<SFNClient> => {
+  private sleep(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+  }
+
+  private async copyFileToContainer(
+    container: StartedTestContainer
+  ): Promise<void> {
+    await container.copyFilesToContainer([
+      {
+        source: StepFunctionConstants.mockFileHostPath,
+        target: StepFunctionConstants.mockFileContainerPath,
+      },
+    ]);
+  }
+
+  private async createSfnClient(): Promise<SFNClient> {
     const container = await this.getContainer();
     return new SFNClient({
       endpoint: `http://${container.getHost()}:${container.getMappedPort(
@@ -133,9 +102,9 @@ export class SfnContainerHelper {
         StepFunctionConstants.AWS_DEFAULT_REGION,
       disableHostPrefix: true,
     });
-  };
+  }
 
-  createTestContainer = async (): Promise<StartedTestContainer> => {
+  private async createTestContainer(): Promise<StartedTestContainer> {
     const container = await new GenericContainer(
       "amazon/aws-stepfunctions-local"
     )
@@ -158,39 +127,39 @@ export class SfnContainerHelper {
       .withStartupTimeout(10_000)
       .start();
 
-    this.sleep(10_000);
+    await this.sleep(10_000);
     return container;
-  };
-  createStateMachine = async (
-    sfnClient: Promise<SFNClient>,
-    stateMachine?: DescribeStateMachineCommandOutput
-  ) => {
+  }
+
+  private async createStateMachine(): Promise<CreateStateMachineCommandOutput> {
     const createStateMachineResponse = await (
-      await sfnClient
+      await this.sfnClient
     ).send(
       new CreateStateMachineCommand({
-        name: stateMachine?.name || StepFunctionConstants.STATE_MACHINE_NAME,
-        definition:
-          stateMachine?.definition || StepFunctionConstants.STATE_MACHINE_ASL,
+        name: StepFunctionConstants.STATE_MACHINE_NAME,
+        definition: StepFunctionConstants.STATE_MACHINE_ASL,
         roleArn:
           process.env.STATE_MACHINE_ROLE || StepFunctionConstants.DUMMY_ROLE,
         type: StateMachineType.STANDARD,
       })
     );
     return createStateMachineResponse;
-  };
+  }
 
-  untilExecutionCompletes = async (
+  private async untilExecutionCompletes(
     sfnClient: SFNClient,
     executionResponse: StartExecutionCommandOutput,
     retries = MAX_RETRIES
-  ): Promise<GetExecutionHistoryCommandOutput> => {
+  ): Promise<GetExecutionHistoryCommandOutput> {
     try {
       const historyResponse = await this.getExecutionHistory(
         sfnClient,
         executionResponse.executionArn
       );
-      if (this.executionState(historyResponse, "ExecutionSucceeded")) {
+      if (
+        this.executionState(historyResponse, ExecutionStatus.success) ||
+        this.executionState(historyResponse, ExecutionStatus.fail)
+      ) {
         return historyResponse;
       }
       if (retries > 0) {
@@ -202,7 +171,7 @@ export class SfnContainerHelper {
         );
       }
       throw new Error(`Execution did not complete successfully`);
-    } catch (error: unknown) {
+    } catch (error) {
       if (
         error instanceof ExecutionDoesNotExist &&
         error.name === "ExecutionDoesNotExist" &&
@@ -223,49 +192,25 @@ export class SfnContainerHelper {
         );
       }
     }
-  };
-  getExecutionHistory = async (
+  }
+
+  private async getExecutionHistory(
     sfnClient: SFNClient,
     executionArn?: string
-  ): Promise<GetExecutionHistoryCommandOutput> => {
+  ): Promise<GetExecutionHistoryCommandOutput> {
     return await sfnClient.send(
       new GetExecutionHistoryCommand({
         executionArn,
       })
     );
-  };
-  executionState = (
+  }
+
+  private executionState(
     history: GetExecutionHistoryCommandOutput,
     state: string
-  ): boolean => {
+  ): boolean {
     return (
       history?.events?.filter((event) => event.type === state).length === 1
     );
-  };
-  describeStepFunction = async (): Promise<
-    DescribeStateMachineCommandOutput | undefined
-  > => {
-    try {
-      const sfnClient = Promise.resolve(
-        new SFNClient({
-          region: process.env.AWS_DEFAULT_REGION,
-          disableHostPrefix: true,
-        })
-      );
-      return await (
-        await sfnClient
-      ).send(
-        new DescribeStateMachineCommand({
-          stateMachineArn:
-            process.env.STATE_MACHINE_ARN ||
-            ((await this.createStateMachine(sfnClient))
-              .stateMachineArn as string),
-        })
-      );
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        return Promise.resolve(undefined);
-      }
-    }
-  };
+  }
 }

--- a/integration-tests/tests/mocked/check-session/sfn-container-helper.ts
+++ b/integration-tests/tests/mocked/check-session/sfn-container-helper.ts
@@ -1,7 +1,6 @@
 import {
   CreateStateMachineCommand,
-  DescribeStateMachineCommand,
-  DescribeStateMachineCommandOutput,
+  CreateStateMachineCommandOutput,
   ExecutionDoesNotExist,
   GetExecutionHistoryCommand,
   GetExecutionHistoryCommandOutput,
@@ -11,109 +10,79 @@ import {
   StartExecutionCommandOutput,
   StateMachineType,
 } from "@aws-sdk/client-sfn";
-import { StartedTestContainer, GenericContainer } from "testcontainers";
-import fs from "fs";
-import path from "path";
+import { GenericContainer, StartedTestContainer } from "testcontainers";
 import { StepFunctionConstants } from "./sfn-constants";
 
 const MAX_RETRIES = 10;
+
+enum ExecutionStatus {
+  success = "ExecutionSucceeded",
+  fail = "ExecutionFailed",
+}
 
 export class SfnContainerHelper {
   private sfnClient: Promise<SFNClient>;
   private composeEnvironment: Promise<StartedTestContainer>;
 
-  public constructor(
-    private readonly mockContent?: string,
-    private tempFilePath?: string
-  ) {
-    this.composeEnvironment = Promise.resolve(this.createTestContainer());
-    this.sfnClient = Promise.resolve(this.createSfnClient());
+  constructor() {
+    this.composeEnvironment = this.createTestContainer();
+    this.sfnClient = this.createSfnClient();
   }
 
-  public getContainer = async () => {
+  public async getContainer(): Promise<StartedTestContainer> {
     const container = await this.composeEnvironment;
-    if (this.mockContent) {
-      this.tempFilePath = this.getFileForPartialMock();
-      await this.copyFileToContainer(container, this.tempFilePath);
-    } else {
-      await this.copyFileToContainer(container);
-    }
-    // (await container.logs())
-    // .on("data", line => console.log(line))
-    // .on("err", line => console.error(line))
-    // .on("end", () => console.log("Stream closed"));
+    this.copyFileToContainer(container);
     return container;
-  };
-
-  getFileForPartialMock = () => {
-    if (!this.mockContent)
-      throw Error("MockContent not supplied for partial mockconfigfile");
-
-    this.tempFilePath = path.join(__dirname, "tempFile.json");
-    fs.writeFileSync(this.tempFilePath, this.mockContent, "utf-8");
-    return this.tempFilePath;
-  };
-
-  private releasePartialMockConfigfile() {
-    if (this.tempFilePath) {
-      fs.unlinkSync(this.tempFilePath);
-    }
   }
 
-  private async copyFileToContainer(
-    container: StartedTestContainer,
-    source?: string
-  ) {
-    const copyConfig = [
-      {
-        source: source || StepFunctionConstants.mockFileHostPath,
-        target: StepFunctionConstants.mockFileContainerPath,
-      },
-    ];
-    await container.copyFilesToContainer(copyConfig);
+  public async shutDown(): Promise<void> {
+    const container = await this.composeEnvironment;
+    await container.stop();
   }
-  public shutDown = async () => {
-    await (await this.composeEnvironment)?.stop();
-    this.releasePartialMockConfigfile();
-  };
 
-  public startStepFunctionExecution = async (
+  public async startStepFunctionExecution(
     testName: string,
-    stepFunctionInput: string,
-    stateMachine?: DescribeStateMachineCommandOutput
-  ): Promise<StartExecutionCommandOutput> => {
+    stepFunctionInput: string
+  ): Promise<StartExecutionCommandOutput> {
     const stateMachineArn = `${
-      (await this.createStateMachine(this.sfnClient, stateMachine))
-        .stateMachineArn as string
+      (await this.createStateMachine()).stateMachineArn as string
     }#${testName}`;
-    return await (
-      await this.sfnClient
-    ).send(
+    return (await this.sfnClient).send(
       new StartExecutionCommand({
         stateMachineArn,
         input: stepFunctionInput,
       })
     );
-  };
-  public waitFor = async (
+  }
+
+  public async waitFor(
     criteria: (event: HistoryEvent) => boolean,
     executionResponse: StartExecutionCommandOutput,
     sfnClient: Promise<SFNClient> = this.sfnClient
-  ): Promise<HistoryEvent[]> => {
+  ): Promise<HistoryEvent[]> {
     const executionHistoryResult = await this.untilExecutionCompletes(
       await sfnClient,
       executionResponse
     );
     return executionHistoryResult?.events?.filter(criteria) as HistoryEvent[];
-  };
-  sleep = (milliseconds: number) =>
-    Promise.resolve((resolve: (arg: string) => unknown) =>
-      setTimeout(() => {
-        resolve(""), milliseconds;
-      })
-    );
+  }
 
-  createSfnClient = async (): Promise<SFNClient> => {
+  private sleep(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+  }
+
+  private async copyFileToContainer(
+    container: StartedTestContainer
+  ): Promise<void> {
+    await container.copyFilesToContainer([
+      {
+        source: StepFunctionConstants.mockFileHostPath,
+        target: StepFunctionConstants.mockFileContainerPath,
+      },
+    ]);
+  }
+
+  private async createSfnClient(): Promise<SFNClient> {
     const container = await this.getContainer();
     return new SFNClient({
       endpoint: `http://${container.getHost()}:${container.getMappedPort(
@@ -133,9 +102,9 @@ export class SfnContainerHelper {
         StepFunctionConstants.AWS_DEFAULT_REGION,
       disableHostPrefix: true,
     });
-  };
+  }
 
-  createTestContainer = async (): Promise<StartedTestContainer> => {
+  private async createTestContainer(): Promise<StartedTestContainer> {
     const container = await new GenericContainer(
       "amazon/aws-stepfunctions-local"
     )
@@ -158,39 +127,39 @@ export class SfnContainerHelper {
       .withStartupTimeout(10_000)
       .start();
 
-    this.sleep(10_000);
+    await this.sleep(10_000);
     return container;
-  };
-  createStateMachine = async (
-    sfnClient: Promise<SFNClient>,
-    stateMachine?: DescribeStateMachineCommandOutput
-  ) => {
+  }
+
+  private async createStateMachine(): Promise<CreateStateMachineCommandOutput> {
     const createStateMachineResponse = await (
-      await sfnClient
+      await this.sfnClient
     ).send(
       new CreateStateMachineCommand({
-        name: stateMachine?.name || StepFunctionConstants.STATE_MACHINE_NAME,
-        definition:
-          stateMachine?.definition || StepFunctionConstants.STATE_MACHINE_ASL,
+        name: StepFunctionConstants.STATE_MACHINE_NAME,
+        definition: StepFunctionConstants.STATE_MACHINE_ASL,
         roleArn:
           process.env.STATE_MACHINE_ROLE || StepFunctionConstants.DUMMY_ROLE,
         type: StateMachineType.STANDARD,
       })
     );
     return createStateMachineResponse;
-  };
+  }
 
-  untilExecutionCompletes = async (
+  private async untilExecutionCompletes(
     sfnClient: SFNClient,
     executionResponse: StartExecutionCommandOutput,
     retries = MAX_RETRIES
-  ): Promise<GetExecutionHistoryCommandOutput> => {
+  ): Promise<GetExecutionHistoryCommandOutput> {
     try {
       const historyResponse = await this.getExecutionHistory(
         sfnClient,
         executionResponse.executionArn
       );
-      if (this.executionState(historyResponse, "ExecutionSucceeded")) {
+      if (
+        this.executionState(historyResponse, ExecutionStatus.success) ||
+        this.executionState(historyResponse, ExecutionStatus.fail)
+      ) {
         return historyResponse;
       }
       if (retries > 0) {
@@ -202,7 +171,7 @@ export class SfnContainerHelper {
         );
       }
       throw new Error(`Execution did not complete successfully`);
-    } catch (error: unknown) {
+    } catch (error) {
       if (
         error instanceof ExecutionDoesNotExist &&
         error.name === "ExecutionDoesNotExist" &&
@@ -223,49 +192,25 @@ export class SfnContainerHelper {
         );
       }
     }
-  };
-  getExecutionHistory = async (
+  }
+
+  private async getExecutionHistory(
     sfnClient: SFNClient,
     executionArn?: string
-  ): Promise<GetExecutionHistoryCommandOutput> => {
+  ): Promise<GetExecutionHistoryCommandOutput> {
     return await sfnClient.send(
       new GetExecutionHistoryCommand({
         executionArn,
       })
     );
-  };
-  executionState = (
+  }
+
+  private executionState(
     history: GetExecutionHistoryCommandOutput,
     state: string
-  ): boolean => {
+  ): boolean {
     return (
       history?.events?.filter((event) => event.type === state).length === 1
     );
-  };
-  describeStepFunction = async (): Promise<
-    DescribeStateMachineCommandOutput | undefined
-  > => {
-    try {
-      const sfnClient = Promise.resolve(
-        new SFNClient({
-          region: process.env.AWS_DEFAULT_REGION,
-          disableHostPrefix: true,
-        })
-      );
-      return await (
-        await sfnClient
-      ).send(
-        new DescribeStateMachineCommand({
-          stateMachineArn:
-            process.env.STATE_MACHINE_ARN ||
-            ((await this.createStateMachine(sfnClient))
-              .stateMachineArn as string),
-        })
-      );
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        return Promise.resolve(undefined);
-      }
-    }
-  };
+  }
 }

--- a/step-functions/abandon.asl.json
+++ b/step-functions/abandon.asl.json
@@ -1,0 +1,90 @@
+{
+  "Comment": "A description of my state machine",
+  "StartAt": "Invoke Check Session",
+  "States": {
+    "Invoke Check Session": {
+      "Type": "Task",
+      "Next": "Is Session Valid?",
+      "Parameters": {
+        "StateMachineArn": "${CheckSessionStateMachineArn}",
+        "Input.$": "States.JsonToString($)"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:startSyncExecution",
+      "ResultSelector": {
+        "sessionId.$": "$$.Execution.Input.sessionId",
+        "sessionCheck.$": "States.StringToJson($.Output)"
+      }
+    },
+    "Is Session Valid?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Not": {
+            "Variable": "$.sessionCheck.status",
+            "StringMatches": "SESSION_OK"
+          },
+          "Next": "Err: Invalid Session"
+        }
+      ],
+      "Default": "Fetch SSM Parameters"
+    },
+    "Fetch SSM Parameters": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${SsmParametersFunction}",
+        "Payload": {
+          "parameters": ["/${CommonStackName}/SessionTableName"]
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Clear Auth Code",
+      "ResultPath": "$.parameters",
+      "ResultSelector": {
+        "SessionTableName.$": "$.Payload[0].Value"
+      }
+    },
+    "Clear Auth Code": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Parameters": {
+        "TableName.$": "$.parameters.SessionTableName",
+        "Key": {
+          "sessionId": {
+            "S.$": "$$.Execution.Input.sessionId"
+          }
+        },
+        "UpdateExpression": "SET authorizationCodeExpiryDate = :expiry REMOVE authorizationCode",
+        "ExpressionAttributeValues": {
+          ":expiry": {
+            "N": "0"
+          }
+        }
+      },
+      "Next": "Success",
+      "ResultSelector": {}
+    },
+    "Success": {
+      "Type": "Succeed"
+    },
+    "Err: Invalid Session": {
+      "Type": "Pass",
+      "End": true,
+      "Parameters": {
+        "httpStatus": 400
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes

### What changed and why
Added the /abandon endpoint which when invoked removes the authorizationCode from the session .
This endpoint returns a HTTP 200 with empty body on success.
HTTP 400 if the sessionId is invalid or HTTP 500 on internal errors. 

**Screenshot**
![image](https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/assets/76599223/638d079c-0ff9-4187-b2b9-c91fa516af28)

### Issue tracking
- [OJ-2345](https://govukverify.atlassian.net/browse/OJ-2345)



[OJ-2345]: https://govukverify.atlassian.net/browse/OJ-2345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ