### PR TITLE
OJ-2436: include birthdate cred subject

### DIFF
--- a/lambdas/credential-subject/src/credential-subject-builder.ts
+++ b/lambdas/credential-subject/src/credential-subject-builder.ts
@@ -6,12 +6,17 @@ type Name = {
   nameParts: Array<NamePart>;
 };
 
+export type BirthDate = {
+  value: string;
+};
+
 export type NamePart = {
   type: string;
   value: string;
 };
 
 export type CredentialSubject = {
+  birthDate: BirthDate[];
   name: Array<Name>;
   socialSecurityRecord: Array<SocialSecurityRecord>;
 };
@@ -19,8 +24,9 @@ export type CredentialSubject = {
 export class CredentialSubjectBuilder {
   private personalNumber!: string;
   private name: Array<NamePart> = [];
+  private birthDate: Array<BirthDate> = [];
 
-  addName(type: string, value: string): CredentialSubjectBuilder {
+  addName(type: string, value: string): this {
     this.name.push({ type, value } as NamePart);
 
     return this;
@@ -29,22 +35,32 @@ export class CredentialSubjectBuilder {
     this.name = names;
     return this;
   }
-  setPersonalNumber(personalNumber: string): CredentialSubjectBuilder {
+  setPersonalNumber(personalNumber: string): this {
     this.personalNumber = personalNumber;
+
+    return this;
+  }
+
+  setBirthDate(birthDates: Array<BirthDate>): this {
+    this.birthDate = birthDates;
+
     return this;
   }
 
   build(): CredentialSubject {
     const credentialSubject = {} as CredentialSubject;
-    if (this.personalNumber) {
+    if (this?.personalNumber) {
       credentialSubject.socialSecurityRecord = [
         {
           personalNumber: this.personalNumber as string,
         } as SocialSecurityRecord,
       ];
     }
-    if (this.name.length != 0) {
-      credentialSubject.name = [{ nameParts: this.name } as Name];
+    if (this?.birthDate?.length) {
+      credentialSubject.birthDate = this.birthDate;
+    }
+    if (this?.name?.length) {
+      credentialSubject.name = [{ nameParts: this?.name } as Name];
     }
     return credentialSubject;
   }

--- a/lambdas/credential-subject/src/credential-subject-handler.ts
+++ b/lambdas/credential-subject/src/credential-subject-handler.ts
@@ -2,6 +2,7 @@ import { LambdaInterface } from "@aws-lambda-powertools/commons";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { UserInfoEvent } from "./user-info-event";
 import {
+  BirthDate,
   CredentialSubject,
   CredentialSubjectBuilder,
   NamePart,
@@ -16,8 +17,13 @@ export class CredentialSubjectHandler implements LambdaInterface {
   ): Promise<CredentialSubject> {
     try {
       return credentialSubjectBuilder
-        .setPersonalNumber(event.nino)
+        .setPersonalNumber(event?.nino)
         .addNames(this.convertToCredentialSubjectNames(event))
+        .setBirthDate(
+          event?.userInfoEvent?.Items[0]?.birthDates?.L?.map(
+            (birthDate) => ({ value: birthDate.M.value.S }) as BirthDate
+          )
+        )
         .build();
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
@@ -29,7 +35,7 @@ export class CredentialSubjectHandler implements LambdaInterface {
   private convertToCredentialSubjectNames = (
     event: UserInfoEvent
   ): Array<NamePart> => {
-    return event.userInfoEvent.Items[0].names.L[0].M.nameParts.L.map(
+    return event?.userInfoEvent?.Items[0]?.names?.L[0]?.M?.nameParts?.L?.map(
       (part) => ({ type: part.M.type.S, value: part.M.value.S }) as NamePart
     );
   };

--- a/lambdas/credential-subject/src/user-info-event.ts
+++ b/lambdas/credential-subject/src/user-info-event.ts
@@ -24,6 +24,17 @@ export type UserInfoEvent = {
             },
           ];
         };
+        birthDates: {
+          L: [
+            {
+              M: {
+                value: {
+                  S: string;
+                };
+              };
+            },
+          ];
+        };
       },
     ];
   };
@@ -48,6 +59,38 @@ export const mockUserInfoEventItem = {
                 },
               },
             },
+          ],
+        },
+      },
+    ],
+  },
+  nino: "BB000001D",
+};
+
+export const mockUserInfoEventItemWithBirthDates = {
+  userInfoEvent: {
+    Items: [
+      {
+        names: {
+          L: [
+            {
+              M: {
+                nameParts: {
+                  L: [
+                    { M: { type: { S: "GivenName" }, value: { S: "Rishi" } } },
+                    {
+                      M: { type: { S: "FamilyName" }, value: { S: "Johnson" } },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+        birthDates: {
+          L: [
+            { M: { value: { S: "2000-01-01" } } },
+            { M: { value: { S: "1990-05-15" } } },
           ],
         },
       },

--- a/lambdas/credential-subject/tests/credential-subject-builder.test.ts
+++ b/lambdas/credential-subject/tests/credential-subject-builder.test.ts
@@ -39,4 +39,28 @@ describe("CredentialSubjectBuilder", () => {
     expect(credentialSubject.name).toHaveLength(1);
     expect(credentialSubject.name[0].nameParts).toEqual(nameParts);
   });
+
+  it("should create a CredentialSubject with name, birthDate", () => {
+    const nameParts = [
+      { type: "GivenName", value: "John" },
+      { type: "FamilyName", value: "Doe" },
+    ];
+
+    const birthDates = [{ value: "15-01-1990" }, { value: "20-05-2000" }];
+
+    const credentialSubject = new CredentialSubjectBuilder()
+      .addNames(nameParts)
+      .setBirthDate(birthDates)
+      .build();
+
+    expect(credentialSubject.name).toHaveLength(1);
+    expect(credentialSubject.name[0].nameParts).toEqual(nameParts);
+
+    expect(credentialSubject.birthDate).toHaveLength(2);
+    expect(credentialSubject.birthDate).toEqual(birthDates);
+  });
+
+  it("should return empty object", () => {
+    expect(new CredentialSubjectBuilder().build()).toEqual({});
+  });
 });

--- a/lambdas/credential-subject/tests/credential-subject-handler.test.ts
+++ b/lambdas/credential-subject/tests/credential-subject-handler.test.ts
@@ -1,45 +1,67 @@
 import { CredentialSubjectHandler } from "../src/credential-subject-handler";
-import { UserInfoEvent, mockUserInfoEventItem } from "../src/user-info-event";
+import {
+  UserInfoEvent,
+  mockUserInfoEventItem,
+  mockUserInfoEventItemWithBirthDates,
+} from "../src/user-info-event";
 
 describe("credential-subject-handler.ts", () => {
+  const expectedCredentialSubject = {
+    name: [
+      {
+        nameParts: [
+          {
+            value: "Rishi",
+            type: "GivenName",
+          },
+          {
+            value: "Johnson",
+            type: "FamilyName",
+          },
+        ],
+      },
+    ],
+    socialSecurityRecord: [
+      {
+        personalNumber: "BB000001D",
+      },
+    ],
+  };
+
   it("should input userInfoEvent and return credentialSubject", async () => {
     const handler = new CredentialSubjectHandler();
     const credentialSubject = await handler.handler(
       mockUserInfoEventItem as UserInfoEvent,
       {} as unknown
     );
-    const expectedCredentialSubject = {
-      name: [
-        {
-          nameParts: [
-            {
-              value: "Rishi",
-              type: "GivenName",
-            },
-            {
-              value: "Johnson",
-              type: "FamilyName",
-            },
-          ],
-        },
-      ],
-      socialSecurityRecord: [
-        {
-          personalNumber: "BB000001D",
-        },
-      ],
-    };
     expect(credentialSubject).toEqual(expectedCredentialSubject);
   });
 
-  it("should return undefined when passed in an emtpy object", async () => {
+  it("should input userInfoEvent with birthDates and return credentialSubject", async () => {
+    const expectedCredentialSubjectWithBirthDates = {
+      ...expectedCredentialSubject,
+      birthDate: [{ value: "2000-01-01" }, { value: "1990-05-15" }],
+    };
     const handler = new CredentialSubjectHandler();
-    const invalidEvent = {} as UserInfoEvent;
-
-    await expect(async () => {
-      await handler.handler(invalidEvent, {} as unknown);
-    }).rejects.toThrowError(
-      "Cannot read properties of undefined (reading 'Items')"
+    const credentialSubject = await handler.handler(
+      mockUserInfoEventItemWithBirthDates as UserInfoEvent,
+      {} as unknown
     );
+
+    expect(credentialSubject).toEqual(expectedCredentialSubjectWithBirthDates);
   });
+
+  it.each([{}, undefined, null])(
+    "should return {} when passed %s",
+    async (payload) => {
+      const handler = new CredentialSubjectHandler();
+
+      const credentialSubject = await handler.handler(
+        payload as UserInfoEvent,
+        {} as unknown
+      );
+
+      expect(credentialSubject).toEqual({});
+    }
+  );
 });


### PR DESCRIPTION
## Proposed changes

see https://govukverify.atlassian.net/browse/OJ-2436

This is the **first part** of introducing, birthdate into nino check VC
Next would be to incorporate birthday into the VC

### What changed

According to https://govukverify.atlassian.net/wiki/spaces/Architecture/pages/3819930131/NINO+record+check+Technical+specification

### Why did it change

This was used intially  https://github.com/govuk-one-login/architecture/blob/main/rfc/0024-identity-vc-for-checks.md#example-16---valid-national-insurance-number

### Issue tracking

- [OJ-2436](https://govukverify.atlassian.net/browse/OJ-2436)



[OJ-2436]: https://govukverify.atlassian.net/browse/OJ-2436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ