### PR TITLE
IPS-676: Implement subscription filter for CSLS logging

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -105,6 +105,18 @@ Mappings:
       integration: review-hc.integration.account.gov.uk
       production: review-hc.production.account.gov.uk
 
+  PlatformConfiguration:
+    dev:
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+    build:
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+    staging:
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+    integration:
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+    production:
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+
 Globals:
   Function:
     Timeout: 30
@@ -164,6 +176,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/EpochTimeFunction
       RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
 
+  EpochTimeFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref EpochTimeFunctionLogGroup
+
   EpochTimeFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -212,6 +232,14 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CiMappingFunction
       RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+
+  CiMappingFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref CiMappingFunctionLogGroup
 
   CiMappingFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -264,6 +292,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CreateAuthCodeFunction
       RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
 
+  CreateAuthCodeFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref CreateAuthCodeFunctionLogGroup
+
   CreateAuthCodeFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -315,6 +351,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CredentialSubjectFunction
       RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
 
+  CredentialSubjectFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref CredentialSubjectFunctionLogGroup
+
   CredentialSubjectFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -365,6 +409,14 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CurrentTimeFunction
       RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+
+  CurrentTimeFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref CurrentTimeFunctionLogGroup
 
   CurrentTimeFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -422,6 +474,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/JwtSignerFunction
       RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
 
+  JwtSignerFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref JwtSignerFunctionLogGroup
+
   JwtSignerFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -472,6 +532,14 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction
       RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+
+  MatchingFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref MatchingFunctionLogGroup
 
   MatchingFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -527,6 +595,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/SsmParametersFunction
       RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
 
+  SsmParametersFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref SsmParametersFunctionLogGroup
+
   SsmParametersFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -577,6 +653,14 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/TimeFunction
       RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+
+  TimeFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref TimeFunctionLogGroup
 
   TimeFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -679,6 +763,14 @@ Resources:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PublicNinoCheckApi}-public-AccessLogs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
+  PublicNinoCheckApiLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref PublicNinoCheckApiAccessLogGroup
+
   PublicNinoCheckApiFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -770,6 +862,14 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PrivateNinoCheckApi}-private-AccessLogs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PrivateNinoCheckApiLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref PrivateNinoCheckApiAccessLogGroup
 
   PrivateNinoCheckApiFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -1005,6 +1105,14 @@ Resources:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoCheck-state-machine-logs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
+  NinoCheckStateMachineLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref NinoCheckStateMachineLogGroup
+
   NinoCheckStateMachineFailedMetric:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -1087,6 +1195,14 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-Abandon-state-machine-logs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  AbandonStateMachineLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref AbandonStateMachineLogGroup
 
   AbandonStateMachineFailedMetric:
     Type: AWS::Logs::MetricFilter
@@ -1201,6 +1317,14 @@ Resources:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoIssueCredential-state-machine-logs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
+  NinoIssueCredentialLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref NinoIssueCredentialLogGroup
+
   NinoIssueCredentialStateMachineFailedMetric:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -1239,6 +1363,14 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-CheckSession-state-machine-logs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  CheckSessionStateMachineLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref CheckSessionStateMachineLogGroup
 
   CheckHmrcEventBus:
     Type: AWS::Events::EventBus
@@ -1392,6 +1524,15 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-AuditEvent-state-machine-logs
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  AuditEventStateMachineLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref AuditEventStateMachineLogGroup
+
   ####################################################################
   #                                                                  #
   #  Metrics                                                         #

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -178,6 +178,7 @@ Resources:
 
   EpochTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -235,6 +236,7 @@ Resources:
 
   CiMappingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -294,6 +296,7 @@ Resources:
 
   CreateAuthCodeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -353,6 +356,7 @@ Resources:
 
   CredentialSubjectFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -412,6 +416,7 @@ Resources:
 
   CurrentTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -476,6 +481,7 @@ Resources:
 
   JwtSignerFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -535,6 +541,7 @@ Resources:
 
   MatchingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -597,6 +604,7 @@ Resources:
 
   SsmParametersFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -656,6 +664,7 @@ Resources:
 
   TimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -765,6 +774,7 @@ Resources:
 
   PublicNinoCheckApiLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -865,6 +875,7 @@ Resources:
 
   PrivateNinoCheckApiLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -1107,6 +1118,7 @@ Resources:
 
   NinoCheckStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -1198,6 +1210,7 @@ Resources:
 
   AbandonStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -1319,6 +1332,7 @@ Resources:
 
   NinoIssueCredentialLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -1366,6 +1380,7 @@ Resources:
 
   CheckSessionStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -1527,6 +1542,7 @@ Resources:
 
   AuditEventStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]


### PR DESCRIPTION
## Proposed changes
- Implement Subscription filter for CSLS logging

### What changed
- Add CSLSEGRESS ARNs for all the environments
- Add subscription filters for the lambda functions and state machines.

### Why did it change

- Add subscription filters to inject logs into splunk

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-676](https://govukverify.atlassian.net/browse/IPS-676)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-676]: https://govukverify.atlassian.net/browse/IPS-676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ