### PR TITLE
Reverts #208

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -162,11 +162,6 @@ paths:
       summary: "IP address of the client."
       parameters:
         - $ref: "#/components/parameters/SessionHeader"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/EmptyBody"
       x-amazon-apigateway-request-validator: "Validate both"
       responses:
         "200":
@@ -222,9 +217,6 @@ components:
         500:
           value: "f27b8afc-90ef-4e0f-83ad-00a2f5692590"
   schemas:
-    EmptyBody:
-      type: object
-      nullable: true
     Nino:
       required: true
       type: "object"


### PR DESCRIPTION
## Proposed changes

### Why did it change
Reverts #208 we did this to be consistent with the API definition as AWS expects the application/json content-type. Since setting this, AWS now requires an empty json body.

AWS and Imposter do not fully align, in imposter the request works however AWS is more strict and expects a payload. 
