### PR TITLE
OJ-2489: Need to exclude for localdev

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -56,6 +56,9 @@ Conditions:
   IsNotDevEnvironment: !Not
     - !Condition IsDevEnvironment
 
+  IsNotDevLikeEnvironment: !Not
+    - !Condition IsDevLikeEnvironment
+
   DeployAlarms: !Or
     - !Condition IsNotDevEnvironment
     - !Equals [!Ref DeployAlarmsInDevEnvironment, "true"]
@@ -178,7 +181,7 @@ Resources:
 
   EpochTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -236,7 +239,7 @@ Resources:
 
   CiMappingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -296,7 +299,7 @@ Resources:
 
   CreateAuthCodeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -356,7 +359,7 @@ Resources:
 
   CredentialSubjectFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -416,7 +419,7 @@ Resources:
 
   CurrentTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -481,7 +484,7 @@ Resources:
 
   JwtSignerFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -541,7 +544,7 @@ Resources:
 
   MatchingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -604,7 +607,7 @@ Resources:
 
   SsmParametersFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -664,7 +667,7 @@ Resources:
 
   TimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -774,7 +777,7 @@ Resources:
 
   PublicNinoCheckApiLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -875,7 +878,7 @@ Resources:
 
   PrivateNinoCheckApiLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -1118,7 +1121,7 @@ Resources:
 
   NinoCheckStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -1210,7 +1213,7 @@ Resources:
 
   AbandonStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -1332,7 +1335,7 @@ Resources:
 
   NinoIssueCredentialLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -1380,7 +1383,7 @@ Resources:
 
   CheckSessionStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
@@ -1542,7 +1545,7 @@ Resources:
 
   AuditEventStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
+    Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]


### PR DESCRIPTION
The condition for subscription filter has been widen to exclude localdev

i.e. `IsNotDevLikeEnvironment` which covers localdev and dev

## Proposed changes

Don't need them while deploying stacks for localdev

### What changed

Subscription filters added for higher environment

### Why did it change

local dev was broken

### Issue tracking

- [IPS-676](https://govukverify.atlassian.net/browse/IPS-676)
- [OJ-2489](https://govukverify.atlassian.net/browse/OJ-2489)

[IPS-676]: https://govukverify.atlassian.net/browse/IPS-676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OJ-2489]: https://govukverify.atlassian.net/browse/OJ-2489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ