### PR TITLE
OJ-2445: Fix State Machine not generating auth code on 2nd check attempt

### DIFF
--- a/integration-tests/tests/mocked/nino-check/MockConfigFile.json
+++ b/integration-tests/tests/mocked/nino-check/MockConfigFile.json
@@ -2,6 +2,20 @@
   "StateMachines": {
     "nino_check": {
       "TestCases": {
+        "ShouldSuccessOnLastAttempt": {
+          "Invoke Check Session": "CheckSessionSuccess",
+          "Fetch SSM Parameters": "FetchSSMParamsSuccess",
+          "Query User Attempts": "QueryUserAttemptSuccessOn2ndTry",
+          "Query Person Identity Table": "QuerySessionSuccess",
+          "Get OAuth Token": "GetOAuthAccessTokenSuccess",
+          "Publish Audit Event Request Sent": "PublishAuditEventRequestSent",
+          "Call Matching API": "CallMatchingDeceasedAPIFail",
+          "Publish Audit Event Response Received": "PublishAuditEventResponseReceived",
+          "Store Deceased Attempt": "DynamoDbQueryNoResult",
+          "Fetch Auth Code Expiry": "FetchAuthCodeExpirySuccess",
+          "Set Auth Code for Session": "SetAuthCodeSuccess",
+          "Save NINO & sessionId to nino-users table": "SaveNinoSuccess"
+        },
         "APIFailRetrySuccessTest": {
           "Invoke Check Session": "CheckSessionSuccess",
           "Fetch SSM Parameters": "FetchSSMParamsSuccess",

--- a/integration-tests/tests/mocked/nino-check/MockConfigFile.json
+++ b/integration-tests/tests/mocked/nino-check/MockConfigFile.json
@@ -109,7 +109,7 @@
         "HMRCError": {
           "Invoke Check Session": "CheckSessionSuccess",
           "Fetch SSM Parameters": "FetchSSMParamsSuccess",
-          "Query User Attempts": "QueryUserAttemptSuccessOn2ndTry",
+          "Query User Attempts": "DynamoDbQueryNoResult",
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Query Person Identity Table": "QuerySessionSuccess",
           "Get OAuth Token": "GetOAuthAccessTokenSuccess",

--- a/integration-tests/tests/mocked/nino-check/makefile
+++ b/integration-tests/tests/mocked/nino-check/makefile
@@ -12,6 +12,13 @@ create:
 	--name ${STATE_MACHINE_NAME} \
 	--role-arn "arn:aws:iam::123456789012:role/DummyRole" \
 	--no-cli-pager
+ShouldSuccessOnLastAttempt:
+	aws stepfunctions start-execution \
+	--endpoint http://localhost:8083 \
+	--name happyPathExecution \
+	--state-machine ${STATE_MACHINE_ARN}#ShouldSuccessOnLastAttempt \
+	--input '{ "sessionId": "12345", "nino": "AA000003D" }' \
+	--no-cli-pager
 happy1stTry:
 	aws stepfunctions start-execution \
 	--endpoint http://localhost:8083 \

--- a/integration-tests/tests/mocked/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/tests/mocked/nino-check/nino-check-happy.test.ts
@@ -27,7 +27,7 @@ describe("nino-check-happy", () => {
     );
     const results = await sfnContainer.waitFor(
       (event: HistoryEvent) =>
-        event?.stateExitedEventDetails?.name === "Nino check successful",
+        event?.stateExitedEventDetails?.name === "Nino check completed",
       responseStepFunction
     );
     expect(results[0].stateExitedEventDetails?.output).toEqual(
@@ -49,7 +49,7 @@ describe("nino-check-happy", () => {
     );
     const results = await sfnContainer.waitFor(
       (event: HistoryEvent) =>
-        event?.stateExitedEventDetails?.name === "Nino check successful",
+        event?.stateExitedEventDetails?.name === "Nino check completed",
       responseStepFunction
     );
     expect(results[0].stateExitedEventDetails?.output).toEqual(

--- a/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/mocked/nino-check/nino-check-unhappy.test.ts
@@ -16,6 +16,24 @@ describe("nino-check-unhappy", () => {
     expect(sfnContainer.getContainer()).toBeDefined();
   });
 
+  it("should succeed on the users last attempt", async () => {
+    const input = JSON.stringify({
+      nino: "AA000003D",
+      sessionId: "12345",
+    });
+    const responseStepFunction = await sfnContainer.startStepFunctionExecution(
+      "ShouldSuccessOnLastAttempt",
+      input
+    );
+    const results = await sfnContainer.waitFor(
+      (event: HistoryEvent) => event?.type === "ExecutionSucceeded",
+      responseStepFunction
+    );
+    expect(results[0].executionSucceededEventDetails?.output).toEqual(
+      '{"httpStatus":200}'
+    );
+  });
+
   it("should fail when session id is invalid", async () => {
     const input = JSON.stringify({
       nino: "AA000003D",

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -339,7 +339,19 @@
           }
         }
       },
-      "Next": "Send Retry"
+      "Next": "Was this the users last attempt?",
+      "ResultPath": "$.saveFailedAttempt"
+    },
+    "Was this the users last attempt?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.check-attempts-exist.Count",
+          "NumericGreaterThanEquals": 1,
+          "Next": "Fetch Auth Code Expiry"
+        }
+      ],
+      "Default": "Send Retry"
     },
     "Send Retry": {
       "Type": "Pass",
@@ -394,7 +406,7 @@
             "S.$": "$$.Execution.Input.sessionId"
           },
           "nino": {
-            "S.$": "$.hmrc_response.payload.body.nino"
+            "S.$": "$$.Execution.Input.nino"
           }
         }
       },
@@ -403,12 +415,12 @@
     },
     "Response Filtering": {
       "Type": "Pass",
-      "Next": "Nino check successful",
+      "Next": "Nino check completed",
       "Parameters": {
         "httpStatus": 200
       }
     },
-    "Nino check successful": {
+    "Nino check completed": {
       "Type": "Succeed"
     },
     "Err: API Error": {
@@ -440,7 +452,8 @@
           }
         }
       },
-      "Next": "Send Retry"
+      "Next": "Was this the users last attempt?",
+      "ResultPath": "$.saveFailedAttempt"
     }
   }
 }


### PR DESCRIPTION
## Proposed changes

### What and why did it change
The nino-check state machine was not generating an auth code on the 2nd attempt which was causing a 3rd retry. The change made here makes it so that that if the user is on their last attempt, the auth code generation flow is triggered.

Unit tests have been fixed to work with the refactoring. 
Added new unit test to test the new flow. 

### Issue tracking
- [OJ-2445](https://govukverify.atlassian.net/browse/OJ-2445)



[OJ-2445]: https://govukverify.atlassian.net/browse/OJ-2445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ