### PR TITLE
Reflect content-type in /abandon OpenAPI 

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -162,6 +162,11 @@ paths:
       summary: "IP address of the client."
       parameters:
         - $ref: "#/components/parameters/SessionHeader"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EmptyBody"
       x-amazon-apigateway-request-validator: "Validate both"
       responses:
         "200":
@@ -217,6 +222,9 @@ components:
         500:
           value: "f27b8afc-90ef-4e0f-83ad-00a2f5692590"
   schemas:
+    EmptyBody:
+      type: object
+      nullable: true
     Nino:
       required: true
       type: "object"


### PR DESCRIPTION
## Proposed changes

### What and Why did it change
The /abandon endpoint expects the content-type header to be set as `application/json`. This change has been added to the OpenAPI spec to reflect this. 
