### PR TITLE
OJ-2458: Include CI Information in IPV_CHECK_HMRC_CRI_VC_ISSUED

### DIFF
--- a/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential.test.ts
+++ b/integration-tests/tests/aws/nino_issue_credential/nino_issue_credential.test.ts
@@ -351,6 +351,10 @@ describe("nino-issue-credential-happy", () => {
           {
             failedCheckDetails: [{ checkMethod: "data" }],
             ci: [expect.any(String)],
+            ciReasons: [
+              { ci: expect.any(String), reason: expect.any(String) },
+              { ci: expect.any(String), reason: expect.any(String) },
+            ],
             strengthScore: 2,
             txn: expect.any(String),
             type: "IdentityCheck",

--- a/integration-tests/tests/mocked/nino-issue-credential/MockConfigFile.json
+++ b/integration-tests/tests/mocked/nino-issue-credential/MockConfigFile.json
@@ -363,7 +363,7 @@
     "FetchCI": {
       "0": {
         "Return": {
-          "Payload": ["AAA"],
+          "Payload": [{ "ci": "AAA", "reason": "reason for ci"} ],
           "SdkHttpMetadata": {
             "HttpStatusCode": 200
           },

--- a/lambdas/ci-mapping/src/ci-mapping-handler.ts
+++ b/lambdas/ci-mapping/src/ci-mapping-handler.ts
@@ -7,7 +7,8 @@ import {
 import { Logger } from "@aws-lambda-powertools/logger";
 import {
   getHmrcErrsCiRecord,
-  deduplicateValues,
+  ContraIndicator,
+  deduplicateContraIndicators,
 } from "./utils/ci-mapping-util";
 
 const logger = new Logger();
@@ -15,7 +16,7 @@ export class CiMappingHandler implements LambdaInterface {
   public async handler(
     event: CiMappingEvent,
     _context: unknown
-  ): Promise<Array<string>> {
+  ): Promise<Array<ContraIndicator>> {
     try {
       return getCIsForHmrcErrors(event);
     } catch (error: unknown) {
@@ -30,7 +31,7 @@ export class CiMappingHandler implements LambdaInterface {
   }
 }
 
-const getCIsForHmrcErrors = (event: CiMappingEvent): Array<string> => {
+const getCIsForHmrcErrors = (event: CiMappingEvent): Array<ContraIndicator> => {
   const { ci_mappings, hmrc_errors } = validateInputs(event);
 
   const contraIndicators = ci_mappings?.flatMap((ci) => {
@@ -44,10 +45,10 @@ const getCIsForHmrcErrors = (event: CiMappingEvent): Array<string> => {
           .map((value) => value.trim())
           .includes(hmrcError)
       )
-      .map(() => ciValue.trim());
+      .map((hmrcError) => ({ ci: ciValue.trim(), reason: hmrcError.trim() }));
   });
 
-  return deduplicateValues(contraIndicators);
+  return deduplicateContraIndicators(contraIndicators);
 };
 
 const handlerClass = new CiMappingHandler();

--- a/lambdas/ci-mapping/src/utils/ci-mapping-util.ts
+++ b/lambdas/ci-mapping/src/utils/ci-mapping-util.ts
@@ -1,7 +1,27 @@
 export type HmrcErrsCiRecord = Record<"mappedHmrcErrors" | "ciValue", string>;
+export type ContraIndicator = {
+  ci: string;
+  reason: string;
+};
 
 export const deduplicateValues = (values: string[]): string[] =>
   Array.from(new Set(values));
+export const deduplicateContraIndicators = (
+  values: Array<ContraIndicator>
+): Array<ContraIndicator> => {
+  const uniqueIndicators = new Set<string>();
+
+  const uniqueStrings = values.map(
+    (indicator) => `${indicator.ci}@${indicator.reason}`
+  );
+
+  uniqueStrings.forEach(uniqueIndicators.add, uniqueIndicators);
+
+  return Array.from(uniqueIndicators).map((str) => {
+    const [ci, reason] = str.split("@");
+    return { ci, reason };
+  });
+};
 
 export const getHmrcErrsCiRecord = (pair: string): HmrcErrsCiRecord => {
   const [key, value] = pair.split(":");

--- a/lambdas/ci-mapping/tests/utils/ci-mapping-utils.test.ts
+++ b/lambdas/ci-mapping/tests/utils/ci-mapping-utils.test.ts
@@ -1,8 +1,8 @@
 import {
-  deduplicateValues,
   getHmrcErrsCiRecord,
   allMappedHmrcErrors,
   isCiHmrcErrorsMappingValid,
+  deduplicateContraIndicators,
 } from "../../src/utils/ci-mapping-util";
 
 describe("ci-mapping-utils", () => {
@@ -16,15 +16,24 @@ describe("ci-mapping-utils", () => {
     goodHmrcErrsCiRecordStringThree,
   ];
   describe("deduplicate values", () => {
-    const test_cis = ["ci_1", "ci_2", "ci_3"];
+    const test_cis = [
+      { ci: "ci_1", reason: "aaaa" },
+      { ci: "ci_2", reason: "bbbb" },
+      { ci: "ci_3", reason: "cccc" },
+    ];
     it("should remove duplicates from inputs", () => {
-      expect(deduplicateValues(["ci_1", "ci_2", "ci_1", "ci_3"])).toEqual(
-        test_cis
-      );
+      expect(
+        deduplicateContraIndicators([
+          { reason: "aaaa", ci: "ci_1" },
+          { ci: "ci_2", reason: "bbbb" },
+          { ci: "ci_1", reason: "aaaa" },
+          { ci: "ci_3", reason: "cccc" },
+        ])
+      ).toEqual(test_cis);
     });
 
     it("should return input same input array, when no duplicates exist", () => {
-      expect(deduplicateValues(test_cis)).toEqual(test_cis);
+      expect(deduplicateContraIndicators(test_cis)).toEqual(test_cis);
     });
   });
 

--- a/step-functions/audit_event.asl.json
+++ b/step-functions/audit_event.asl.json
@@ -4,11 +4,12 @@
   "States": {
     "Get Audit name components": {
       "Type": "Pass",
+      "Comment": "The details JSON object is stringified using States.JsonToString and then split it on ':\"' creating an array with key and value as items if a key called evidence is found DetailsContainsEvidence returns boolean value true",
       "Parameters": {
         "prefix.$": "$$.Execution.Input.detail.auditPrefix",
-        "type.$": "$$.Execution.Input.detail-type"
+        "type.$": "$$.Execution.Input.detail-type",
+        "DetailsContainsEvidence.$": "States.ArrayContains(States.StringSplit(States.JsonToString($$.Execution.Input.detail), ':\"'), 'evidence')"
       },
-      "ResultPath": "$.audit",
       "Next": "Parallel"
     },
     "Parallel": {
@@ -119,36 +120,74 @@
     },
     "Is Restricted Info Present?": {
       "Type": "Choice",
+      "Comment": "This check uses the empty object returned from the CredentialSubjectFunction to determine there is no Restricted user info present",
       "Choices": [
         {
           "Variable": "$[0].restricted.containsUserInfo",
           "StringEquals": "{}",
-          "Next": "Add User Context"
+          "Next": "AuditEvent Without Restricted Info"
         }
       ],
-      "Default": "Audit User Context With Restricted Fields"
+      "Default": "Add Restricted Info to AuditEvent"
+    },
+    "AuditEvent Without Restricted Info": {
+      "Type": "Pass",
+      "Comment": "The user context info is returned only is there is no Restricted user information",
+      "Parameters": {
+        "event_name.$": "States.Format('{}_{}', $[0].prefix, $[0].type)",
+        "timestamp.$": "$[1].epochSeconds.value",
+        "event_timestamp_ms.$": "$[2].epochMilliseconds.value",
+        "component_id.$": "$$.Execution.Input.detail.issuer",
+        "user.$": "$$.Execution.Input.detail.user"
+      },
+      "ResultPath": "$[0].auditEvent",
+      "OutputPath": "$",
+      "Next": "Is evidence Present?"
+    },
+    "Add Restricted Info to AuditEvent": {
+      "Type": "Pass",
+      "Comment": "The user context info is returned in added with the Restricted user information",
+      "Parameters": {
+        "event_name.$": "States.Format('{}_{}', $[0].prefix, $[0].type)",
+        "timestamp.$": "$[1].epochSeconds.value",
+        "event_timestamp_ms.$": "$[2].epochMilliseconds.value",
+        "component_id.$": "$$.Execution.Input.detail.issuer",
+        "user.$": "$$.Execution.Input.detail.user",
+        "restricted.$": "$[0].restricted.value"
+      },
+      "ResultPath": "$[0].auditEvent",
+      "OutputPath": "$",
+      "Next": "Is evidence Present?"
+    },
+    "Is evidence Present?": {
+      "Type": "Choice",
+      "Comment": "This check uses the DetailsContainsEvidence boolean to know when to add evidence details to the audit structure",
+      "Choices": [
+        {
+          "Variable": "$[0].DetailsContainsEvidence",
+          "BooleanEquals": true,
+          "Next": "Audit Event With Evidence & Restricted Info"
+        }
+      ],
+      "Default": "Add User Context"
     },
     "Add User Context": {
       "Type": "Pass",
       "Parameters": {
-        "event_name.$": "States.Format('{}_{}', $[0].audit.prefix, $[0].audit.type)",
-        "timestamp.$": "$[1].epochSeconds.value",
-        "event_timestamp_ms.$": "$[2].epochMilliseconds.value",
-        "component_id.$": "$$.Execution.Input.detail.issuer",
-        "user.$": "$$.Execution.Input.detail.user"
+        "auditEvent.$": "$.[0].auditEvent"
       },
+      "ResultPath": "$[0]",
+      "OutputPath": "$",
       "Next": "publish event to TxMa Queue"
     },
-    "Audit User Context With Restricted Fields": {
+    "Audit Event With Evidence & Restricted Info": {
       "Type": "Pass",
+      "Comment": "Merges the evidence detail contained in the details input by interpolating is into a stringified version of {evidence: {}}, {} is replaced with string form of the incoming evidence detail, which is then converted to Json and merge with the auditEvent state",
       "Parameters": {
-        "event_name.$": "States.Format('{}_{}', $[0].audit.prefix, $[0].audit.type)",
-        "timestamp.$": "$[1].epochSeconds.value",
-        "event_timestamp_ms.$": "$[2].epochMilliseconds.value",
-        "component_id.$": "$$.Execution.Input.detail.issuer",
-        "restricted.$": "$[0].restricted.value",
-        "user.$": "$$.Execution.Input.detail.user"
+        "auditEvent.$": "States.JsonMerge($.[0].auditEvent, States.StringToJson(States.Format('\\{\"extensions\":\\{\"evidence\": {}\\}\\}', States.JsonToString($$.Execution.Input.detail.evidence))), false)"
       },
+      "ResultPath": "$[0]",
+      "OutputPath": "$",
       "Next": "publish event to TxMa Queue"
     },
     "publish event to TxMa Queue": {

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -272,6 +272,9 @@
                   "hmrc_errors.$": "$.check-attempts-exist.Items[*].text.S"
                 }
               },
+              "ResultSelector": {
+                "contraIndicators.$": "$.Payload[*]"
+              },
               "Next": "Create Evidence (Failed)",
               "ResultPath": "$.ci_lambda_output"
             },
@@ -289,7 +292,8 @@
                         "checkMethod": "data"
                       }
                     ],
-                    "ci.$": "$.ci_lambda_output.Payload"
+                    "ci.$": "States.ArrayUnique($.ci_lambda_output.contraIndicators[*].ci)",
+                    "ciReasons.$": "$.ci_lambda_output.contraIndicators[*]"
                   }
                 ]
               },
@@ -384,7 +388,8 @@
             "Detail": {
               "auditPrefix": "${AuditEventPrefix}",
               "user.$": "$.user",
-              "issuer.$": "$.payload.iss"
+              "issuer.$": "$.payload.iss",
+              "evidence.$": "$.payload.vc.evidence"
             },
             "DetailType": "${AuditEventNameVcIssued}",
             "EventBusName": "${CheckHmrcEventBus}",


### PR DESCRIPTION
## Proposed changes

see: https://govukverify.atlassian.net/browse/OJ-2458

This include the reasons behind related to CIs in audit events, is also has the consequence of adding these to the VC
generated


### What changed

VC structure change to include CI reason and IPV_CHECK_HMRC_CRI_VC_ISSUED event updated to include CI reasons

### Why did it change

So that counter-fraud teams can use this as part of their investigation


- [OJ-2458](https://govukverify.atlassian.net/browse/OJ-2458)

