### PR TITLE
OJ-2479: make persistent id optional

### DIFF
--- a/integration-tests/tests/mocked/check-session/MockConfigFile.json
+++ b/integration-tests/tests/mocked/check-session/MockConfigFile.json
@@ -6,6 +6,10 @@
           "Fetch Current Time": "FetchCurrentTimeHappy",
           "Fetch Session": "FetchSessionHappy"
         },
+        "HappyPathWithOptionalPersistentSessionId": {
+          "Fetch Current Time": "FetchCurrentTimeHappy",
+          "Fetch Session": "FetchSessionHappyWithoutPersistentSessionId"
+        },
         "NoSessionFound": {
           "Fetch Current Time": "FetchCurrentTimeHappy",
           "Fetch Session": "NoResults"
@@ -48,6 +52,38 @@
               },
               "persistentSessionId": {
                 "S": "156714ef-f9df-48c2-ada8-540e7bce44f7"
+              },
+              "sessionId": {
+                "S": "12345"
+              },
+              "subject": {
+                "S": "urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "FetchSessionHappyWithoutPersistentSessionId": {
+      "0": {
+        "Return": {
+          "Count": 1,
+          "Items": [
+            {
+              "expiryDate": {
+                "N": "2695828259"
+              },
+              "clientId": {
+                "S": "exampleClientId"
+              },
+              "clientIpAddress": {
+                "S": "51.149.8.29"
+              },
+              "redirectUri": {
+                "S": "http://localhost:8085/callback"
+              },
+              "clientSessionId": {
+                "S": "252561a2-c6ef-47e7-87ab-93891a2a6a41"
               },
               "sessionId": {
                 "S": "12345"

--- a/integration-tests/tests/mocked/check-session/check-session.test.ts
+++ b/integration-tests/tests/mocked/check-session/check-session.test.ts
@@ -29,8 +29,27 @@ describe("check-session", () => {
           event?.stateExitedEventDetails?.name === "Session OK",
         responseStepFunction
       );
-      expect(results[0].stateExitedEventDetails?.output).toEqual(
-        '{"status":"SESSION_OK","userAuditInfo":{"govuk_signin_journey_id":"252561a2-c6ef-47e7-87ab-93891a2a6a41","user_id":"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2","persistent_session_id":"156714ef-f9df-48c2-ada8-540e7bce44f7","session_id":"12345","ip_address":"51.149.8.29"},"clientId":"exampleClientId"}'
+      expect(results[0].stateExitedEventDetails?.output).toBe(
+        '{"status":"SESSION_OK","clientId":"exampleClientId","userAuditInfo":{"govuk_signin_journey_id":"252561a2-c6ef-47e7-87ab-93891a2a6a41","user_id":"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2","persistent_session_id":"156714ef-f9df-48c2-ada8-540e7bce44f7","session_id":"12345","ip_address":"51.149.8.29"}}'
+      );
+    });
+    it("it should pass when a valid session exists and persistent_session_id is absent", async () => {
+      const input = JSON.stringify({
+        sessionId: "12345",
+      });
+      const responseStepFunction =
+        await sfnContainer.startStepFunctionExecution(
+          "HappyPathWithOptionalPersistentSessionId",
+          input
+        );
+      const results = await sfnContainer.waitFor(
+        (event: HistoryEvent) =>
+          event?.type === "PassStateExited" &&
+          event?.stateExitedEventDetails?.name === "Session OK",
+        responseStepFunction
+      );
+      expect(results[0].stateExitedEventDetails?.output).toBe(
+        '{"status":"SESSION_OK","clientId":"exampleClientId","userAuditInfo":{"govuk_signin_journey_id":"252561a2-c6ef-47e7-87ab-93891a2a6a41","user_id":"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2","session_id":"12345","ip_address":"51.149.8.29"}}'
       );
     });
   });

--- a/integration-tests/tests/mocked/nino-issue-credential/MockConfigFile.json
+++ b/integration-tests/tests/mocked/nino-issue-credential/MockConfigFile.json
@@ -11,7 +11,18 @@
           "Fetch exp time and NBF": "FetchExpTimeAndNBF",
           "Fetch Failed Attempts": "FetchFailedAttempts",
           "Sign VC claimsSet": "SignVCClaimSet",
-          "Publish Audit Event VC Issued": "PublishAuditEventVcIssued"
+          "Audit Event VC Issued Sent": "PublishAuditEventVcIssued"
+        },
+        "HappyPathWithoutPersistentSessionId": {
+          "Fetch SSM Parameters": "FetchSSMParamsSuccess",
+          "Query Session Item": "QuerySessionItemWithoutPersistentSessionId",
+          "Fetch details from person identity": "FetchDetailsFromPersonIdentity",
+          "Fetch Nino": "FetchNino",
+          "Create Credential Subject": "CreateCredentialSubject",
+          "Fetch exp time and NBF": "FetchExpTimeAndNBF",
+          "Fetch Failed Attempts": "FetchFailedAttempts",
+          "Sign VC claimsSet": "SignVCClaimSet",
+          "Audit Event VC Issued Sent": "PublishAuditEventVcIssued"
         },
         "UnHappyPath": {
           "Fetch SSM Parameters": "FetchSSMParamsSuccess",
@@ -23,7 +34,7 @@
           "Fetch Failed Attempts": "FetchExceededFailedAttempts",
           "Fetch CI": "FetchCI",
           "Sign VC claimsSet": "SignVCClaimSetWithCi",
-          "Publish Audit Event VC Issued": "PublishAuditEventVcIssued"
+          "Audit Event VC Issued Sent": "PublishAuditEventVcIssued"
         },
         "UnHappyPathBearerTokenInvalid": {
           "Fetch SSM Parameters": "FetchSSMParamsSuccess",
@@ -107,6 +118,42 @@
               },
               "persistentSessionId": {
                 "S": "156714ef-f9df-48c2-ada8-540e7bce44f7"
+              }
+            }
+          ],
+          "ScannedCount": 1
+        }
+      }
+    },
+    "QuerySessionItemWithoutPersistentSessionId": {
+      "0": {
+        "Return": {
+          "Count": 1,
+          "Items": [
+            {
+              "subject": {
+                "S": "test"
+              },
+              "sessionId": {
+                "S": "123456789"
+              },
+              "accessToken": {
+                "S": "Bearer test"
+              },
+              "expiryDate": {
+                "N": "2695828259"
+              },
+              "clientId": {
+                "S": "exampleClientId"
+              },
+              "clientIpAddress": {
+                "S": "51.149.8.29"
+              },
+              "redirectUri": {
+                "S": "http://localhost:8085/callback"
+              },
+              "clientSessionId": {
+                "S": "252561a2-c6ef-47e7-87ab-93891a2a6a41"
               }
             }
           ],

--- a/step-functions/check_session.asl.json
+++ b/step-functions/check_session.asl.json
@@ -65,7 +65,41 @@
           "Next": "Err: Session Expired"
         }
       ],
-      "Default": "Session OK"
+      "Default": "Is Persistent SessionId Present?"
+    },
+    "Is Persistent SessionId Present?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.sessionQuery.items[0].persistentSessionId",
+          "IsPresent": false,
+          "Next": "Get User Info Without Persistent Session Id"
+        }
+      ],
+      "Default": "Get User Session Info"
+    },
+    "Get User Info Without Persistent Session Id": {
+      "Type": "Pass",
+      "Parameters": {
+        "govuk_signin_journey_id.$": "$.sessionQuery.items[0].clientSessionId.S",
+        "ip_address.$": "$.sessionQuery.items[0].clientIpAddress.S",
+        "session_id.$": "$.sessionQuery.items[0].sessionId.S",
+        "user_id.$": "$.sessionQuery.items[0].subject.S"
+      },
+      "ResultPath": "$.UserSessionInfo",
+      "Next": "Session OK"
+    },
+    "Get User Session Info": {
+      "Type": "Pass",
+      "Parameters": {
+        "govuk_signin_journey_id.$": "$.sessionQuery.items[0].clientSessionId.S",
+        "ip_address.$": "$.sessionQuery.items[0].clientIpAddress.S",
+        "persistent_session_id.$": "$.sessionQuery.items[0].persistentSessionId.S",
+        "session_id.$": "$.sessionQuery.items[0].sessionId.S",
+        "user_id.$": "$.sessionQuery.items[0].subject.S"
+      },
+      "ResultPath": "$.UserSessionInfo",
+      "Next": "Session OK"
     },
     "Err: Session Expired": {
       "Type": "Pass",
@@ -87,13 +121,7 @@
       "Parameters": {
         "status": "SESSION_OK",
         "clientId.$": "$.sessionQuery.items[0].clientId.S",
-        "userAuditInfo": {
-          "govuk_signin_journey_id.$": "$.sessionQuery.items[0].clientSessionId.S",
-          "ip_address.$": "$.sessionQuery.items[0].clientIpAddress.S",
-          "persistent_session_id.$": "$.sessionQuery.items[0].persistentSessionId.S",
-          "session_id.$": "$.sessionQuery.items[0].sessionId.S",
-          "user_id.$": "$.sessionQuery.items[0].subject.S"
-        }
+        "userAuditInfo.$": "$.UserSessionInfo"
       }
     },
     "Err: No sessionId provided": {

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -58,10 +58,44 @@
         {
           "Variable": "$.querySessionResult.Count",
           "NumericGreaterThan": 0,
-          "Next": "Filter Session Result"
+          "Next": "Is Persistent Id Present?"
         }
       ],
       "Default": "Err: Invalid Bearer Token"
+    },
+    "Is Persistent Id Present?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.querySessionResult.Items[0].persistentSessionId",
+          "IsPresent": true,
+          "Next": "Get Audit UserInfo With Persistent Id"
+        }
+      ],
+      "Default": "Get Audit UserInfo"
+    },
+    "Get Audit UserInfo": {
+      "Type": "Pass",
+      "Parameters": {
+        "govuk_signin_journey_id.$": "$.querySessionResult.Items[0].clientSessionId.S",
+        "ip_address.$": "$.querySessionResult.Items[0].clientIpAddress.S",
+        "session_id.$": "$.querySessionResult.Items[0].sessionId.S",
+        "user_id.$": "$.querySessionResult.Items[0].subject.S"
+      },
+      "ResultPath": "$.userAuditInfo",
+      "Next": "Filter Session Result"
+    },
+    "Get Audit UserInfo With Persistent Id": {
+      "Type": "Pass",
+      "Parameters": {
+        "govuk_signin_journey_id.$": "$.querySessionResult.Items[0].clientSessionId.S",
+        "ip_address.$": "$.querySessionResult.Items[0].clientIpAddress.S",
+        "persistent_session_id.$": "$.querySessionResult.Items[0].persistentSessionId.S",
+        "session_id.$": "$.querySessionResult.Items[0].sessionId.S",
+        "user_id.$": "$.querySessionResult.Items[0].subject.S"
+      },
+      "ResultPath": "$.userAuditInfo",
+      "Next": "Filter Session Result"
     },
     "Filter Session Result": {
       "Type": "Pass",
@@ -70,13 +104,7 @@
       "Parameters": {
         "sessionId.$": "$.querySessionResult.Items[0].sessionId.S",
         "subject.$": "$.querySessionResult.Items[0].subject.S",
-        "userAuditInfo": {
-          "govuk_signin_journey_id.$": "$.querySessionResult.Items[0].clientSessionId.S",
-          "ip_address.$": "$.querySessionResult.Items[0].clientIpAddress.S",
-          "persistent_session_id.$": "$.querySessionResult.Items[0].persistentSessionId.S",
-          "session_id.$": "$.querySessionResult.Items[0].sessionId.S",
-          "user_id.$": "$.querySessionResult.Items[0].subject.S"
-        }
+        "userAuditInfo.$": "$.userAuditInfo"
       }
     },
     "Err: Invalid Bearer Token": {
@@ -341,13 +369,13 @@
           "BackoffRate": 2
         }
       ],
-      "Next": "Publish Audit Event VC Issued",
+      "Next": "Audit Event VC Issued Sent",
       "ResultSelector": {
         "Payload.$": "$.Payload"
       },
       "ResultPath": "$.jwt"
     },
-    "Publish Audit Event VC Issued": {
+    "Audit Event VC Issued Sent": {
       "Type": "Task",
       "Resource": "arn:aws:states:::events:putEvents",
       "Parameters": {
@@ -375,9 +403,9 @@
         "issuer.$": "$.payload.iss",
         "httpStatus": 200
       },
-      "Next": "Publish Audit Event End"
+      "Next": "Audit Event End Sent"
     },
-    "Publish Audit Event End": {
+    "Audit Event End Sent": {
       "Type": "Task",
       "Resource": "arn:aws:states:::events:putEvents",
       "Parameters": {


### PR DESCRIPTION
## Proposed changes

Make the Persistent Session Id optional

**Check Session was:**
![image](https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/assets/3749690/8d91e576-170d-48ca-981a-f9aa6fd703e6)

**Now:**

![image](https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/assets/3749690/87b8ca4b-3470-4d72-b01b-466cfdd387d0)




### Why did it change

Core integration broke in staging due to the assumption that it was always present in the JAR request


- [OJ-2479](https://govukverify.atlassian.net/browse/OJ-2479)

[OJ-2479]: https://govukverify.atlassian.net/browse/OJ-2479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ