### PR TITLE
OJ-2456: Added code creating JAR requests in for session tests

### DIFF
--- a/integration-tests/api-gateway/aws/crypto/client.ts
+++ b/integration-tests/api-gateway/aws/crypto/client.ts
@@ -1,0 +1,70 @@
+import { CompactEncrypt, importJWK, JWK, JWTHeaderParameters, JWTPayload, SignJWT } from "jose";
+
+export type PrivateKeyType = { privateSigningKey: string | JWK } | { privateSigningKeyId: string };
+export type BaseParams = {
+  issuer?: string;
+  customClaims?: JWTPayload;
+} & PrivateKeyType;
+
+const publicKeyToJwk = async (publicKey: string) => {
+  const decoded = Buffer.from(publicKey, "base64").toString();
+  const keyObject = JSON.parse(decoded);
+  return await importJWK(keyObject, "RSA256");
+};
+
+const msToSeconds = (ms: number) => Math.round(ms / 1000);
+
+const signJwt = async (
+  jwtPayload: JWTPayload,
+  params: BaseParams,
+  jwtHeader: JWTHeaderParameters = { alg: "ES256", typ: "JWT" }
+) => {
+  if ("privateSigningKey" in params && params.privateSigningKey) {
+    return await new SignJWT(jwtPayload).setProtectedHeader(jwtHeader).sign(await importJWK(params.privateSigningKey as JWK, "ES256"));
+  } else {
+    throw new Error("No signing key provided!");
+  }
+};
+
+export const buildJarAuthorizationRequest = async (params: any) => {
+  const jwtPayload: JWTPayload = {
+    iss: params.issuer,
+    iat: msToSeconds(new Date().getTime()),
+    nbf: msToSeconds(new Date().getTime()),
+    exp: msToSeconds(new Date().getTime() + 5 * 60 * 1000),
+    client_id: params.clientId,
+    redirect_uri: params.redirectUrl,
+    response_type: "code",
+    state: uuid(),
+    govuk_signin_journey_id: uuid(),
+    sub: uuid(),
+    aud: params.audience,
+    ...params.customClaims,
+  };
+  const signedJwt = await signJwt(jwtPayload, params);
+  const encryptionKeyJwk = await publicKeyToJwk(params.publicEncryptionKeyBase64);
+  const encryptedSignedJwt = await new CompactEncrypt(new TextEncoder().encode(signedJwt))
+    .setProtectedHeader({ alg: "RSA-OAEP-256", enc: "A256GCM" })
+    .encrypt(encryptionKeyJwk);
+  return {
+    client_id: params.clientId,
+    request: encryptedSignedJwt,
+  };
+};
+
+const uuid = () => {
+  const hexValues = '0123456789abcdef';
+  let uuid = '';
+  for (let i = 0; i < 36; i++) {
+    if (i === 8 || i === 13 || i === 18 || i === 23) {
+      uuid += '-';
+    } else if (i === 14) {
+      uuid += '4';
+    } else if (i === 19) {
+      uuid += hexValues[(Math.random() * 4 | 8)];
+    } else {
+      uuid += hexValues[(Math.random() * 16 | 0)];
+    }
+  }
+  return uuid;
+}

--- a/integration-tests/api-gateway/aws/crypto/create-jar-request-payload.ts
+++ b/integration-tests/api-gateway/aws/crypto/create-jar-request-payload.ts
@@ -1,0 +1,33 @@
+import { JWTPayload } from "jose";
+import { buildJarAuthorizationRequest } from "./client";
+
+export type PrivateSigningKey = {
+  kty: string,
+  d: string,
+  use: string,
+  crv: string,
+  kid: string,
+  x: string,
+  y: string,
+  alg: string
+}
+
+export type Payload = {
+  clientId: string,
+  audience: string,
+  authorizationEndpoint: string,
+  redirectUrl: string,
+  publicEncryptionKeyBase64: string,
+  privateSigningKey: PrivateSigningKey,
+  issuer: string,
+  claimSet : JWTPayload,
+};
+
+export const getJarAuthorizationPayload = async (payload: Payload) => {
+  try {
+    return await buildJarAuthorizationRequest(payload);
+  } catch (error) {
+    console.error("Error building Jar Authorization Request:", error);
+    return null;
+  }
+};

--- a/integration-tests/api-gateway/aws/private-api.test.ts
+++ b/integration-tests/api-gateway/aws/private-api.test.ts
@@ -1,5 +1,64 @@
+import { getJarAuthorizationPayload, Payload } from "./crypto/create-jar-request-payload";
+
+const environment = process.env.Environment;
+const publicEncryptionKeyBase64 = process.env.publicEncryptionKeyBase64;
+const privateSigningKey = JSON.parse(process.env.privateSigningKey || "");
+
+let claimSet = {
+  sub: "urn:fdc:gov.uk:2022:0df67954-5537-4c98-92d9-e95f0b2e6f44",
+  shared_claims: {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld",
+    ],
+    name: [
+      {
+        nameParts: [
+          { type: "GivenName", value: "Jim" },
+          { type: "FamilyName", value: "Ferguson" },
+        ],
+      },
+    ],
+    birthDate: [{ value: "1948-04-23" }],
+    address: [
+      {
+        buildingNumber: "",
+        buildingName: "",
+        streetName: "",
+        addressLocality: "",
+        postalCode: "",
+        validFrom: "2021-01-01",
+      },
+    ],
+  },
+  iss: "https://cri.core.stubs.account.gov.uk",
+  persistent_session_id: "a67c497b-ac49-46a0-832c-8e7864c6d4cf",
+  response_type: "code",
+  client_id: "ipv-core-stub-aws-prod",
+  govuk_signin_journey_id: "84521e2b-43ab-4437-a118-f7c3a6d24c8e",
+  aud: `https://review-hc.${environment}.account.gov.uk`,
+  nbf: 1697516406,
+  scope: "openid",
+  redirect_uri: "https://cri.core.stubs.account.gov.uk/callback",
+  state: "diWgdrCGYnjrZK7cMPEKwJXvpGn6rvhCBteCl_I2ejg",
+  exp: Date.now() + 100000000000,
+  iat: 1697516406,
+};
+
 describe("Private API", () => {
-    it("Placeholder", () => {
-        console.log("Test boilerplate code.")
+    it("should produce a \"client_id\" and \"request\" in the session request body", async () => {
+      const payload = {
+        clientId: 'ipv-core-stub-aws-prod',
+        audience: `https://review-hc.${environment}.account.gov.uk`,
+        authorizationEndpoint: `https://review-hc.${environment}.account.gov.uk/oauth2/authorize`,
+        redirectUrl: 'https://cri.core.stubs.account.gov.uk/callback',
+        publicEncryptionKeyBase64: publicEncryptionKeyBase64,
+        privateSigningKey: privateSigningKey,
+        issuer: 'https://cri.core.stubs.account.gov.uk',
+        claimSet:  claimSet
+      } as Payload;
+      const ipvCoreAuthorizationUrl = await getJarAuthorizationPayload(payload);
+      expect(ipvCoreAuthorizationUrl?.client_id).toEqual("ipv-core-stub-aws-prod");
+      expect(ipvCoreAuthorizationUrl?.request).toBeDefined();
     });
 });


### PR DESCRIPTION
## Proposed changes

### What changed
Added helpers to generate JARs for the `/session` endpoint. This is for our testing.

The following environment variables are required:
* Environment - this is the environment that the test is running in [dev, build, staging]
* publicEncryptionKeyBase64 - the public envrionment key in base64 format
* privateSigningKey - the private signing key in JSON

### Issue tracking
- [OJ-2456](https://govukverify.atlassian.net/browse/OJ-2456)
