### PR TITLE
OJ-2347: Create 403 on Auth Endpoint

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -23,6 +23,10 @@ paths:
                 $ref: "#/components/schemas/Error"
         "403":
           description: "403 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "500":
           description: "500 response"
           content:

--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -21,6 +21,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "403":
+          description: "403 response"
         "500":
           description: "500 response"
           content:


### PR DESCRIPTION

## Proposed changes
Updated the private-api.yml file to include the 403 response for /authorization endpoint 
### What changed
Updated the private-api.yml file to include the 403 response for /authorization endpoint 

### Why did it change

To run unit tests in the check-hmrc-front repo  

### Issue tracking

- [OJ-2347](https://govukverify.atlassian.net/browse/OJ-2347)

## Checklists

### Other considerations


[OJ-2347]: https://govukverify.atlassian.net/browse/OJ-2347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ