### PR TITLE
OJ-2295: Made default status HTTP 500 for state machines in VTL

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -139,7 +139,7 @@ paths:
               }
         responses:
           default:
-            statusCode: 200
+            statusCode: 500
             responseTemplates:
               application/json: |
                 #set($response = $util.parseJson($input.body))
@@ -181,7 +181,7 @@ paths:
               }
         responses:
           default:
-            statusCode: 200
+            statusCode: 500
             responseTemplates:
               application/json: |
                 #set($response = $util.parseJson($input.body))

--- a/infrastructure/public-api.yaml
+++ b/infrastructure/public-api.yaml
@@ -160,7 +160,7 @@ paths:
               }
         responses:
           default:
-            statusCode: 200
+            statusCode: 500
             responseTemplates:
               application/jwt: |
                 #set($resp = $util.parseJson($input.body))


### PR DESCRIPTION
## Proposed changes

### Why did it change
Made the default status a HTTP 500 so that if the state unexpectedly fails (e.g. it does not exist), it won't just return a HTTP 200. 

The `StartSyncExecution` will return a `200 OK` response, even if execution fails, because the status code in the API response doesn't reflect function errors. 

### Issue tracking

- [OJ-2295](https://govukverify.atlassian.net/browse/OJ-2295)


[OJ-2295]: https://govukverify.atlassian.net/browse/OJ-2295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ