### PR TITLE
OJ-2490: Use the OTG API

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -546,6 +546,25 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction
       RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
 
+  OTGFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Sourcemap: true
+    Properties:
+      Handler: lambdas/otg-api/src/otg-api-handler.lambdaHandler
+      LoggingConfig:
+        LogGroup: !Sub /aws/lambda/${AWS::StackName}/OTGFunction
+      CodeSigningConfigArn:
+        !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+
+  OTGFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/OTGFunction
+      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+
   MatchingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
@@ -1055,6 +1074,7 @@ Resources:
         BearerTokenName: !Ref BearerTokenName
         CommonStackName: !Ref CommonStackName
         SsmParametersFunction: !Ref SsmParametersFunction
+        OTGFunction: !Ref OTGFunction
         CheckHmrcEventBus: !Ref CheckHmrcEventBus
         CheckHmrcEventBusSource: !FindInMap [Audit, Source, !Ref Environment]
         AuditEventNameResponseReceived:
@@ -1067,6 +1087,8 @@ Resources:
         IncludeExecutionData: True
         Level: ALL
       Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref OTGFunction
         - LambdaInvokePolicy:
             FunctionName: !Ref SsmParametersFunction
         - LambdaInvokePolicy:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -587,6 +587,67 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
+  OTGFunctionFatalErrorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref OTGFunctionLogGroup
+      FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
+      MetricTransformations:
+        -
+          MetricValue: "1"
+          MetricNamespace: !Sub "${AWS::StackName}/LogMessages"
+          MetricName: "OTGFunction-Fatalerror"
+
+  OTGFunctionFatalErrorAlarm:
+    DependsOn:
+      - "OTGFunctionFatalErrorMetricFilter"
+    Type: AWS::CloudWatch::Alarm
+    Condition: "DeployAlarms"
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-BearerTokenHandlerFunction-FatalErrorAlarm"
+      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      InsufficientDataActions: [ ]
+      MetricName: BearerTokenHandlerFunction-Fatalerror
+      Namespace: !Sub "${AWS::StackName}/LogMessages"
+      Statistic: Sum
+      Dimensions: [ ]
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  OTGFunctionThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: "DeployAlarms"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-critical-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-critical-alert-topic
+      InsufficientDataActions: []
+      AlarmDescription: !Sub "Trigger if the ${OTGFunction} lambda throttles. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-OTGFunction-throttles"
+      MetricName: Throttles
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref OTGFunction
+      TreatMissingData: notBreaching
+      Period: 60 # This is the minimum value for the AWS Namespace
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+
   MatchingFunction:
     Type: AWS::Serverless::Function
     Metadata:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -544,7 +544,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/OTGFunction
-      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
   OTGFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -527,25 +527,6 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
-  MatchingFunction:
-    Type: AWS::Serverless::Function
-    Metadata:
-      BuildMethod: esbuild
-      BuildProperties:
-        Sourcemap: true
-    Properties:
-      Handler: lambdas/matching/src/matching-handler.lambdaHandler
-      LoggingConfig:
-        LogGroup: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction
-      CodeSigningConfigArn:
-        !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
-
-  MatchingFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction
-      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
-
   OTGFunction:
     Type: AWS::Serverless::Function
     Metadata:
@@ -563,6 +544,66 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/OTGFunction
+      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+
+  OTGFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevLikeEnvironment
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref OTGFunctionLogGroup
+
+  OTGFunctionEventErrorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref OTGFunctionLogGroup
+      FilterPattern: "{($.eventName = ExecutionsFailed) || ($.eventName = ExecutionThrottled) || ($.eventName = ExecutionsAborted) || ($.eventName = ExecutionsTimedOut)}"
+      MetricTransformations:
+        - MetricValue: 1
+          MetricName: !Sub ${MatchingFunction}-Error
+          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
+
+  OTGFunctionEventErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-${OTGFunction}-Errors"
+      AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${OTGFunction} errors. ${SupportManualURL}"
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      InsufficientDataActions: []
+      MetricName: !Sub ${OTGFunction}-Error
+      Namespace: !Sub ${AWS::StackName}/LogMessages
+      Statistic: Sum
+      Dimensions: []
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  MatchingFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Sourcemap: true
+    Properties:
+      Handler: lambdas/matching/src/matching-handler.lambdaHandler
+      LoggingConfig:
+        LogGroup: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction
+      CodeSigningConfigArn:
+        !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+
+  MatchingFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction
       RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
 
   MatchingFunctionLogsSubscriptionFilterCSLS:

--- a/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/tests/aws/nino-check/nino-check-unhappy.test.ts
@@ -324,31 +324,4 @@ describe("nino-check-unhappy", () => {
       expect(startExecutionResult.status).toEqual("FAILED");
     });
   });
-
-  describe("HMRC bearer token is invalid", () => {
-    beforeAll(
-      async () =>
-        await secretsManager.updateSecret({
-          SecretId: "HMRCBearerToken",
-          SecretString: "badToken",
-        })
-    );
-
-    afterAll(
-      async () =>
-        await secretsManager.updateSecret({
-          SecretId: "HMRCBearerToken",
-          SecretString: "goodToken",
-        })
-    );
-
-    it("should throw an error when token is invalid", async () => {
-      const startExecutionResult = await executeStepFunction(
-        output.NinoCheckStateMachineArn as string,
-        input
-      );
-
-      expect(startExecutionResult.status).toEqual("FAILED");
-    });
-  });
 });

--- a/integration-tests/tests/mocked/nino-check/MockConfigFile.json
+++ b/integration-tests/tests/mocked/nino-check/MockConfigFile.json
@@ -7,7 +7,7 @@
           "Fetch SSM Parameters": "FetchSSMParamsSuccess",
           "Query User Attempts": "QueryUserAttemptSuccessOn2ndTry",
           "Query Person Identity Table": "QuerySessionSuccess",
-          "Get OAuth Token": "GetOAuthAccessTokenSuccess",
+          "Call OTG API": "OTGFunctionSuccess",
           "Audit Event Request Sent": "PublishAuditEventRequestSent",
           "Call Matching API": "CallMatchingDeceasedAPIFail",
           "Audit Event Response Received": "PublishAuditEventResponseReceived",
@@ -22,7 +22,7 @@
           "Query User Attempts": "DynamoDbQueryNoResult",
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Query Person Identity Table": "QuerySessionSuccess",
-          "Get OAuth Token": "GetOAuthAccessTokenSuccess",
+          "Call OTG API": "OTGFunctionSuccess",
           "Audit Event Request Sent": "PublishAuditEventRequestSent",
           "Call Matching API": "CallMatchingAPIRetryThenSuccess",
           "Audit Event Response Received": "PublishAuditEventResponseReceived",
@@ -37,7 +37,7 @@
           "Query User Attempts": "DynamoDbQueryNoResult",
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Query Person Identity Table": "QuerySessionSuccess",
-          "Get OAuth Token": "GetOAuthAccessTokenSuccess",
+          "Call OTG API": "OTGFunctionSuccess",
           "Audit Event Request Sent": "PublishAuditEventRequestSent",
           "Call Matching API": "CallMatchingAPIRetryThenFail"
         },
@@ -47,7 +47,7 @@
           "Query User Attempts": "DynamoDbQueryNoResult",
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Query Person Identity Table": "QuerySessionSuccess",
-          "Get OAuth Token": "GetOAuthAccessTokenSuccess",
+          "Call OTG API": "OTGFunctionSuccess",
           "Audit Event Request Sent": "PublishAuditEventRequestSent",
           "Call Matching API": "CallMatchingDeceasedAPIFail",
           "Audit Event Response Received": "PublishAuditEventResponseReceived",
@@ -59,7 +59,7 @@
           "Query User Attempts": "DynamoDbQueryNoResult",
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Query Person Identity Table": "QuerySessionSuccess",
-          "Get OAuth Token": "GetOAuthAccessTokenSuccess",
+          "Call OTG API": "OTGFunctionSuccess",
           "Audit Event Request Sent": "PublishAuditEventRequestSent",
           "Call Matching API": "CallMatchingAPISuccess",
           "Audit Event Response Received": "PublishAuditEventResponseReceived",
@@ -74,7 +74,7 @@
           "Query User Attempts": "QueryUserAttemptSuccessOn2ndTry",
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Query Person Identity Table": "QuerySessionSuccess",
-          "Get OAuth Token": "GetOAuthAccessTokenSuccess",
+          "Call OTG API": "OTGFunctionSuccess",
           "Audit Event Request Sent": "PublishAuditEventRequestSent",
           "Call Matching API": "CallMatchingAPISuccess",
           "Audit Event Response Received": "PublishAuditEventResponseReceived",
@@ -104,7 +104,7 @@
           "Query User Attempts": "DynamoDbQueryNoResult",
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Query Person Identity Table": "QuerySessionSuccess",
-          "Get OAuth Token": "GetOAuthAccessTokenSuccess",
+          "Call OTG API": "OTGFunctionSuccess",
           "Audit Event Request Sent": "PublishAuditEventRequestSent",
           "Call Matching API": "CallMatchingAPIFailAuth",
           "Audit Event Response Received": "PublishAuditEventResponseReceived"
@@ -115,7 +115,7 @@
           "Query User Attempts": "QueryUserAttemptSuccessOn2ndTry",
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Query Person Identity Table": "QuerySessionSuccess",
-          "Get OAuth Token": "GetOAuthAccessTokenSuccess",
+          "Call OTG API": "OTGFunctionSuccess",
           "Audit Event Request Sent": "PublishAuditEventRequestSent",
           "Call Matching API": "CallMatchingAPIInvalidURL",
           "Audit Event Response Received": "PublishAuditEventResponseReceived"
@@ -126,7 +126,7 @@
           "Query User Attempts": "DynamoDbQueryNoResult",
           "Create new user attempt": "DynamoDbQueryNoResult",
           "Query Person Identity Table": "QuerySessionSuccess",
-          "Get OAuth Token": "GetOAuthAccessTokenSuccess",
+          "Call OTG API": "OTGFunctionSuccess",
           "Audit Event Request Sent": "PublishAuditEventRequestSent",
           "Call Matching API": "CallMatchingAPIFailNoRecords",
           "Audit Event Response Received": "PublishAuditEventResponseReceived",
@@ -479,10 +479,13 @@
         }
       }
     },
-    "GetOAuthAccessTokenSuccess": {
+    "OTGFunctionSuccess": {
       "0": {
         "Return": {
-          "SecretString": "abc"
+          "Payload": {
+            "token": "goodToken",
+            "expiry": "123456789"
+          }
         }
       }
     },

--- a/lambdas/otg-api/jest.config.ts
+++ b/lambdas/otg-api/jest.config.ts
@@ -1,0 +1,7 @@
+import type { Config } from "jest";
+import baseConfig from "../../jest.config.base";
+
+export default {
+  ...baseConfig,
+  displayName: "lambdas/matching",
+} satisfies Config;

--- a/lambdas/otg-api/package.json
+++ b/lambdas/otg-api/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "otg-api",
+  "description": "",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "unit": "jest --silent",
+    "test": "npm run unit --",
+    "test:coverage": "npm run unit -- --coverage",
+    "deploy": "../../deploy.sh",
+    "compile": "tsc"
+  },
+  "dependencies": {}
+}

--- a/lambdas/otg-api/src/otg-api-handler.ts
+++ b/lambdas/otg-api/src/otg-api-handler.ts
@@ -26,10 +26,8 @@ export class OTGApiHandler implements LambdaInterface {
       throw new Error(
         `Error response received from OTG ${response.status} ${response.statusText}`)
     } catch (error: unknown) {
-      let message;
-      if (error instanceof Error) message = error.message;
-      else message = String(error);
-      logger.error("Error in MatchingHandler: " + message);
+      const message = (error instanceof Error) ? error.message : String(error);
+      logger.error("Error in OTGApiHandler: " + message);
       throw error;
     }
   }

--- a/lambdas/otg-api/src/otg-api-handler.ts
+++ b/lambdas/otg-api/src/otg-api-handler.ts
@@ -1,0 +1,39 @@
+import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { Logger } from "@aws-lambda-powertools/logger";
+
+const logger = new Logger();
+
+export class OTGApiHandler implements LambdaInterface {
+  public async handler(
+    event: { apiURL: string },
+    _context: unknown
+  ): Promise<{ token: string, expiry: number }> {
+    try {
+      const response = await fetch(event.apiURL, {
+        method: "GET",
+      });
+
+      if(response.ok) {
+        const body = await response.json();
+        const expiry = body.expiry;
+        const now = Date.now();
+        if(now > expiry) {
+          throw new Error("OTG returned an expired Bearer Token")
+        }
+        return body;
+      }
+
+      throw new Error(
+        `Error response received from OTG ${response.status} ${response.statusText}`)
+    } catch (error: unknown) {
+      let message;
+      if (error instanceof Error) message = error.message;
+      else message = String(error);
+      logger.error("Error in MatchingHandler: " + message);
+      throw error;
+    }
+  }
+}
+
+const handlerClass = new OTGApiHandler();
+export const lambdaHandler = handlerClass.handler.bind(handlerClass);

--- a/lambdas/otg-api/tests/otg-api-handler.test.ts
+++ b/lambdas/otg-api/tests/otg-api-handler.test.ts
@@ -1,0 +1,74 @@
+import { Context } from "aws-lambda";
+import { OTGApiHandler } from "../src/otg-api-handler";
+
+describe("otg-api-handler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it("should return a token and expiry", async () => {
+    const mockToken = "goodToken";
+    const mockExpiry = Date.now() + 600000;
+
+    global.fetch = jest.fn();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValueOnce({
+        token: mockToken,
+        expiry: mockExpiry
+      }),
+      ok: true
+    });
+
+    const otgApiHandler = new OTGApiHandler();
+    const event = {
+      apiURL: "https://apigwId-vpceId.execute-api.eu-west-2.amazonaws.com/dev/token/?tokenType=stub",
+    };
+    const result = await otgApiHandler.handler(event, {} as Context);
+    expect(result.token).toBe(mockToken);
+    expect(result.expiry).toBe(mockExpiry);
+  });
+
+  it("should throw when an invalid response is returned from OTG", async () => {
+    global.fetch = jest.fn();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValueOnce({}),
+      ok: false,
+      status: 400,
+      statusText: "Forbidden",
+    });
+
+    const otgApiHandler = new OTGApiHandler();
+    const event = {
+      apiURL: "https://apigwId-vpceId.execute-api.eu-west-2.amazonaws.com/dev/token/?tokenType=stub"
+    };
+
+    await expect(() => otgApiHandler.handler(event, {})).rejects.toThrow(
+      new Error("Error response received from OTG 400 Forbidden")
+    );
+  });
+
+  it("should throw when the bearer token has expired", async () => {
+    const mockToken = "goodToken";
+    const mockExpiry = Date.now() - 600000;
+
+    global.fetch = jest.fn();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValueOnce({
+        token: mockToken,
+        expiry: mockExpiry
+      }),
+      ok: true
+    });
+
+    const otgApiHandler = new OTGApiHandler();
+    const event = {
+      apiURL: "https://apigwId-vpceId.execute-api.eu-west-2.amazonaws.com/dev/token/?tokenType=stub"
+    };
+
+    await expect(() => otgApiHandler.handler(event, {})).rejects.toThrow(
+      new Error("OTG returned an expired Bearer Token")
+    );
+  });
+
+});

--- a/lambdas/otg-api/tsconfig.json
+++ b/lambdas/otg-api/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "target": "es2022",
+    "strict": true,
+    "preserveConstEnums": true,
+    "sourceMap": true,
+    "module": "es2022",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["jest", "node", "aws-lambda"],
+    "outDir": "./build/",
+    "noImplicitAny": true
+  },
+  "exclude": ["node_modules", "build", "coverage"],
+  "include": ["src", "tests"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -532,7 +532,9 @@
         }
       }
     },
-    "lambdas/attributes": {},
+    "lambdas/attributes": {
+      "extraneous": true
+    },
     "lambdas/ci-mapping": {},
     "lambdas/credential-subject": {},
     "lambdas/der-signature-to-jose": {
@@ -556,8 +558,11 @@
         "jose": "^5.1.0"
       }
     },
-    "lambdas/logging-handler": {},
+    "lambdas/logging-handler": {
+      "extraneous": true
+    },
     "lambdas/matching": {},
+    "lambdas/otg-api": {},
     "lambdas/ssm-parameters": {},
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -10033,10 +10038,6 @@
       "version": "1.0.2",
       "license": "MIT"
     },
-    "node_modules/attributes": {
-      "resolved": "lambdas/attributes",
-      "link": true
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.6.tgz",
@@ -15376,10 +15377,6 @@
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true
     },
-    "node_modules/logging-handler": {
-      "resolved": "lambdas/logging-handler",
-      "link": true
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "dev": true,
@@ -15772,6 +15769,10 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/otg-api": {
+      "resolved": "lambdas/otg-api",
+      "link": true
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
@@ -25500,9 +25501,6 @@
     "atomic-batcher": {
       "version": "1.0.2"
     },
-    "attributes": {
-      "version": "file:lambdas/attributes"
-    },
     "available-typed-arrays": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.6.tgz",
@@ -29499,9 +29497,6 @@
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true
     },
-    "logging-handler": {
-      "version": "file:lambdas/logging-handler"
-    },
     "lru-cache": {
       "version": "5.1.1",
       "dev": true,
@@ -29770,6 +29765,9 @@
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0"
       }
+    },
+    "otg-api": {
+      "version": "file:lambdas/otg-api"
     },
     "p-finally": {
       "version": "1.0.0",

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -33,7 +33,7 @@
       "Parameters": {
         "FunctionName": "${SsmParametersFunction}",
         "Payload": {
-          "parameters.$": "States.Array('/${CommonStackName}/PersonIdentityTableName', '${UserAgent}', '/${CommonStackName}/SessionTableName', States.Format('/check-hmrc-cri-api/NinoCheckUrl/{}', $.sessionCheck.clientId), '/${CommonStackName}/verifiable-credential/issuer')"
+          "parameters.$": "States.Array(States.Format('/check-hmrc-cri-api/OtgUrl/{}', $.sessionCheck.clientId), '/${CommonStackName}/PersonIdentityTableName', '${UserAgent}', '/${CommonStackName}/SessionTableName', States.Format('/check-hmrc-cri-api/NinoCheckUrl/{}', $.sessionCheck.clientId), '/${CommonStackName}/verifiable-credential/issuer')"
         }
       },
       "Retry": [
@@ -52,11 +52,12 @@
       "Next": "Query User Attempts",
       "ResultPath": "$.parameters",
       "ResultSelector": {
-        "PersonIdentityTableName.$": "$.Payload[0].Value",
-        "UserAgent.$": "$.Payload[1].Value",
-        "SessionTableName.$": "$.Payload[2].Value",
-        "CheckUrl.$": "$.Payload[3].Value",
-        "Issuer.$": "$.Payload[4].Value"
+        "OtgUrl.$": "$.Payload[0].Value",
+        "PersonIdentityTableName.$": "$.Payload[1].Value",
+        "UserAgent.$": "$.Payload[2].Value",
+        "SessionTableName.$": "$.Payload[3].Value",
+        "CheckUrl.$": "$.Payload[4].Value",
+        "Issuer.$": "$.Payload[5].Value"
       }
     },
     "Err: Invalid Session": {
@@ -151,28 +152,41 @@
               ]
             }
           ],
-          "Next": "Get OAuth Token"
+          "Next": "Call OTG API"
         }
       ],
       "Default": "Err: No user found in Person Identity"
+    },
+    "Call OTG API": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${OTGFunction}",
+        "Payload": {
+          "apiURL.$": "$.parameters.OtgUrl"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Audit Event Request Sent",
+      "ResultPath": "$.otg"
     },
     "Err: No user found in Person Identity": {
       "Type": "Pass",
       "End": true,
       "Parameters": {
         "httpStatus": 500
-      }
-    },
-    "Get OAuth Token": {
-      "Type": "Task",
-      "Next": "Audit Event Request Sent",
-      "Parameters": {
-        "SecretId": "HMRCBearerToken"
-      },
-      "Resource": "arn:aws:states:::aws-sdk:secretsmanager:getSecretValue",
-      "ResultPath": "$.oAuthToken",
-      "ResultSelector": {
-        "value.$": "$.SecretString"
       }
     },
     "Audit Event Request Sent": {
@@ -212,7 +226,7 @@
           },
           "userAgent.$": "$.parameters.UserAgent",
           "apiURL.$": "$.parameters.CheckUrl",
-          "oAuthToken.$": "$.oAuthToken.value",
+          "oAuthToken.$": "$.otg.Payload.token",
           "user.$": "$.sessionCheck.userAuditInfo",
           "userInfo.$": "$.userInfo"
         }


### PR DESCRIPTION
## Proposed changes

### What and why did it change
* Created a Lambda that can call the OTG API and check expiry
* Created unit tests for the new Lambda
* Updated the state machine to use the OTG Lambda in place of the Get Secret Value
* Updated "Fetch SSM Parameters" state to fetch OTG URL based on the `clientId`
* Added CSLS SubscriptionFilter for OTG Lambda
* Added Error Metric Filter for OTG Lambda
* Added CloudWatch Alarm for OTG Lambda

### Issue tracking
- [OJ-2490](https://govukverify.atlassian.net/browse/OJ-2490)


[OJ-2490]: https://govukverify.atlassian.net/browse/OJ-2490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ