### PR TITLE
BAU: Fix  incorrect response header being returned by issue/credential

### DIFF
--- a/infrastructure/public-api.yaml
+++ b/infrastructure/public-api.yaml
@@ -123,10 +123,7 @@ paths:
           content:
             application/jwt:
               schema:
-                type: string
-                format: application/jwt
-                pattern: ^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]+)$
-                example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+                $ref: "#/components/schemas/VcResponse"
         "400":
           description: 400 Bad Response
           content:
@@ -184,6 +181,12 @@ paths:
 
 components:
   schemas:
+    VcResponse:
+      title: "Vc"
+      type: string
+      format: application/jwt
+      pattern: ^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]+)$
+      example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
     TokenResponse:
       title: "AccessToken"
       required:


### PR DESCRIPTION
## Proposed changes

### What changed and why
The /issue/credential api was returning application/json as the content-type instead of application/jwt. This is needed to be fixed for core as they use application/jwt on their side. 
