### PR TITLE
OJ-2458 vc issued audit event

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1438,6 +1438,7 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${MaxJwtTtlParameter}"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${JwtTtlUnitParameter}"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/check-hmrc-cri-api/contraindicationMappings"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/check-hmrc-cri-api/contraIndicatorReasonsMapping"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiableCredentialKmsSigningKeyId"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"

--- a/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
+++ b/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
@@ -351,6 +351,10 @@ describe("nino-issue-credential-happy", () => {
           {
             failedCheckDetails: [{ checkMethod: "data" }],
             ci: [expect.any(String)],
+            ciReasons: [
+              { ci: expect.any(String), reason: expect.any(String) },
+              { ci: expect.any(String), reason: expect.any(String) },
+            ],
             strengthScore: 2,
             txn: expect.any(String),
             type: "IdentityCheck",

--- a/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
+++ b/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
@@ -351,10 +351,6 @@ describe("nino-issue-credential-happy", () => {
           {
             failedCheckDetails: [{ checkMethod: "data" }],
             ci: [expect.any(String)],
-            ciReasons: [
-              { ci: expect.any(String), reason: expect.any(String) },
-              { ci: expect.any(String), reason: expect.any(String) },
-            ],
             strengthScore: 2,
             txn: expect.any(String),
             type: "IdentityCheck",

--- a/integration-tests/step-functions/mocked/nino-issue-credential/MockConfigFile.json
+++ b/integration-tests/step-functions/mocked/nino-issue-credential/MockConfigFile.json
@@ -363,7 +363,7 @@
     "FetchCI": {
       "0": {
         "Return": {
-          "Payload": ["AAA"],
+          "Payload": [{ "ci": "AAA", "reason": "reason for ci"} ],
           "SdkHttpMetadata": {
             "HttpStatusCode": 200
           },

--- a/integration-tests/step-functions/mocked/nino-issue-credential/MockConfigFile.json
+++ b/integration-tests/step-functions/mocked/nino-issue-credential/MockConfigFile.json
@@ -59,11 +59,11 @@
               "Value": "dummy-value"
             },
             {
-              "Name": "/check-hmrc-cri-api-suraj-cache/MaxJwtTtl",
+              "Name": "/check-hmrc-cri-api-cache/MaxJwtTtl",
               "Value": "dummy-value"
             },
             {
-              "Name": "/check-hmrc-cri-api-suraj-cache/JwtTtlUnit",
+              "Name": "/check-hmrc-cri-api-cache/JwtTtlUnit",
               "Value": "dummy-value"
             },
             {
@@ -81,6 +81,10 @@
             {
               "Name": "/common-cri-api/verifiable-credential/issuer",
               "Value": "dummy-value"
+            },
+            {
+              "Name": "/check-hmrc-cri-api/contraIndicatorReasonsMapping",
+              "Value": "[{\"ci\":\"AAA\",\"reason\":\"The reason for the CI\"}]"
             }
           ]
         }
@@ -363,7 +367,12 @@
     "FetchCI": {
       "0": {
         "Return": {
-          "Payload": [{ "ci": "AAA", "reason": "reason for ci"} ],
+          "Payload": [
+            {
+              "ci": "AAA",
+              "reason": "The reason for the CI"
+            }
+          ],
           "SdkHttpMetadata": {
             "HttpStatusCode": 200
           },

--- a/lambdas/ci-mapping/src/ci-mapping-event-validator.ts
+++ b/lambdas/ci-mapping/src/ci-mapping-event-validator.ts
@@ -1,48 +1,128 @@
 import {
+  ContraIndicator,
   allMappedHmrcErrors,
-  flattenCommaSepInput,
+  convertInputToArray,
+  getHmrcErrsCiRecord,
   isCiHmrcErrorsMappingValid,
 } from "./utils/ci-mapping-util";
 
+const CONTRAINDICATION_MAPPINGS_ABSENT_ERROR =
+  "ContraIndicationMapping cannot be undefined in CiMappingEvent";
+const CONTRAINDICATOR_REASONS_MAPPINGS_ABSENT_ERROR =
+  "ContraIndicatorReasonsMapping cannot be undefined in CiMappingEvent";
+
 export const HMRC_ERRORS_ABSENT = "Hmrc errors absent in CiMappingEvent";
 export interface CiMappingEvent {
-  ci_mapping: string[];
-  hmrc_errors: string[];
+  contraIndicationMapping: string[];
+  hmrcErrors: string[];
+  contraIndicatorReasonsMapping: Array<CiReasonsMapping>;
+}
+
+export interface CiReasonsMapping {
+  ci: string;
+  reason: string;
 }
 
 export const validateInputs = (event: CiMappingEvent) => {
-  const ci_mappings = getCiMapping(event?.ci_mapping);
-  const hmrc_errors = getInputHmrcErrors(event.hmrc_errors);
+  const contraIndicationMapping = getContraIndicationMappingMapping(
+    event.contraIndicationMapping
+  );
+  const hmrcErrors = getInputHmrcErrors(event.hmrcErrors);
+  const contraIndicatorReasonsMapping = getCiReasonsMapping(
+    event.contraIndicatorReasonsMapping
+  );
 
   const hmrcErrorIsNotMapped = (hmrcError: string) =>
-    !allMappedHmrcErrors(ci_mappings).includes(hmrcError);
+    !allMappedHmrcErrors(contraIndicationMapping).includes(hmrcError);
 
-  const allHmrcErrorsUnMatched = hmrc_errors.every(hmrcErrorIsNotMapped);
-  const someHmrcErrorsUnMatched = hmrc_errors.some(hmrcErrorIsNotMapped);
+  const allHmrcErrorsUnMatched = hmrcErrors.every(hmrcErrorIsNotMapped);
+  const someHmrcErrorsUnMatched = hmrcErrors.some(hmrcErrorIsNotMapped);
 
-  if (!isCiHmrcErrorsMappingValid(ci_mappings)) {
-    throw new Error("ci_mapping format is invalid");
+  if (!isCiHmrcErrorsMappingValid(contraIndicationMapping)) {
+    throw new Error("ContraIndicationMapping format is invalid");
   } else if (allHmrcErrorsUnMatched) {
-    throw new Error("No matching hmrc_error for any ci_mapping");
+    throw new Error("No matching hmrcError for any ContraIndicationMapping");
   } else if (someHmrcErrorsUnMatched) {
-    throw new Error("Not all items in hmrc_errors have matching ci_mapping");
+    throw new Error(
+      "Not all items in hmrc_errors have matching ContraIndicationMapping"
+    );
   }
-
-  return { ci_mappings, hmrc_errors };
+  throwUnMatchedCIsAreDetectedError(
+    contraIndicatorReasonsMapping,
+    contraIndicationMapping
+  );
+  return {
+    contraIndicationMapping,
+    hmrcErrors,
+    contraIndicatorReasonsMapping,
+  };
 };
 
-const getCiMapping = (ci_mapping?: string[]) => {
-  if (ci_mapping && ci_mapping.length > 0) {
-    return ci_mapping;
-  }
-  throw new Error("ci_mapping cannot be undefined in CiMappingEvent");
+export const getContraIndicatorWithReason = (
+  ciReasons: CiReasonsMapping[],
+  contraIndicators: ContraIndicator[]
+): ContraIndicator[] => {
+  return contraIndicators.map((c) => ({
+    ci: c.ci,
+    reason: ciReasons?.find((r) => areCIsEqual(r.ci, c.ci))?.reason,
+  }));
 };
 
-const getInputHmrcErrors = (hmrc_errors: string[] = []) => {
-  if (hmrc_errors.length === 0) {
+const areCIsEqual = (reasonCi?: string, contraCi?: string): boolean =>
+  reasonCi?.trim() === contraCi?.trim();
+
+const getContraIndicationMappingMapping = (
+  contraIndicationMapping: string[]
+): string[] => {
+  if (contraIndicationMapping?.length) {
+    return contraIndicationMapping;
+  }
+  throw new Error(CONTRAINDICATION_MAPPINGS_ABSENT_ERROR);
+};
+
+const getCiReasonsMapping = (
+  ciReasonsMapping: CiReasonsMapping[]
+): CiReasonsMapping[] => {
+  if (ciReasonsMapping?.length) {
+    return ciReasonsMapping;
+  }
+  throw new Error(CONTRAINDICATOR_REASONS_MAPPINGS_ABSENT_ERROR);
+};
+
+const getInputHmrcErrors = (hmrcErrors: string[] = []) => {
+  if (!hmrcErrors.length) {
     throw new Error(HMRC_ERRORS_ABSENT);
   }
-  return hmrc_errors.reduce((result, hmrc_error) => {
-    return result.concat(flattenCommaSepInput(hmrc_error));
+  return hmrcErrors.reduce((result, hmrcError) => {
+    return result.concat(convertInputToArray(hmrcError));
   }, [] as string[]);
+};
+
+const throwUnMatchedCIsAreDetectedError = (
+  ciReasons: CiReasonsMapping[],
+  ciMappings: string[]
+): void => {
+  const reasonsMap = new Set(ciReasons.map((r) => r?.ci?.trim()));
+  const contraMap = new Set(
+    ciMappings.map((c) => getHmrcErrsCiRecord(c)?.ciValue?.trim())
+  );
+
+  const unMatchedCIsFromReasons = [...reasonsMap].filter(
+    (ci) => !contraMap.has(ci)
+  );
+  const unMatchedCIsFromContraIndications = [...contraMap].filter(
+    (ci) => !reasonsMap.has(ci)
+  );
+  const unMatchedCIs = [
+    ...unMatchedCIsFromReasons,
+    ...unMatchedCIsFromContraIndications,
+  ];
+  const configurationLocation = unMatchedCIsFromReasons?.length
+    ? "ContraIndicatorReasonsMapping"
+    : "ContraIndicationMappings";
+
+  if (unMatchedCIs?.length)
+    throw new Error(
+      `Unmatched ${configurationLocation} ${unMatchedCIs} detected in configured mappings`
+    );
 };

--- a/lambdas/ci-mapping/src/ci-mapping-handler.ts
+++ b/lambdas/ci-mapping/src/ci-mapping-handler.ts
@@ -7,7 +7,8 @@ import {
 import { Logger } from "@aws-lambda-powertools/logger";
 import {
   getHmrcErrsCiRecord,
-  deduplicateValues,
+  ContraIndicator,
+  deduplicateContraIndicators,
 } from "./utils/ci-mapping-util";
 
 const logger = new Logger();
@@ -15,7 +16,7 @@ export class CiMappingHandler implements LambdaInterface {
   public async handler(
     event: CiMappingEvent,
     _context: unknown
-  ): Promise<Array<string>> {
+  ): Promise<Array<ContraIndicator>> {
     try {
       return getCIsForHmrcErrors(event);
     } catch (error: unknown) {
@@ -30,7 +31,7 @@ export class CiMappingHandler implements LambdaInterface {
   }
 }
 
-const getCIsForHmrcErrors = (event: CiMappingEvent): Array<string> => {
+const getCIsForHmrcErrors = (event: CiMappingEvent): Array<ContraIndicator> => {
   const { ci_mappings, hmrc_errors } = validateInputs(event);
 
   const contraIndicators = ci_mappings?.flatMap((ci) => {
@@ -44,10 +45,10 @@ const getCIsForHmrcErrors = (event: CiMappingEvent): Array<string> => {
           .map((value) => value.trim())
           .includes(hmrcError)
       )
-      .map(() => ciValue.trim());
+      .map((hmrcError) => ({ ci: ciValue.trim(), reason: hmrcError.trim() }));
   });
 
-  return deduplicateValues(contraIndicators);
+  return deduplicateContraIndicators(contraIndicators);
 };
 
 const handlerClass = new CiMappingHandler();

--- a/lambdas/ci-mapping/src/utils/ci-mapping-util.ts
+++ b/lambdas/ci-mapping/src/utils/ci-mapping-util.ts
@@ -1,7 +1,27 @@
 export type HmrcErrsCiRecord = Record<"mappedHmrcErrors" | "ciValue", string>;
+export type ContraIndicator = {
+  ci: string;
+  reason: string;
+};
 
 export const deduplicateValues = (values: string[]): string[] =>
   Array.from(new Set(values));
+export const deduplicateContraIndicators = (
+  values: Array<ContraIndicator>
+): Array<ContraIndicator> => {
+  const uniqueIndicators = new Set<string>();
+
+  const uniqueStrings = values.map(
+    (indicator) => `${indicator.ci}@${indicator.reason}`
+  );
+
+  uniqueStrings.forEach(uniqueIndicators.add, uniqueIndicators);
+
+  return Array.from(uniqueIndicators).map((str) => {
+    const [ci, reason] = str.split("@");
+    return { ci, reason };
+  });
+};
 
 export const getHmrcErrsCiRecord = (pair: string): HmrcErrsCiRecord => {
   const [key, value] = pair.split(":");

--- a/lambdas/ci-mapping/src/utils/ci-mapping-util.ts
+++ b/lambdas/ci-mapping/src/utils/ci-mapping-util.ts
@@ -1,26 +1,7 @@
 export type HmrcErrsCiRecord = Record<"mappedHmrcErrors" | "ciValue", string>;
 export type ContraIndicator = {
-  ci: string;
-  reason: string;
-};
-
-export const deduplicateValues = (values: string[]): string[] =>
-  Array.from(new Set(values));
-export const deduplicateContraIndicators = (
-  values: Array<ContraIndicator>
-): Array<ContraIndicator> => {
-  const uniqueIndicators = new Set<string>();
-
-  const uniqueStrings = values.map(
-    (indicator) => `${indicator.ci}@${indicator.reason}`
-  );
-
-  uniqueStrings.forEach(uniqueIndicators.add, uniqueIndicators);
-
-  return Array.from(uniqueIndicators).map((str) => {
-    const [ci, reason] = str.split("@");
-    return { ci, reason };
-  });
+  ci?: string;
+  reason?: string;
 };
 
 export const getHmrcErrsCiRecord = (pair: string): HmrcErrsCiRecord => {
@@ -45,7 +26,5 @@ export const isCiHmrcErrorsMappingValid = (mappings: string[]) =>
     );
   });
 
-export const flattenCommaSepInput = (CommaSepInput: string) =>
-  CommaSepInput.split(",").flatMap((comma_sep_string) =>
-    comma_sep_string.split(",").map((value) => value.trim())
-  );
+export const convertInputToArray = (CommaSepInput: string) =>
+  CommaSepInput.split(",").map((CommaSepInput) => CommaSepInput.trim());

--- a/lambdas/ci-mapping/tests/ci-mapping-event-validator.test.ts
+++ b/lambdas/ci-mapping/tests/ci-mapping-event-validator.test.ts
@@ -1,116 +1,241 @@
 import {
   CiMappingEvent,
+  CiReasonsMapping,
   validateInputs,
 } from "../src/ci-mapping-event-validator";
 
 describe("ci-mapping-event-validator", () => {
   describe("validateInputs", () => {
-    const ci_mapping = [
+    const contraIndicationMapping = [
       "aaaa:ci_1",
       "bbbb,cccc,dddd:ci_2",
       "eeee,ffff,gggg:ci_3",
     ];
+    const contraIndicatorReasonsMapping = [
+      { ci: "ci_1", reason: "ci_1 reason" },
+      { ci: "ci_2", reason: "ci_2 reason" },
+      { ci: "ci_3", reason: "ci_3 reason" },
+    ];
     it("should return successfully when CiMappingEvent is valid", () => {
       expect(
         validateInputs({
-          ci_mapping,
-          hmrc_errors: ["aaaa"],
+          contraIndicationMapping,
+          hmrcErrors: ["aaaa"],
+          contraIndicatorReasonsMapping,
         })
       ).toEqual({
-        ci_mappings: ci_mapping,
-        hmrc_errors: ["aaaa"],
+        contraIndicationMapping,
+        hmrcErrors: ["aaaa"],
+        contraIndicatorReasonsMapping,
       });
     });
 
-    it("throws error, no matching hmrc_error for any ci_mapping", () => {
+    it("throws error, no matching hmrc_error for any ContraIndicationMapping", () => {
       expect(() =>
         validateInputs({
-          ci_mapping,
-          hmrc_errors: ["not-a-mapped-error"],
+          contraIndicationMapping,
+          hmrcErrors: ["not-a-mapped-error"],
+          contraIndicatorReasonsMapping,
         })
-      ).toThrow("No matching hmrc_error for any ci_mapping");
+      ).toThrow("No matching hmrcError for any ContraIndicationMapping");
     });
 
-    it("throws an error, not all items in hmrc_errors have matching ci_mapping", () => {
+    it("throws an error, not all items in hmrc_errors have matching ContraIndicationMapping", () => {
       expect(() =>
         validateInputs({
-          ci_mapping,
-          hmrc_errors: ["aaaa", "not-a-mapped-error"],
+          contraIndicationMapping,
+          hmrcErrors: ["aaaa", "not-a-mapped-error"],
+          contraIndicatorReasonsMapping,
         })
-      ).toThrow("Not all items in hmrc_errors have matching ci_mapping");
+      ).toThrow(
+        "Not all items in hmrc_errors have matching ContraIndicationMapping"
+      );
     });
 
     describe("CiMappingEvent has an empty, blank or undefined component", () => {
-      it("throws error, ci_mapping cannot be undefined given CiMappingEvent is an empty object", () => {
+      it("throws error, ContraIndicationMapping cannot be undefined given CiMappingEvent is an empty object", () => {
         expect(() => validateInputs({} as CiMappingEvent)).toThrow(
-          "ci_mapping cannot be undefined"
+          "ContraIndicationMapping cannot be undefined in CiMappingEvent"
         );
       });
 
-      it("throws ci_mapping cannot be undefined, given both ci_mapping and hmrc errors array are empty", () => {
+      it("throws ContraIndicationMapping cannot be undefined, given both ContraIndicationMapping, contraIndicatorReasonsMapping and hmrc errors array are empty", () => {
         expect(() =>
           validateInputs({
-            ci_mapping: [],
-            hmrc_errors: [],
+            contraIndicationMapping: [],
+            hmrcErrors: [],
+            contraIndicatorReasonsMapping: [],
           })
-        ).toThrow("ci_mapping cannot be undefined");
+        ).toThrow(
+          "ContraIndicationMapping cannot be undefined in CiMappingEvent"
+        );
       });
 
       it.each([undefined, [], ""])(
-        "throws hmrc errors absent in CiMappingEvent given only hmrc errors array is %s and a valid ci_mapping",
+        "throws hmrc errors absent in CiMappingEvent given only hmrc errors array is %s and valid ContraIndicationMapping and contraIndicatorReasonsMapping",
         (actual) => {
           expect(() =>
             validateInputs({
-              ci_mapping,
-              hmrc_errors: actual as unknown as string[],
+              contraIndicationMapping,
+              hmrcErrors: actual as unknown as string[],
+              contraIndicatorReasonsMapping,
             })
           ).toThrow("Hmrc errors absent in CiMappingEvent");
         }
       );
 
       it.each([undefined, [], ""])(
-        "throws ci_mapping cannot be undefined, given valid hmrc error and ci_mapping is %s",
+        "throws ContraIndicationMapping cannot be undefined, given valid hmrc error and ContraIndicationMapping is %s",
         (actual) => {
           expect(() =>
             validateInputs({
-              ci_mapping: actual as unknown as string[],
-              hmrc_errors: ["aaaa"],
+              contraIndicationMapping: actual as unknown as string[],
+              hmrcErrors: ["aaaa"],
+              contraIndicatorReasonsMapping: [
+                { ci: "aaaa", reason: undefined as unknown as string },
+              ],
             })
-          ).toThrow("ci_mapping cannot be undefined");
+          ).toThrow(
+            "ContraIndicationMapping cannot be undefined in CiMappingEvent"
+          );
+        }
+      );
+
+      it.each([undefined, [], ""])(
+        "throws ContraIndicatorReasonsMapping cannot be undefined, given valid hmrc error and ContraIndicatorReasonsMapping is %s",
+        (actual) => {
+          expect(() =>
+            validateInputs({
+              contraIndicationMapping,
+              hmrcErrors: ["aaaa"],
+              contraIndicatorReasonsMapping:
+                actual as unknown as CiReasonsMapping[],
+            })
+          ).toThrow(
+            "ContraIndicatorReasonsMapping cannot be undefined in CiMappingEvent"
+          );
         }
       );
     });
 
-    describe("Given ci_mapping format is invalid", () => {
+    describe("Given ContraIndicationMapping format is invalid", () => {
       it("throws error when ci entries that are colon separated are without hmrc error key but with a CI value", async () => {
         expect(() =>
           validateInputs({
-            ci_mapping: [":Ci_1"],
-            hmrc_errors: [""],
+            contraIndicationMapping: [":Ci_1"],
+            hmrcErrors: [""],
+            contraIndicatorReasonsMapping: [{ ci: "Ci_1" } as CiReasonsMapping],
           })
-        ).toThrow("ci_mapping format is invalid");
+        ).toThrow("ContraIndicationMapping format is invalid");
       });
 
       it("throws error with ci entries that are colon separated with a hmrc error key but without a CI value", async () => {
         expect(() =>
           validateInputs({
-            ci_mapping: ["err1:"],
-            hmrc_errors: [""],
+            contraIndicationMapping: ["err1:"],
+            hmrcErrors: [""],
+            contraIndicatorReasonsMapping: [{ ci: "" } as CiReasonsMapping],
           })
-        ).toThrow("ci_mapping format is invalid");
+        ).toThrow("ContraIndicationMapping format is invalid");
       });
 
       it("throws error given ci entries that are not colon separated", async () => {
         expect(() =>
           validateInputs({
-            ci_mapping: [
+            contraIndicationMapping: [
               "aaaa,ci_1",
               "bbbb,cccc,dddd;ci_2",
               "eeee,ffff,gggg/ci_3",
             ],
-            hmrc_errors: ["aaaa"],
+            hmrcErrors: ["aaaa"],
+            contraIndicatorReasonsMapping: [
+              {
+                ci: "",
+                reason: "",
+              },
+            ],
           })
-        ).toThrow("ci_mapping format is invalid");
+        ).toThrow("ContraIndicationMapping format is invalid");
+      });
+    });
+
+    describe("Given ContraIndication Mapping and ContraIndicator reason mapping are out of sync", () => {
+      it("throws an unmatched error when ContraIndicationMapping is missing a CI", () => {
+        const contraIndicationMappingMissingCi_3 = [
+          "aaaa:ci_1",
+          "bbbb,cccc,dddd:ci_2",
+        ];
+        expect(() =>
+          validateInputs({
+            contraIndicationMapping: contraIndicationMappingMissingCi_3,
+            hmrcErrors: ["aaaa"],
+            contraIndicatorReasonsMapping,
+          })
+        ).toThrow(
+          "Unmatched ContraIndicatorReasonsMapping ci_3 detected in configured mappings"
+        );
+      });
+
+      it("throws an unmatched error when ContraIndicationMapping is missing multiple CIs", () => {
+        const contraIndicationMappingMissingCis = ["aaaa:ci_1"];
+        expect(() =>
+          validateInputs({
+            contraIndicationMapping: contraIndicationMappingMissingCis,
+            hmrcErrors: ["aaaa"],
+            contraIndicatorReasonsMapping,
+          })
+        ).toThrow(
+          "Unmatched ContraIndicatorReasonsMapping ci_2,ci_3 detected in configured mappings"
+        );
+      });
+
+      it("throws a different undefined error when all ContraIndicatorReasonsMapping is missing", () => {
+        const contraIndicationMappingMissingCi_3 = ["aaaa:ci_1"];
+        const validatedResult = () =>
+          validateInputs({
+            contraIndicationMapping: contraIndicationMappingMissingCi_3,
+            hmrcErrors: ["aaaa"],
+            contraIndicatorReasonsMapping: [],
+          });
+        expect(() => validatedResult()).not.toThrow(
+          "Unmatched ContraIndicatorReasonsMapping ci_2,ci_3 detected in configured mappings"
+        );
+        expect(() => validatedResult()).toThrow(
+          "ContraIndicatorReasonsMapping cannot be undefined in CiMappingEvent"
+        );
+      });
+
+      it("throws an unmatched error when ContraIndicatorReasonsMapping is missing multiple CI", () => {
+        const contraIndicatorReasonsMappingMissingCis = [
+          { ci: "ci_2", reason: "ci_2 reason" },
+        ];
+        expect(() =>
+          validateInputs({
+            contraIndicationMapping,
+            hmrcErrors: ["aaaa"],
+            contraIndicatorReasonsMapping:
+              contraIndicatorReasonsMappingMissingCis,
+          })
+        ).toThrow(
+          "Unmatched ContraIndicationMappings ci_1,ci_3 detected in configured mappings"
+        );
+      });
+
+      it("throws an unmatched error when ContraIndicatorReasonsMapping is missing multiple CIs", () => {
+        const contraIndicatorReasonsMappingMissingCi_1 = [
+          { ci: "ci_2", reason: "ci_2 reason" },
+          { ci: "ci_3", reason: "ci_3 reason" },
+        ];
+        expect(() =>
+          validateInputs({
+            contraIndicationMapping,
+            hmrcErrors: ["aaaa"],
+            contraIndicatorReasonsMapping:
+              contraIndicatorReasonsMappingMissingCi_1,
+          })
+        ).toThrow(
+          "Unmatched ContraIndicationMappings ci_1 detected in configured mappings"
+        );
       });
     });
   });

--- a/lambdas/ci-mapping/tests/utils/ci-mapping-utils.test.ts
+++ b/lambdas/ci-mapping/tests/utils/ci-mapping-utils.test.ts
@@ -2,45 +2,25 @@ import {
   getHmrcErrsCiRecord,
   allMappedHmrcErrors,
   isCiHmrcErrorsMappingValid,
-  deduplicateContraIndicators,
 } from "../../src/utils/ci-mapping-util";
 
 describe("ci-mapping-utils", () => {
-  const goodHmrcErrsCiRecordStringOne = "hmrc-error1,hmrc error2:Ci_1";
+  const goodHmrcErrsCiRecordStringOne =
+    '"An error description, with a comma",hmrc-error1,hmrc error2:Ci_1';
   const goodHmrcErrsCiRecordStringTwo = "bbbb,cccc,dddd:ci_2";
   const goodHmrcErrsCiRecordStringThree = "eeee,ffff,gggg:ci_3";
 
-  const ci_mapping = [
+  const ContraIndicationMapping = [
     goodHmrcErrsCiRecordStringOne,
     goodHmrcErrsCiRecordStringTwo,
     goodHmrcErrsCiRecordStringThree,
   ];
-  describe("deduplicate values", () => {
-    const test_cis = [
-      { ci: "ci_1", reason: "aaaa" },
-      { ci: "ci_2", reason: "bbbb" },
-      { ci: "ci_3", reason: "cccc" },
-    ];
-    it("should remove duplicates from inputs", () => {
-      expect(
-        deduplicateContraIndicators([
-          { reason: "aaaa", ci: "ci_1" },
-          { ci: "ci_2", reason: "bbbb" },
-          { ci: "ci_1", reason: "aaaa" },
-          { ci: "ci_3", reason: "cccc" },
-        ])
-      ).toEqual(test_cis);
-    });
-
-    it("should return input same input array, when no duplicates exist", () => {
-      expect(deduplicateContraIndicators(test_cis)).toEqual(test_cis);
-    });
-  });
 
   describe("get hmrc errors record", () => {
     it("should return an HmrcErrsCiRecord with hmrcErrors and ciValue", () => {
       expect(getHmrcErrsCiRecord(goodHmrcErrsCiRecordStringOne)).toEqual({
-        mappedHmrcErrors: "hmrc-error1,hmrc error2",
+        mappedHmrcErrors:
+          '"An error description, with a comma",hmrc-error1,hmrc error2',
         ciValue: "Ci_1",
       });
     });
@@ -48,8 +28,8 @@ describe("ci-mapping-utils", () => {
 
   describe("allMappedHmrcErrors", () => {
     it("should extract all hmrc errors in CiMapping into a comma list of the errors", () => {
-      expect(allMappedHmrcErrors(ci_mapping)).toBe(
-        "hmrc-error1,hmrc error2,bbbb,cccc,dddd,eeee,ffff,gggg"
+      expect(allMappedHmrcErrors(ContraIndicationMapping)).toBe(
+        '"An error description, with a comma",hmrc-error1,hmrc error2,bbbb,cccc,dddd,eeee,ffff,gggg'
       );
     });
   });
@@ -57,30 +37,32 @@ describe("ci-mapping-utils", () => {
   describe("is Ci Hmrc Errors Mapping Valid", () => {
     const badHmrcErrsWithoutCiRecordInString = "hmrc-error1,hmrc error2:";
     const badWithoutHmrcErrsCiRecordInString = ":ci_2";
-    const bad_ci_mapping = [
+    const bad_ContraIndicationMapping = [
       goodHmrcErrsCiRecordStringOne,
       badWithoutHmrcErrsCiRecordInString,
       goodHmrcErrsCiRecordStringTwo,
       badHmrcErrsWithoutCiRecordInString,
     ];
-    it("should return true given a valid ci_mapping", () => {
-      expect(isCiHmrcErrorsMappingValid(ci_mapping)).toBe(true);
+    it("should return true given a valid ContraIndicationMapping", () => {
+      expect(isCiHmrcErrorsMappingValid(ContraIndicationMapping)).toBe(true);
     });
 
-    it("should return false given invalid ci_mapping without CI component in string", () => {
+    it("should return false given invalid ContraIndicationMapping without CI component in string", () => {
       expect(
         isCiHmrcErrorsMappingValid([badHmrcErrsWithoutCiRecordInString])
       ).toBe(false);
     });
 
-    it("should return false given invalid ci_mapping without hmrc error component in string", () => {
+    it("should return false given invalid ContraIndicationMapping without hmrc error component in string", () => {
       expect(
         isCiHmrcErrorsMappingValid([badWithoutHmrcErrsCiRecordInString])
       ).toBe(false);
     });
 
-    it("should return false given invalid ci_mapping that has some good Hmrc Errors CiRecord String", () => {
-      expect(isCiHmrcErrorsMappingValid(bad_ci_mapping)).toBe(false);
+    it("should return false given invalid ContraIndicationMapping that has some good Hmrc Errors CiRecord String", () => {
+      expect(isCiHmrcErrorsMappingValid(bad_ContraIndicationMapping)).toBe(
+        false
+      );
     });
   });
 });

--- a/lambdas/ci-mapping/tests/utils/ci-mapping-utils.test.ts
+++ b/lambdas/ci-mapping/tests/utils/ci-mapping-utils.test.ts
@@ -1,8 +1,8 @@
 import {
-  deduplicateValues,
   getHmrcErrsCiRecord,
   allMappedHmrcErrors,
   isCiHmrcErrorsMappingValid,
+  deduplicateContraIndicators,
 } from "../../src/utils/ci-mapping-util";
 
 describe("ci-mapping-utils", () => {
@@ -16,15 +16,24 @@ describe("ci-mapping-utils", () => {
     goodHmrcErrsCiRecordStringThree,
   ];
   describe("deduplicate values", () => {
-    const test_cis = ["ci_1", "ci_2", "ci_3"];
+    const test_cis = [
+      { ci: "ci_1", reason: "aaaa" },
+      { ci: "ci_2", reason: "bbbb" },
+      { ci: "ci_3", reason: "cccc" },
+    ];
     it("should remove duplicates from inputs", () => {
-      expect(deduplicateValues(["ci_1", "ci_2", "ci_1", "ci_3"])).toEqual(
-        test_cis
-      );
+      expect(
+        deduplicateContraIndicators([
+          { reason: "aaaa", ci: "ci_1" },
+          { ci: "ci_2", reason: "bbbb" },
+          { ci: "ci_1", reason: "aaaa" },
+          { ci: "ci_3", reason: "cccc" },
+        ])
+      ).toEqual(test_cis);
     });
 
     it("should return input same input array, when no duplicates exist", () => {
-      expect(deduplicateValues(test_cis)).toEqual(test_cis);
+      expect(deduplicateContraIndicators(test_cis)).toEqual(test_cis);
     });
   });
 

--- a/step-functions/audit_event.asl.json
+++ b/step-functions/audit_event.asl.json
@@ -4,11 +4,12 @@
   "States": {
     "Get Audit name components": {
       "Type": "Pass",
+      "Comment": "The details JSON object is stringified using States.JsonToString and then split it on ':\"' creating an array with key and value as items if a key called evidence is found DetailsContainsEvidence returns boolean value true",
       "Parameters": {
         "prefix.$": "$$.Execution.Input.detail.auditPrefix",
-        "type.$": "$$.Execution.Input.detail-type"
+        "type.$": "$$.Execution.Input.detail-type",
+        "DetailsContainsEvidence.$": "States.ArrayContains(States.StringSplit(States.JsonToString($$.Execution.Input.detail), ':\"'), 'evidence')"
       },
-      "ResultPath": "$.audit",
       "Next": "Parallel"
     },
     "Parallel": {
@@ -119,36 +120,74 @@
     },
     "Is Restricted Info Present?": {
       "Type": "Choice",
+      "Comment": "This check uses the empty object returned from the CredentialSubjectFunction to determine there is no Restricted user info present",
       "Choices": [
         {
           "Variable": "$[0].restricted.containsUserInfo",
           "StringEquals": "{}",
-          "Next": "Add User Context"
+          "Next": "AuditEvent Without Restricted Info"
         }
       ],
-      "Default": "Audit User Context With Restricted Fields"
+      "Default": "Add Restricted Info to AuditEvent"
+    },
+    "AuditEvent Without Restricted Info": {
+      "Type": "Pass",
+      "Comment": "The user context info is returned only is there is no Restricted user information",
+      "Parameters": {
+        "event_name.$": "States.Format('{}_{}', $[0].prefix, $[0].type)",
+        "timestamp.$": "$[1].epochSeconds.value",
+        "event_timestamp_ms.$": "$[2].epochMilliseconds.value",
+        "component_id.$": "$$.Execution.Input.detail.issuer",
+        "user.$": "$$.Execution.Input.detail.user"
+      },
+      "ResultPath": "$[0].auditEvent",
+      "OutputPath": "$",
+      "Next": "Is evidence Present?"
+    },
+    "Add Restricted Info to AuditEvent": {
+      "Type": "Pass",
+      "Comment": "The user context info is returned in added with the Restricted user information",
+      "Parameters": {
+        "event_name.$": "States.Format('{}_{}', $[0].prefix, $[0].type)",
+        "timestamp.$": "$[1].epochSeconds.value",
+        "event_timestamp_ms.$": "$[2].epochMilliseconds.value",
+        "component_id.$": "$$.Execution.Input.detail.issuer",
+        "user.$": "$$.Execution.Input.detail.user",
+        "restricted.$": "$[0].restricted.value"
+      },
+      "ResultPath": "$[0].auditEvent",
+      "OutputPath": "$",
+      "Next": "Is evidence Present?"
+    },
+    "Is evidence Present?": {
+      "Type": "Choice",
+      "Comment": "This check uses the DetailsContainsEvidence boolean to know when to add evidence details to the audit structure",
+      "Choices": [
+        {
+          "Variable": "$[0].DetailsContainsEvidence",
+          "BooleanEquals": true,
+          "Next": "Audit Event With Evidence & Restricted Info"
+        }
+      ],
+      "Default": "Add User Context"
     },
     "Add User Context": {
       "Type": "Pass",
       "Parameters": {
-        "event_name.$": "States.Format('{}_{}', $[0].audit.prefix, $[0].audit.type)",
-        "timestamp.$": "$[1].epochSeconds.value",
-        "event_timestamp_ms.$": "$[2].epochMilliseconds.value",
-        "component_id.$": "$$.Execution.Input.detail.issuer",
-        "user.$": "$$.Execution.Input.detail.user"
+        "auditEvent.$": "$.[0].auditEvent"
       },
+      "ResultPath": "$[0]",
+      "OutputPath": "$",
       "Next": "publish event to TxMa Queue"
     },
-    "Audit User Context With Restricted Fields": {
+    "Audit Event With Evidence & Restricted Info": {
       "Type": "Pass",
+      "Comment": "Merges the evidence detail contained in the details input by interpolating is into a stringified version of {evidence: {}}, {} is replaced with string form of the incoming evidence detail, which is then converted to Json and merge with the auditEvent state",
       "Parameters": {
-        "event_name.$": "States.Format('{}_{}', $[0].audit.prefix, $[0].audit.type)",
-        "timestamp.$": "$[1].epochSeconds.value",
-        "event_timestamp_ms.$": "$[2].epochMilliseconds.value",
-        "component_id.$": "$$.Execution.Input.detail.issuer",
-        "restricted.$": "$[0].restricted.value",
-        "user.$": "$$.Execution.Input.detail.user"
+        "auditEvent.$": "States.JsonMerge($.[0].auditEvent, States.StringToJson(States.Format('\\{\"extensions\":\\{\"evidence\": {}\\}\\}', States.JsonToString($$.Execution.Input.detail.evidence))), false)"
       },
+      "ResultPath": "$[0]",
+      "OutputPath": "$",
       "Next": "publish event to TxMa Queue"
     },
     "publish event to TxMa Queue": {

--- a/step-functions/audit_event.asl.json
+++ b/step-functions/audit_event.asl.json
@@ -132,7 +132,7 @@
     },
     "AuditEvent Without Restricted Info": {
       "Type": "Pass",
-      "Comment": "The user context info is returned only is there is no Restricted user information",
+      "Comment": "The user context info is returned only if there is no Restricted user information",
       "Parameters": {
         "event_name.$": "States.Format('{}_{}', $[0].prefix, $[0].type)",
         "timestamp.$": "$[1].epochSeconds.value",
@@ -182,7 +182,7 @@
     },
     "Audit Event With Evidence & Restricted Info": {
       "Type": "Pass",
-      "Comment": "Merges the evidence detail contained in the details input by interpolating is into a stringified version of {evidence: {}}, {} is replaced with string form of the incoming evidence detail, which is then converted to Json and merge with the auditEvent state",
+      "Comment": "Merges the evidence detail contained in the details input by interpolating it into a stringified version of {evidence: {}}, {} is replaced with string form of the incoming evidence detail, which is then converted to Json and merge with the auditEvent state",
       "Parameters": {
         "auditEvent.$": "States.JsonMerge($.[0].auditEvent, States.StringToJson(States.Format('\\{\"extensions\":\\{\"evidence\": {}\\}\\}', States.JsonToString($$.Execution.Input.detail.evidence))), false)"
       },

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -1,434 +1,456 @@
 {
-  "Comment": "A description of my state machine",
-  "StartAt": "Fetch SSM Parameters",
-  "States": {
-    "Fetch SSM Parameters": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "Parameters": {
-        "FunctionName": "${SsmParametersFunction}",
-        "Payload": {
-          "parameters.$": "States.Array('/${CommonStackName}/SessionTableName','${MaxJwtTtlParameter}','${JwtTtlUnitParameter}','/${CommonStackName}/verifiableCredentialKmsSigningKeyId','/${CommonStackName}/PersonIdentityTableName','/check-hmrc-cri-api/contraindicationMappings','/${CommonStackName}/verifiable-credential/issuer')"
-        }
-      },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException"
-          ],
-          "IntervalSeconds": 1,
-          "MaxAttempts": 3,
-          "BackoffRate": 2
-        }
-      ],
-      "Next": "Query Session Item",
-      "ResultPath": "$.parameters",
-      "ResultSelector": {
-        "SessionTableName.$": "$.Payload[0].Value",
-        "MaxJwtTtl.$": "$.Payload[1].Value",
-        "JwtTtlUnit.$": "$.Payload[2].Value",
-        "verifiableCredentialKmsSigningKeyId.$": "$.Payload[3].Value",
-        "PersonIdentityTableName.$": "$.Payload[4].Value",
-        "contraindicationMappings.$": "$.Payload[5].Value",
-        "issuer.$": "$.Payload[6].Value"
-      }
-    },
-    "Query Session Item": {
-      "Type": "Task",
-      "Parameters": {
-        "TableName.$": "$.parameters.SessionTableName",
-        "IndexName": "access-token-index-with-event-data",
-        "KeyConditionExpression": "accessToken = :value",
-        "ExpressionAttributeValues": {
-          ":value": {
-            "S.$": "$.bearerToken"
-          }
-        }
-      },
-      "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
-      "ResultPath": "$.querySessionResult",
-      "Next": "Bearer Token Valid?"
-    },
-    "Bearer Token Valid?": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.querySessionResult.Count",
-          "NumericGreaterThan": 0,
-          "Next": "Is Persistent Id Present?"
-        }
-      ],
-      "Default": "Err: Invalid Bearer Token"
-    },
-    "Is Persistent Id Present?": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.querySessionResult.Items[0].persistentSessionId",
-          "IsPresent": true,
-          "Next": "Get Audit UserInfo With Persistent Id"
-        }
-      ],
-      "Default": "Get Audit UserInfo"
-    },
-    "Get Audit UserInfo": {
-      "Type": "Pass",
-      "Parameters": {
-        "govuk_signin_journey_id.$": "$.querySessionResult.Items[0].clientSessionId.S",
-        "ip_address.$": "$.querySessionResult.Items[0].clientIpAddress.S",
-        "session_id.$": "$.querySessionResult.Items[0].sessionId.S",
-        "user_id.$": "$.querySessionResult.Items[0].subject.S"
-      },
-      "ResultPath": "$.userAuditInfo",
-      "Next": "Filter Session Result"
-    },
-    "Get Audit UserInfo With Persistent Id": {
-      "Type": "Pass",
-      "Parameters": {
-        "govuk_signin_journey_id.$": "$.querySessionResult.Items[0].clientSessionId.S",
-        "ip_address.$": "$.querySessionResult.Items[0].clientIpAddress.S",
-        "persistent_session_id.$": "$.querySessionResult.Items[0].persistentSessionId.S",
-        "session_id.$": "$.querySessionResult.Items[0].sessionId.S",
-        "user_id.$": "$.querySessionResult.Items[0].subject.S"
-      },
-      "ResultPath": "$.userAuditInfo",
-      "Next": "Filter Session Result"
-    },
-    "Filter Session Result": {
-      "Type": "Pass",
-      "Next": "Create Credential Subject And Evidence",
-      "ResultPath": "$.querySession",
-      "Parameters": {
-        "sessionId.$": "$.querySessionResult.Items[0].sessionId.S",
-        "subject.$": "$.querySessionResult.Items[0].subject.S",
-        "userAuditInfo.$": "$.userAuditInfo"
-      }
-    },
-    "Err: Invalid Bearer Token": {
-      "Type": "Pass",
-      "End": true,
-      "Parameters": {
-        "error": "Invalid Bearer Token",
-        "httpStatus": 400
-      }
-    },
-    "Create Credential Subject And Evidence": {
-      "Type": "Parallel",
-      "Next": "Create VC Claim Set",
-      "Branches": [
-        {
-          "StartAt": "Fetch details from person identity",
-          "States": {
-            "Fetch details from person identity": {
-              "Type": "Task",
-              "Next": "Fetch Nino",
-              "Parameters": {
-                "TableName.$": "$.parameters.PersonIdentityTableName",
-                "KeyConditionExpression": "sessionId = :value",
-                "ExpressionAttributeValues": {
-                  ":value": {
-                    "S.$": "$.querySession.sessionId"
-                  }
-                }
-              },
-              "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
-              "ResultPath": "$.userDetails"
-            },
-            "Fetch Nino": {
-              "Type": "Task",
-              "Resource": "arn:aws:states:::dynamodb:getItem",
-              "Parameters": {
-                "TableName": "${NinoUsersTable}",
-                "Key": {
-                  "sessionId": {
-                    "S.$": "$.userDetails.Items[0].sessionId.S"
-                  }
-                }
-              },
-              "Next": "Create Credential Subject",
-              "ResultPath": "$.nino"
-            },
-            "Create Credential Subject": {
-              "Type": "Task",
-              "Resource": "arn:aws:states:::lambda:invoke",
-              "Parameters": {
-                "FunctionName": "${CredentialSubjectFunctionArn}",
-                "Payload": {
-                  "userInfoEvent.$": "$.userDetails",
-                  "nino.$": "$.nino.Item.nino.S"
-                }
-              },
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.AWSLambdaException",
-                    "Lambda.SdkClientException",
-                    "Lambda.TooManyRequestsException"
-                  ],
-                  "IntervalSeconds": 1,
-                  "MaxAttempts": 3,
-                  "BackoffRate": 2
-                }
-              ],
-              "ResultSelector": {
-                "Payload.$": "$.Payload"
-              },
-              "ResultPath": "$.credentialSubject",
-              "End": true
-            }
-          }
-        },
-        {
-          "StartAt": "Fetch exp time and NBF",
-          "States": {
-            "Fetch exp time and NBF": {
-              "Type": "Task",
-              "Resource": "arn:aws:states:::lambda:invoke",
-              "Parameters": {
-                "FunctionName": "${TimeFunctionArn}",
-                "Payload": {
-                  "ttlValue.$": "$.parameters.MaxJwtTtl",
-                  "ttlUnit.$": "$.parameters.JwtTtlUnit"
-                }
-              },
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.AWSLambdaException",
-                    "Lambda.SdkClientException",
-                    "Lambda.TooManyRequestsException"
-                  ],
-                  "IntervalSeconds": 2,
-                  "MaxAttempts": 6,
-                  "BackoffRate": 2
-                }
-              ],
-              "ResultPath": "$.time",
-              "End": true
-            }
-          }
-        },
-        {
-          "StartAt": "Fetch Failed Attempts",
-          "States": {
-            "Fetch Failed Attempts": {
-              "Type": "Task",
-              "Next": "Add Type to VC",
-              "Parameters": {
-                "TableName": "${UserAttemptsTable}",
-                "KeyConditionExpression": "sessionId = :value",
-                "FilterExpression": "attempt = :attempt",
-                "ExpressionAttributeValues": {
-                  ":value": {
-                    "S.$": "$.querySession.sessionId"
-                  },
-                  ":attempt": {
-                    "S": "FAIL"
-                  }
-                }
-              },
-              "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
-              "ResultPath": "$.check-attempts-exist"
-            },
-            "Add Type to VC": {
-              "Type": "Pass",
-              "Next": "Did the user fail or pass the check?",
-              "Parameters": {
-                "type": ["VerifiableCredential", "IdentityCheckCredential"],
-                "@context": [
-                  "https://www.w3.org/2018/credentials/v1",
-                  "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
-                ]
-              },
-              "ResultPath": "$.vctype"
-            },
-            "Did the user fail or pass the check?": {
-              "Type": "Choice",
-              "Choices": [
-                {
-                  "Or": [
-                    {
-                      "Variable": "$.check-attempts-exist.Count",
-                      "NumericGreaterThanEquals": 2
-                    }
-                  ],
-                  "Next": "Fetch CI"
-                }
-              ],
-              "Default": "Create Evidence (Pass)"
-            },
-            "Fetch CI": {
-              "Type": "Task",
-              "Resource": "arn:aws:states:::lambda:invoke",
-              "Parameters": {
-                "FunctionName": "${CiMappingFunctionArn}",
-                "Payload": {
-                  "ci_mapping.$": "States.StringSplit($.parameters.contraindicationMappings,'||')",
-                  "hmrc_errors.$": "$.check-attempts-exist.Items[*].text.S"
-                }
-              },
-              "ResultSelector": {
-                "contraIndicators.$": "$.Payload[*]"
-              },
-              "Next": "Create Evidence (Failed)",
-              "ResultPath": "$.ci_lambda_output"
-            },
-            "Create Evidence (Failed)": {
-              "Type": "Pass",
-              "Parameters": {
-                "evidence": [
-                  {
-                    "type": "IdentityCheck",
-                    "txn.$": "States.UUID()",
-                    "strengthScore": 2,
-                    "validityScore": 0,
-                    "failedCheckDetails": [
-                      {
-                        "checkMethod": "data"
-                      }
-                    ],
-                    "ci.$": "States.ArrayUnique($.ci_lambda_output.contraIndicators[*].ci)",
-                    "ciReasons.$": "$.ci_lambda_output.contraIndicators[*]"
-                  }
-                ]
-              },
-              "ResultPath": "$.vc",
-              "End": true
-            },
-            "Create Evidence (Pass)": {
-              "Type": "Pass",
-              "Parameters": {
-                "evidence": [
-                  {
-                    "type": "IdentityCheck",
-                    "txn.$": "States.UUID()",
-                    "strengthScore": 2,
-                    "validityScore": 2,
-                    "checkDetails": [
-                      {
-                        "checkMethod": "data"
-                      }
-                    ]
-                  }
-                ]
-              },
-              "ResultPath": "$.vc",
-              "End": true
-            }
-          }
-        }
-      ]
-    },
-    "Create VC Claim Set": {
-      "Type": "Pass",
-      "Next": "Sign VC claimsSet",
-      "Parameters": {
-        "header": {
-          "kid.$": "$[0].parameters.verifiableCredentialKmsSigningKeyId",
-          "typ": "JWT",
-          "alg": "ES256"
-        },
-        "payload": {
-          "jti.$": "States.Format('urn:uuid:{}',States.UUID())",
-          "sub.$": "$[0].querySession.subject",
-          "iss.$": "$[0].parameters.issuer",
-          "nbf.$": "$[1].time.Payload.nbf",
-          "exp.$": "$[1].time.Payload.expiry",
-          "vc": {
-            "type.$": "$[2].vctype.type",
-            "@context.$": "$[2].vctype.@context",
-            "credentialSubject.$": "$[0].credentialSubject.Payload",
-            "evidence.$": "$[2].vc.evidence"
-          }
-        },
-        "user.$": "$[0].querySession.userAuditInfo"
-      }
-    },
-    "Sign VC claimsSet": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "Parameters": {
-        "Payload": {
-          "kid.$": "$.header.kid",
-          "header.$": "States.JsonToString($.header)",
-          "claimsSet.$": "States.JsonToString($.payload)"
-        },
-        "FunctionName": "${JwtSignerFunction}"
-      },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException"
-          ],
-          "IntervalSeconds": 1,
-          "MaxAttempts": 3,
-          "BackoffRate": 2
-        }
-      ],
-      "Next": "Audit Event VC Issued Sent",
-      "ResultSelector": {
-        "Payload.$": "$.Payload"
-      },
-      "ResultPath": "$.jwt"
-    },
-    "Audit Event VC Issued Sent": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::events:putEvents",
-      "Parameters": {
-        "Entries": [
-          {
-            "Detail": {
-              "auditPrefix": "${AuditEventPrefix}",
-              "user.$": "$.user",
-              "issuer.$": "$.payload.iss",
-              "evidence.$": "$.payload.vc.evidence"
-            },
-            "DetailType": "${AuditEventNameVcIssued}",
-            "EventBusName": "${CheckHmrcEventBus}",
-            "Source": "${CheckHmrcEventBusSource}"
-          }
-        ]
-      },
-      "Next": "Create Signed JWT",
-      "ResultPath": null
-    },
-    "Create Signed JWT": {
-      "Type": "Pass",
-      "Parameters": {
-        "jwt.$": "$.jwt.Payload",
-        "user.$": "$.user",
-        "issuer.$": "$.payload.iss",
-        "httpStatus": 200
-      },
-      "Next": "Audit Event End Sent"
-    },
-    "Audit Event End Sent": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::events:putEvents",
-      "Parameters": {
-        "Entries": [
-          {
-            "Detail": {
-              "auditPrefix": "${AuditEventPrefix}",
-              "user.$": "$.user",
-              "issuer.$": "$.issuer"
-            },
-            "DetailType": "${AuditEventNameEnd}",
-            "EventBusName": "${CheckHmrcEventBus}",
-            "Source": "${CheckHmrcEventBusSource}"
-          }
-        ]
-      },
-      "End": true,
-      "ResultPath": null
-    }
-  }
+	"Comment": "A description of my state machine",
+	"StartAt": "Fetch SSM Parameters",
+	"States": {
+		"Fetch SSM Parameters": {
+			"Type": "Task",
+			"Resource": "arn:aws:states:::lambda:invoke",
+			"Parameters": {
+				"FunctionName": "${SsmParametersFunction}",
+				"Payload": {
+					"parameters.$": "States.Array('/${CommonStackName}/SessionTableName','${MaxJwtTtlParameter}','${JwtTtlUnitParameter}','/${CommonStackName}/verifiableCredentialKmsSigningKeyId','/${CommonStackName}/PersonIdentityTableName','/check-hmrc-cri-api/contraindicationMappings','/${CommonStackName}/verifiable-credential/issuer', '/check-hmrc-cri-api/contraIndicatorReasonsMapping')"
+				}
+			},
+			"Retry": [
+				{
+					"ErrorEquals": [
+						"Lambda.ServiceException",
+						"Lambda.AWSLambdaException",
+						"Lambda.SdkClientException",
+						"Lambda.TooManyRequestsException"
+					],
+					"IntervalSeconds": 1,
+					"MaxAttempts": 3,
+					"BackoffRate": 2
+				}
+			],
+			"Next": "Query Session Item",
+			"ResultPath": "$.parameters",
+			"ResultSelector": {
+				"SessionTableName.$": "$.Payload[0].Value",
+				"MaxJwtTtl.$": "$.Payload[1].Value",
+				"JwtTtlUnit.$": "$.Payload[2].Value",
+				"verifiableCredentialKmsSigningKeyId.$": "$.Payload[3].Value",
+				"PersonIdentityTableName.$": "$.Payload[4].Value",
+				"contraindicationMappings.$": "$.Payload[5].Value",
+				"issuer.$": "$.Payload[6].Value",
+        "contraindicatorReasonMappings.$": "$.Payload[7].Value"
+			}
+		},
+		"Query Session Item": {
+			"Type": "Task",
+			"Parameters": {
+				"TableName.$": "$.parameters.SessionTableName",
+				"IndexName": "access-token-index-with-event-data",
+				"KeyConditionExpression": "accessToken = :value",
+				"ExpressionAttributeValues": {
+					":value": {
+						"S.$": "$.bearerToken"
+					}
+				}
+			},
+			"Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
+			"ResultPath": "$.querySessionResult",
+			"Next": "Bearer Token Valid?"
+		},
+		"Bearer Token Valid?": {
+			"Type": "Choice",
+			"Choices": [
+				{
+					"Variable": "$.querySessionResult.Count",
+					"NumericGreaterThan": 0,
+					"Next": "Is Persistent Id Present?"
+				}
+			],
+			"Default": "Err: Invalid Bearer Token"
+		},
+		"Is Persistent Id Present?": {
+			"Type": "Choice",
+			"Choices": [
+				{
+					"Variable": "$.querySessionResult.Items[0].persistentSessionId",
+					"IsPresent": true,
+					"Next": "Get Audit UserInfo With Persistent Id"
+				}
+			],
+			"Default": "Get Audit UserInfo"
+		},
+		"Get Audit UserInfo": {
+			"Type": "Pass",
+			"Parameters": {
+				"govuk_signin_journey_id.$": "$.querySessionResult.Items[0].clientSessionId.S",
+				"ip_address.$": "$.querySessionResult.Items[0].clientIpAddress.S",
+				"session_id.$": "$.querySessionResult.Items[0].sessionId.S",
+				"user_id.$": "$.querySessionResult.Items[0].subject.S"
+			},
+			"ResultPath": "$.userAuditInfo",
+			"Next": "Filter Session Result"
+		},
+		"Get Audit UserInfo With Persistent Id": {
+			"Type": "Pass",
+			"Parameters": {
+				"govuk_signin_journey_id.$": "$.querySessionResult.Items[0].clientSessionId.S",
+				"ip_address.$": "$.querySessionResult.Items[0].clientIpAddress.S",
+				"persistent_session_id.$": "$.querySessionResult.Items[0].persistentSessionId.S",
+				"session_id.$": "$.querySessionResult.Items[0].sessionId.S",
+				"user_id.$": "$.querySessionResult.Items[0].subject.S"
+			},
+			"ResultPath": "$.userAuditInfo",
+			"Next": "Filter Session Result"
+		},
+		"Filter Session Result": {
+			"Type": "Pass",
+			"Next": "Create Credential Subject And Evidence",
+			"ResultPath": "$.querySession",
+			"Parameters": {
+				"sessionId.$": "$.querySessionResult.Items[0].sessionId.S",
+				"subject.$": "$.querySessionResult.Items[0].subject.S",
+				"userAuditInfo.$": "$.userAuditInfo"
+			}
+		},
+		"Err: Invalid Bearer Token": {
+			"Type": "Pass",
+			"End": true,
+			"Parameters": {
+				"error": "Invalid Bearer Token",
+				"httpStatus": 400
+			}
+		},
+		"Create Credential Subject And Evidence": {
+			"Type": "Parallel",
+			"Next": "Create VC Claim Set",
+			"Branches": [
+				{
+					"StartAt": "Fetch details from person identity",
+					"States": {
+						"Fetch details from person identity": {
+							"Type": "Task",
+							"Next": "Fetch Nino",
+							"Parameters": {
+								"TableName.$": "$.parameters.PersonIdentityTableName",
+								"KeyConditionExpression": "sessionId = :value",
+								"ExpressionAttributeValues": {
+									":value": {
+										"S.$": "$.querySession.sessionId"
+									}
+								}
+							},
+							"Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
+							"ResultPath": "$.userDetails"
+						},
+						"Fetch Nino": {
+							"Type": "Task",
+							"Resource": "arn:aws:states:::dynamodb:getItem",
+							"Parameters": {
+								"TableName": "${NinoUsersTable}",
+								"Key": {
+									"sessionId": {
+										"S.$": "$.userDetails.Items[0].sessionId.S"
+									}
+								}
+							},
+							"Next": "Create Credential Subject",
+							"ResultPath": "$.nino"
+						},
+						"Create Credential Subject": {
+							"Type": "Task",
+							"Resource": "arn:aws:states:::lambda:invoke",
+							"Parameters": {
+								"FunctionName": "${CredentialSubjectFunctionArn}",
+								"Payload": {
+									"userInfoEvent.$": "$.userDetails",
+									"nino.$": "$.nino.Item.nino.S"
+								}
+							},
+							"Retry": [
+								{
+									"ErrorEquals": [
+										"Lambda.ServiceException",
+										"Lambda.AWSLambdaException",
+										"Lambda.SdkClientException",
+										"Lambda.TooManyRequestsException"
+									],
+									"IntervalSeconds": 1,
+									"MaxAttempts": 3,
+									"BackoffRate": 2
+								}
+							],
+							"ResultSelector": {
+								"Payload.$": "$.Payload"
+							},
+							"ResultPath": "$.credentialSubject",
+							"End": true
+						}
+					}
+				},
+				{
+					"StartAt": "Fetch exp time and NBF",
+					"States": {
+						"Fetch exp time and NBF": {
+							"Type": "Task",
+							"Resource": "arn:aws:states:::lambda:invoke",
+							"Parameters": {
+								"FunctionName": "${TimeFunctionArn}",
+								"Payload": {
+									"ttlValue.$": "$.parameters.MaxJwtTtl",
+									"ttlUnit.$": "$.parameters.JwtTtlUnit"
+								}
+							},
+							"Retry": [
+								{
+									"ErrorEquals": [
+										"Lambda.ServiceException",
+										"Lambda.AWSLambdaException",
+										"Lambda.SdkClientException",
+										"Lambda.TooManyRequestsException"
+									],
+									"IntervalSeconds": 2,
+									"MaxAttempts": 6,
+									"BackoffRate": 2
+								}
+							],
+							"ResultPath": "$.time",
+							"End": true
+						}
+					}
+				},
+				{
+					"StartAt": "Fetch Failed Attempts",
+					"States": {
+						"Fetch Failed Attempts": {
+							"Type": "Task",
+							"Next": "Add Type to VC",
+							"Parameters": {
+								"TableName": "${UserAttemptsTable}",
+								"KeyConditionExpression": "sessionId = :value",
+								"FilterExpression": "attempt = :attempt",
+								"ExpressionAttributeValues": {
+									":value": {
+										"S.$": "$.querySession.sessionId"
+									},
+									":attempt": {
+										"S": "FAIL"
+									}
+								}
+							},
+							"Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
+							"ResultPath": "$.check-attempts-exist"
+						},
+						"Add Type to VC": {
+							"Type": "Pass",
+							"Next": "Did the user fail or pass the check?",
+							"Parameters": {
+								"type": [
+									"VerifiableCredential",
+									"IdentityCheckCredential"
+								],
+								"@context": [
+									"https://www.w3.org/2018/credentials/v1",
+									"https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
+								]
+							},
+							"ResultPath": "$.vctype"
+						},
+						"Did the user fail or pass the check?": {
+							"Type": "Choice",
+							"Choices": [
+								{
+									"Or": [
+										{
+											"Variable": "$.check-attempts-exist.Count",
+											"NumericGreaterThanEquals": 2
+										}
+									],
+									"Next": "Fetch CI"
+								}
+							],
+							"Default": "create VC evidence of a pass"
+						},
+						"create VC evidence of a pass": {
+							"Type": "Pass",
+							"Parameters": {
+								"type": "IdentityCheck",
+								"txn.$": "States.UUID()",
+								"strengthScore": 2,
+								"validityScore": 2,
+								"checkDetails": [
+									{
+										"checkMethod": "data"
+									}
+								]
+							},
+							"ResultPath": "$.evidence",
+							"Next": "create Audit evidence of a pass"
+						},
+						"create Audit evidence of a pass": {
+							"Type": "Pass",
+							"Parameters": {
+								"evidence.$": "$.evidence"
+							},
+							"ResultPath": "$.audit",
+							"End": true
+						},
+						"Fetch CI": {
+							"Type": "Task",
+							"Resource": "arn:aws:states:::lambda:invoke",
+							"Parameters": {
+								"FunctionName": "${CiMappingFunctionArn}",
+								"Payload": {
+									"contraIndicationMapping.$": "States.StringSplit($.parameters.contraindicationMappings,'||')",
+									"hmrcErrors.$": "$.check-attempts-exist.Items[*].text.S",
+                  "contraIndicatorReasonsMapping.$": "States.StringToJson($.parameters.contraindicatorReasonMappings)"
+								}
+							},
+							"Next": "create VC evidence of a failure",
+							"ResultPath": "$.contraIndicators"
+						},
+						"create VC evidence of a failure": {
+							"Type": "Pass",
+							"Parameters": {
+								"type": "IdentityCheck",
+								"txn.$": "States.UUID()",
+								"strengthScore": 2,
+								"validityScore": 0,
+								"failedCheckDetails": [
+									{
+										"checkMethod": "data"
+									}
+								],
+								"ci.$": "States.ArrayUnique($.contraIndicators.Payload[*].ci)"
+							},
+							"Next": "create Audit evidence of a failure",
+							"ResultPath": "$.evidence"
+						},
+						"create Audit evidence of a failure": {
+							"Type": "Pass",
+							"Parameters": {
+								"evidence": {
+									"type": "IdentityCheck",
+									"txn.$": "States.UUID()",
+									"strengthScore": 2,
+									"validityScore": 0,
+									"failedCheckDetails": [
+										{
+											"checkMethod": "data"
+										}
+									],
+									"ci.$": "States.ArrayUnique($.contraIndicators.Payload[*].ci)",
+									"ciReasons.$": "States.ArrayUnique($.contraIndicators.Payload)"
+								}
+							},
+							"ResultPath": "$.audit",
+							"End": true
+						}
+					}
+				}
+			]
+		},
+		"Create VC Claim Set": {
+			"Type": "Pass",
+			"Next": "Sign VC claimsSet",
+			"Parameters": {
+				"audit.$": "$[2].audit",
+				"header": {
+					"kid.$": "$[0].parameters.verifiableCredentialKmsSigningKeyId",
+					"typ": "JWT",
+					"alg": "ES256"
+				},
+				"payload": {
+					"jti.$": "States.Format('urn:uuid:{}',States.UUID())",
+					"sub.$": "$[0].querySession.subject",
+					"iss.$": "$[0].parameters.issuer",
+					"nbf.$": "$[1].time.Payload.nbf",
+					"exp.$": "$[1].time.Payload.expiry",
+					"vc": {
+						"type.$": "$[2].vctype.type",
+						"@context.$": "$[2].vctype.@context",
+						"credentialSubject.$": "$[0].credentialSubject.Payload",
+						"evidence.$": "States.Array($[2].evidence)"
+					}
+				},
+				"user.$": "$[0].querySession.userAuditInfo"
+			}
+		},
+		"Sign VC claimsSet": {
+			"Type": "Task",
+			"Resource": "arn:aws:states:::lambda:invoke",
+			"Parameters": {
+				"Payload": {
+					"kid.$": "$.header.kid",
+					"header.$": "States.JsonToString($.header)",
+					"claimsSet.$": "States.JsonToString($.payload)"
+				},
+				"FunctionName": "${JwtSignerFunction}"
+			},
+			"Retry": [
+				{
+					"ErrorEquals": [
+						"Lambda.ServiceException",
+						"Lambda.AWSLambdaException",
+						"Lambda.SdkClientException",
+						"Lambda.TooManyRequestsException"
+					],
+					"IntervalSeconds": 1,
+					"MaxAttempts": 3,
+					"BackoffRate": 2
+				}
+			],
+			"Next": "Audit Event VC Issued Sent",
+			"ResultSelector": {
+				"Payload.$": "$.Payload"
+			},
+			"ResultPath": "$.jwt"
+		},
+		"Audit Event VC Issued Sent": {
+			"Type": "Task",
+			"Resource": "arn:aws:states:::events:putEvents",
+			"Parameters": {
+				"Entries": [
+					{
+						"Detail": {
+							"auditPrefix": "${AuditEventPrefix}",
+							"user.$": "$.user",
+							"issuer.$": "$.payload.iss",
+							"evidence.$": "States.Array($.audit.evidence)"
+						},
+						"DetailType": "${AuditEventNameVcIssued}",
+						"EventBusName": "${CheckHmrcEventBus}",
+						"Source": "${CheckHmrcEventBusSource}"
+					}
+				]
+			},
+			"Next": "Create Signed JWT",
+			"ResultPath": null
+		},
+		"Create Signed JWT": {
+			"Type": "Pass",
+			"Parameters": {
+				"jwt.$": "$.jwt.Payload",
+				"user.$": "$.user",
+				"issuer.$": "$.payload.iss",
+				"httpStatus": 200
+			},
+			"Next": "Audit Event End Sent"
+		},
+		"Audit Event End Sent": {
+			"Type": "Task",
+			"Resource": "arn:aws:states:::events:putEvents",
+			"Parameters": {
+				"Entries": [
+					{
+						"Detail": {
+							"auditPrefix": "${AuditEventPrefix}",
+							"user.$": "$.user",
+							"issuer.$": "$.issuer"
+						},
+						"DetailType": "${AuditEventNameEnd}",
+						"EventBusName": "${CheckHmrcEventBus}",
+						"Source": "${CheckHmrcEventBusSource}"
+					}
+				]
+			},
+			"End": true,
+			"ResultPath": null
+		}
+	}
 }

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -272,6 +272,9 @@
                   "hmrc_errors.$": "$.check-attempts-exist.Items[*].text.S"
                 }
               },
+              "ResultSelector": {
+                "contraIndicators.$": "$.Payload[*]"
+              },
               "Next": "Create Evidence (Failed)",
               "ResultPath": "$.ci_lambda_output"
             },
@@ -289,7 +292,8 @@
                         "checkMethod": "data"
                       }
                     ],
-                    "ci.$": "$.ci_lambda_output.Payload"
+                    "ci.$": "States.ArrayUnique($.ci_lambda_output.contraIndicators[*].ci)",
+                    "ciReasons.$": "$.ci_lambda_output.contraIndicators[*]"
                   }
                 ]
               },
@@ -384,7 +388,8 @@
             "Detail": {
               "auditPrefix": "${AuditEventPrefix}",
               "user.$": "$.user",
-              "issuer.$": "$.payload.iss"
+              "issuer.$": "$.payload.iss",
+              "evidence.$": "$.payload.vc.evidence"
             },
             "DetailType": "${AuditEventNameVcIssued}",
             "EventBusName": "${CheckHmrcEventBus}",


### PR DESCRIPTION
## Proposed changes

see: https://govukverify.atlassian.net/browse/OJ-2458

This include the reasons behind related to CIs in audit events


### What changed

Audit to include CI reason and IPV_CHECK_HMRC_CRI_VC_ISSUED event updated to include CI reasons

### Why did it change

So that counter-fraud teams can use this as part of their investigation


- [OJ-2458](https://govukverify.atlassian.net/browse/OJ-2458)



[OJ-2458]: https://govukverify.atlassian.net/browse/OJ-2458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ