### PR TITLE
OJ-2436: Reflecting inclusion of birthday in integration-tests

### DIFF
--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential.test.ts
@@ -142,11 +142,10 @@ describe("nino-issue-credential-happy", () => {
         algorithms: [alg],
       });
 
+      const result = await aVcWithCheckDetailsAndNoCi();
       expect(isValidTimestamp(payload.exp || 0)).toBe(true);
       expect(isValidTimestamp(payload.nbf || 0)).toBe(true);
-      expect(payload).toEqual(
-        expect.objectContaining(aVcWithCheckDetailsAndNoCi())
-      );
+      expect(payload).toEqual(result);
     });
     it("should create a VC with a checkDetail, Validity Score of 2 and no Ci", async () => {
       const startExecutionResult = await getExecutionResult("Bearer happy");
@@ -166,11 +165,11 @@ describe("nino-issue-credential-happy", () => {
         alg: "ES256",
         kid: currentCredentialKmsSigningKeyId,
       });
+
+      const result = await aVcWithCheckDetailsAndNoCi();
       expect(isValidTimestamp(payload.exp)).toBe(true);
       expect(isValidTimestamp(payload.nbf)).toBe(true);
-      expect(payload).toEqual(
-        expect.objectContaining(aVcWithCheckDetailsAndNoCi())
-      );
+      expect(payload).toEqual(result);
     });
   });
   describe("Nino check is unsuccessful", () => {
@@ -224,11 +223,10 @@ describe("nino-issue-credential-happy", () => {
         algorithms: [alg],
       });
 
+      const result = await aVcWithFailedCheckDetailsAndCi();
       expect(isValidTimestamp(payload.exp || 0)).toBe(true);
       expect(isValidTimestamp(payload.nbf || 0)).toBe(true);
-      expect(payload).toEqual(
-        expect.objectContaining(aVcWithFailedCheckDetailAndCi())
-      );
+      expect(payload).toEqual(result);
     });
 
     it("should create a VC with a failedCheckDetail, validity score of 0 and Ci", async () => {
@@ -249,11 +247,11 @@ describe("nino-issue-credential-happy", () => {
         alg: "ES256",
         kid: currentCredentialKmsSigningKeyId,
       });
+
+      const result = await aVcWithFailedCheckDetailsAndCi();
       expect(isValidTimestamp(payload.exp)).toBe(true);
       expect(isValidTimestamp(payload.nbf)).toBe(true);
-      expect(payload).toEqual(
-        expect.objectContaining(aVcWithFailedCheckDetailAndCi())
-      );
+      expect(payload).toEqual(result);
     });
   });
   const getExecutionResult = async (token: string) =>
@@ -295,6 +293,8 @@ describe("nino-issue-credential-happy", () => {
     return {
       iss: `${issuer}`,
       jti: expect.any(String),
+      nbf: expect.any(String),
+      exp: expect.any(String),
       sub: "test",
       vc: {
         "@context": [
@@ -338,7 +338,7 @@ describe("nino-issue-credential-happy", () => {
     };
   };
 
-  const aVcWithFailedCheckDetailAndCi = async () => {
+  const aVcWithFailedCheckDetailsAndCi = async () => {
     const { vc: customClaims, ...standardClaims } = await getBaseVcCredential();
     return {
       ...standardClaims,

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential.test.ts
@@ -330,9 +330,7 @@ describe("nino-issue-credential-happy", () => {
         ...customClaims,
         evidence: [
           {
-            checkDetails: [
-              { checkMethod: "data", identityCheckPolicy: "published" },
-            ],
+            checkDetails: [{ checkMethod: "data" }],
             strengthScore: 2,
             txn: expect.any(String),
             type: "IdentityCheck",
@@ -351,16 +349,14 @@ describe("nino-issue-credential-happy", () => {
         ...customClaims,
         evidence: [
           {
-            failedCheckDetails: [
-              { checkMethod: "data", identityCheckPolicy: "published" },
-            ],
+            failedCheckDetails: [{ checkMethod: "data" }],
+            ci: [expect.any(String)],
             strengthScore: 2,
             txn: expect.any(String),
             type: "IdentityCheck",
             validityScore: 0,
           },
         ],
-        ci: [expect.any(String)],
       },
     };
   };

--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential.test.ts
@@ -293,8 +293,8 @@ describe("nino-issue-credential-happy", () => {
     return {
       iss: `${issuer}`,
       jti: expect.any(String),
-      nbf: expect.any(String),
-      exp: expect.any(String),
+      nbf: expect.any(Number),
+      exp: expect.any(Number),
       sub: "test",
       vc: {
         "@context": [
@@ -308,6 +308,11 @@ describe("nino-issue-credential-happy", () => {
                 { type: "GivenName", value: "Jim" },
                 { type: "FamilyName", value: "Ferguson" },
               ],
+            },
+          ],
+          birthDate: [
+            {
+              value: "1948-04-23",
             },
           ],
           socialSecurityRecord: [{ personalNumber: "AA000003D" }],

--- a/integration-tests/tests/mocked/nino-issue-credential/MockConfigFile.json
+++ b/integration-tests/tests/mocked/nino-issue-credential/MockConfigFile.json
@@ -164,26 +164,6 @@
             }
           },
           "SdkHttpMetadata": {
-            "AllHttpHeaders": {
-              "Server": ["Server"],
-              "Connection": ["keep-alive"],
-              "x-amzn-RequestId": [
-                "UBN5LMPIPOSG6VVSNBII02TEJFVV4KQNSO5AEMVJF66Q9ASUAAJG"
-              ],
-              "x-amz-crc32": ["3691538148"],
-              "Content-Length": ["65"],
-              "Date": ["Tue, 14 Nov 2023 12:29:15 GMT"],
-              "Content-Type": ["application/x-amz-json-1.0"]
-            },
-            "HttpHeaders": {
-              "Connection": "keep-alive",
-              "Content-Length": "65",
-              "Content-Type": "application/x-amz-json-1.0",
-              "Date": "Tue, 14 Nov 2023 12:29:15 GMT",
-              "Server": "Server",
-              "x-amz-crc32": "3691538148",
-              "x-amzn-RequestId": "UBN5LMPIPOSG6VVSNBII02TEJFVV4KQNSO5AEMVJF66Q9ASUAAJG"
-            },
             "HttpStatusCode": 200
           },
           "SdkResponseMetadata": {
@@ -195,7 +175,6 @@
     "CreateCredentialSubject": {
       "0": {
         "Return": {
-          "ExecutedVersion": "$LATEST",
           "Payload": {
             "socialSecurityRecord": [
               {
@@ -215,35 +194,15 @@
                   }
                 ]
               }
+            ],
+            "birthDate": [
+              {
+                "value": "1965-07-08"
+              }
             ]
           },
           "SdkHttpMetadata": {
-            "AllHttpHeaders": {
-              "X-Amz-Executed-Version": ["$LATEST"],
-              "x-amzn-Remapped-Content-Length": ["0"],
-              "Connection": ["keep-alive"],
-              "x-amzn-RequestId": ["1ea2ffe5-3bf3-4907-88ea-8d2aeb974ed9"],
-              "Content-Length": ["158"],
-              "Date": ["Tue, 14 Nov 2023 12:29:16 GMT"],
-              "X-Amzn-Trace-Id": [
-                "root=1-6553681b-2b7cbbce403466dc6c23dc13;sampled=0;lineage=acbd3b6c:0"
-              ],
-              "Content-Type": ["application/json"]
-            },
-            "HttpHeaders": {
-              "Connection": "keep-alive",
-              "Content-Length": "158",
-              "Content-Type": "application/json",
-              "Date": "Tue, 14 Nov 2023 12:29:16 GMT",
-              "X-Amz-Executed-Version": "$LATEST",
-              "x-amzn-Remapped-Content-Length": "0",
-              "x-amzn-RequestId": "1ea2ffe5-3bf3-4907-88ea-8d2aeb974ed9",
-              "X-Amzn-Trace-Id": "root=1-6553681b-2b7cbbce403466dc6c23dc13;sampled=0;lineage=acbd3b6c:0"
-            },
             "HttpStatusCode": 200
-          },
-          "SdkResponseMetadata": {
-            "RequestId": "1ea2ffe5-3bf3-4907-88ea-8d2aeb974ed9"
           },
           "StatusCode": 200
         }
@@ -252,38 +211,12 @@
     "FetchExpTimeAndNBF": {
       "0": {
         "Return": {
-          "ExecutedVersion": "$LATEST",
           "Payload": {
             "nbf": 1699964956131,
             "expiry": 1699972156131
           },
           "SdkHttpMetadata": {
-            "AllHttpHeaders": {
-              "X-Amz-Executed-Version": ["$LATEST"],
-              "x-amzn-Remapped-Content-Length": ["0"],
-              "Connection": ["keep-alive"],
-              "x-amzn-RequestId": ["9c68a67e-6091-48a7-ac92-53af1da8677b"],
-              "Content-Length": ["44"],
-              "Date": ["Tue, 14 Nov 2023 12:29:16 GMT"],
-              "X-Amzn-Trace-Id": [
-                "root=1-6553681b-1f7e69db5b5a8ccd6c13a903;sampled=0;lineage=9be44ed0:0"
-              ],
-              "Content-Type": ["application/json"]
-            },
-            "HttpHeaders": {
-              "Connection": "keep-alive",
-              "Content-Length": "44",
-              "Content-Type": "application/json",
-              "Date": "Tue, 14 Nov 2023 12:29:16 GMT",
-              "X-Amz-Executed-Version": "$LATEST",
-              "x-amzn-Remapped-Content-Length": "0",
-              "x-amzn-RequestId": "9c68a67e-6091-48a7-ac92-53af1da8677b",
-              "X-Amzn-Trace-Id": "root=1-6553681b-1f7e69db5b5a8ccd6c13a903;sampled=0;lineage=9be44ed0:0"
-            },
             "HttpStatusCode": 200
-          },
-          "SdkResponseMetadata": {
-            "RequestId": "9c68a67e-6091-48a7-ac92-53af1da8677b"
           },
           "StatusCode": 200
         }
@@ -351,35 +284,9 @@
     "FetchCI": {
       "0": {
         "Return": {
-          "ExecutedVersion": "$LATEST",
           "Payload": ["AAA"],
           "SdkHttpMetadata": {
-            "AllHttpHeaders": {
-              "X-Amz-Executed-Version": ["$LATEST"],
-              "x-amzn-Remapped-Content-Length": ["0"],
-              "Connection": ["keep-alive"],
-              "x-amzn-RequestId": ["8d137f0e-31be-4d30-a09e-85da3197dbb9"],
-              "Content-Length": ["7"],
-              "Date": ["Mon, 08 Jan 2024 14:20:19 GMT"],
-              "X-Amzn-Trace-Id": [
-                "root=1-659c04a2-6e34b4cf4e19d19b75684a75;sampled=0;lineage=499fa3f8:0"
-              ],
-              "Content-Type": ["application/json"]
-            },
-            "HttpHeaders": {
-              "Connection": "keep-alive",
-              "Content-Length": "7",
-              "Content-Type": "application/json",
-              "Date": "Mon, 08 Jan 2024 14:20:19 GMT",
-              "X-Amz-Executed-Version": "$LATEST",
-              "x-amzn-Remapped-Content-Length": "0",
-              "x-amzn-RequestId": "8d137f0e-31be-4d30-a09e-85da3197dbb9",
-              "X-Amzn-Trace-Id": "root=1-659c04a2-6e34b4cf4e19d19b75684a75;sampled=0;lineage=499fa3f8:0"
-            },
             "HttpStatusCode": 200
-          },
-          "SdkResponseMetadata": {
-            "RequestId": "8d137f0e-31be-4d30-a09e-85da3197dbb9"
           },
           "StatusCode": 200
         }
@@ -388,31 +295,8 @@
     "SignVCClaimSet": {
       "0": {
         "Return": {
-          "ExecutedVersion": "$LATEST",
-          "Payload": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjA5NzZjMTFlLThlZjMtNDY1OS1iN2YyLWVlMGI4NDJiODViZCJ9.eyJ2YyI6eyJldmlkZW5jZSI6W3sidHlwZSI6IklkZW50aXR5Q2hlY2siLCJzdHJlbmd0aFNjb3JlIjoyLCJ2YWxpZGl0eVNjb3JlIjoyLCJjaGVja0RldGFpbHMiOlt7ImNoZWNrTWV0aG9kIjoiZGF0YSIsImlkZW50aXR5Q2hlY2tQb2xpY3kiOiJwdWJsaXNoZWQifV0sInR4biI6IjNmMWQzYmI1LWM2ODgtNGI0NS1hMzgzLTI1ZTY3NjI3NGRmYSJ9XSwiY3JlZGVudGlhbFN1YmplY3QiOnsic29jaWFsU2VjdXJpdHlSZWNvcmQiOlt7InBlcnNvbmFsTnVtYmVyIjoiQUEwMDAwMDNEIn1dLCJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IktFTk5FVEgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJERUNFUlFVRUlSQSJ9XX1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sIkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIiwiaHR0cHM6Ly92b2NhYi5sb25kb24uY2xvdWRhcHBzLmRpZ2l0YWwvY29udGV4dHMvaWRlbnRpdHktdjEuanNvbmxkIl19LCJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOmRiZmFjMGVkLTNlMGEtNDAwOS1hNDgwLWNjNGMyMWY5Mjc1OCIsIm5iZiI6MTcwOTczNDMxMCwiaXNzIjoiaHR0cHM6Ly9yZXZpZXctaGMuZGV2LmFjY291bnQuZ292LnVrIiwiZXhwIjoxNzA5NzQxNTEwLCJqdGkiOiJ1cm46dXVpZDozZmJiZDMwYS00MTJlLTQyZTgtYjJlNC0yOTY5NWY4NzQ2YjMifQ.715JtWTkjEehjLHCfVLWYertqeCpgM5AASlSHgW3YjAKB0AMHHekWGfJWqAnNKFYetD_mKK4zPOdwMfUd8nWJg",
+          "Payload": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjA5NzZjMTFlLThlZjMtNDY1OS1iN2YyLWVlMGI4NDJiODViZCJ9.eyJ2YyI6eyJldmlkZW5jZSI6W3sidHlwZSI6IklkZW50aXR5Q2hlY2siLCJzdHJlbmd0aFNjb3JlIjoyLCJ2YWxpZGl0eVNjb3JlIjoyLCJjaGVja0RldGFpbHMiOlt7ImNoZWNrTWV0aG9kIjoiZGF0YSJ9XSwidHhuIjoiNjVhZTE5ZjUtOGI0Zi00NmQ1LTg4Y2QtNTE3YWRjYTJmMWMwIn1dLCJjcmVkZW50aWFsU3ViamVjdCI6eyJzb2NpYWxTZWN1cml0eVJlY29yZCI6W3sicGVyc29uYWxOdW1iZXIiOiJBQTAwMDAwM0QifV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTY1LTA3LTA4In1dLCJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IktFTk5FVEgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJERUNFUlFVRUlSQSJ9XX1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sIkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIiwiaHR0cHM6Ly92b2NhYi5sb25kb24uY2xvdWRhcHBzLmRpZ2l0YWwvY29udGV4dHMvaWRlbnRpdHktdjEuanNvbmxkIl19LCJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOjA1NzA1MDE2LTQ0OTQtNDc5NC04ZDdkLTdhMWUyNTE2YWY1NiIsIm5iZiI6MTcxMDM5NjU2MywiaXNzIjoiaHR0cHM6Ly9yZXZpZXctaGMuZGV2LmFjY291bnQuZ292LnVrIiwiZXhwIjoxNzEwNDAzNzYzLCJqdGkiOiJ1cm46dXVpZDpmNTQwYjc4Yy05ZTUyLTRhMGYtYjAzMy1jNzhlN2FiMzI3ZWEifQ.BNBgan12MNxiDTm_yDtwr67Q5dbKYyGUOh5WeDHfJqG9GJVdIgCQyMc_pqWsXY6s74T0DEkLhXxD8kr4ZBWFAA",
           "SdkHttpMetadata": {
-            "AllHttpHeaders": {
-              "X-Amz-Executed-Version": ["$LATEST"],
-              "x-amzn-Remapped-Content-Length": ["0"],
-              "Connection": ["keep-alive"],
-              "x-amzn-RequestId": ["20229acd-1926-4994-be1f-752b8767e4bb"],
-              "Content-Length": ["88"],
-              "Date": ["Thu, 23 Nov 2023 15:55:38 GMT"],
-              "X-Amzn-Trace-Id": [
-                "root=1-655f75f9-27f6647873d4d7973877b13e;sampled=0;lineage=43496acb:0"
-              ],
-              "Content-Type": ["application/json"]
-            },
-            "HttpHeaders": {
-              "Connection": "keep-alive",
-              "Content-Length": "88",
-              "Content-Type": "application/json",
-              "Date": "Thu, 23 Nov 2023 15:55:38 GMT",
-              "X-Amz-Executed-Version": "$LATEST",
-              "x-amzn-Remapped-Content-Length": "0",
-              "x-amzn-RequestId": "20229acd-1926-4994-be1f-752b8767e4bb",
-              "X-Amzn-Trace-Id": "root=1-655f75f9-27f6647873d4d7973877b13e;sampled=0;lineage=43496acb:0"
-            },
             "HttpStatusCode": 200
           },
           "SdkResponseMetadata": {

--- a/integration-tests/tests/mocked/nino-issue-credential/nino-issue-credential-happy.test.ts
+++ b/integration-tests/tests/mocked/nino-issue-credential/nino-issue-credential-happy.test.ts
@@ -16,10 +16,9 @@ const expectedPayload = {
         checkDetails: [
           {
             checkMethod: "data",
-            identityCheckPolicy: "published",
           },
         ],
-        txn: "3f1d3bb5-c688-4b45-a383-25e676274dfa",
+        txn: "65ae19f5-8b4f-46d5-88cd-517adca2f1c0",
       },
     ],
     credentialSubject: {
@@ -42,6 +41,11 @@ const expectedPayload = {
           ],
         },
       ],
+      birthDate: [
+        {
+          value: "1965-07-08",
+        },
+      ],
     },
     type: ["VerifiableCredential", "IdentityCheckCredential"],
     "@context": [
@@ -49,11 +53,11 @@ const expectedPayload = {
       "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld",
     ],
   },
-  sub: "urn:fdc:gov.uk:2022:dbfac0ed-3e0a-4009-a480-cc4c21f92758",
-  nbf: 1709734310,
+  sub: "urn:fdc:gov.uk:2022:05705016-4494-4794-8d7d-7a1e2516af56",
+  nbf: 1710396563,
   iss: "https://review-hc.dev.account.gov.uk",
-  exp: 1709741510,
-  jti: "urn:uuid:3fbbd30a-412e-42e8-b2e4-29695f8746b3",
+  exp: 1710403763,
+  jti: "urn:uuid:f540b78c-9e52-4a0f-b033-c78e7ab327ea",
 };
 
 describe("nino-issue-credential-happy", () => {
@@ -71,7 +75,7 @@ describe("nino-issue-credential-happy", () => {
 
   it("should create signed JWT when nino check is successful", async () => {
     const input = JSON.stringify({
-      bearerToken: "Bearer test",
+      bearerToken: "Bearer happy",
     });
     const responseStepFunction = await sfnContainer.startStepFunctionExecution(
       "HappyPath",

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -271,8 +271,7 @@
                     "validityScore": 2,
                     "checkDetails": [
                       {
-                        "checkMethod": "data",
-                        "identityCheckPolicy": "published"
+                        "checkMethod": "data"
                       }
                     ]
                   }


### PR DESCRIPTION
## Proposed changes

PART 2 see PART 1: https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/pull/168

Update VC structure to include birthDate

### What changed

VC structure to now contain birthDate according to https://govukverify.atlassian.net/wiki/spaces/Architecture/pages/3819930131/NINO+record+check+Technical+specification#Successful-NINO-check

### Why did it change

Original implementation referenced VC structure to now contain birthDate according to https://govukverify.atlassian.net/wiki/spaces/Architecture/pages/3819930131/NINO+record+check+Technical+specification#Successful-NINO-check

### Issue tracking

- [OJ-2436](https://govukverify.atlassian.net/browse/OJ-2436)



[OJ-2436]: https://govukverify.atlassian.net/browse/OJ-2436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ