### PR TITLE
OJ-2453: Check for `evidence_requested` before adding CI into VC

### DIFF
--- a/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
+++ b/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
@@ -380,5 +380,9 @@ describe("nino-issue-credential-happy", () => {
     clientIpAddress: "00.100.8.20",
     clientSessionId: "252561a2-c6ef-47e7-87ab-93891a2a6a41",
     persistentSessionId: "156714ef-f9df-48c2-ada8-540e7bce44f7",
+    evidenceRequest: {
+      scoringPolicy: "gpg45",
+      strengthScore: 2
+    }
   });
 });

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -1,456 +1,486 @@
 {
-	"Comment": "A description of my state machine",
-	"StartAt": "Fetch SSM Parameters",
-	"States": {
-		"Fetch SSM Parameters": {
-			"Type": "Task",
-			"Resource": "arn:aws:states:::lambda:invoke",
-			"Parameters": {
-				"FunctionName": "${SsmParametersFunction}",
-				"Payload": {
-					"parameters.$": "States.Array('/${CommonStackName}/SessionTableName','${MaxJwtTtlParameter}','${JwtTtlUnitParameter}','/${CommonStackName}/verifiableCredentialKmsSigningKeyId','/${CommonStackName}/PersonIdentityTableName','/check-hmrc-cri-api/contraindicationMappings','/${CommonStackName}/verifiable-credential/issuer', '/check-hmrc-cri-api/contraIndicatorReasonsMapping')"
-				}
-			},
-			"Retry": [
-				{
-					"ErrorEquals": [
-						"Lambda.ServiceException",
-						"Lambda.AWSLambdaException",
-						"Lambda.SdkClientException",
-						"Lambda.TooManyRequestsException"
-					],
-					"IntervalSeconds": 1,
-					"MaxAttempts": 3,
-					"BackoffRate": 2
-				}
-			],
-			"Next": "Query Session Item",
-			"ResultPath": "$.parameters",
-			"ResultSelector": {
-				"SessionTableName.$": "$.Payload[0].Value",
-				"MaxJwtTtl.$": "$.Payload[1].Value",
-				"JwtTtlUnit.$": "$.Payload[2].Value",
-				"verifiableCredentialKmsSigningKeyId.$": "$.Payload[3].Value",
-				"PersonIdentityTableName.$": "$.Payload[4].Value",
-				"contraindicationMappings.$": "$.Payload[5].Value",
-				"issuer.$": "$.Payload[6].Value",
+  "Comment": "A description of my state machine",
+  "StartAt": "Fetch SSM Parameters",
+  "States": {
+    "Fetch SSM Parameters": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${SsmParametersFunction}",
+        "Payload": {
+          "parameters.$": "States.Array('/${CommonStackName}/SessionTableName','${MaxJwtTtlParameter}','${JwtTtlUnitParameter}','/${CommonStackName}/verifiableCredentialKmsSigningKeyId','/${CommonStackName}/PersonIdentityTableName','/check-hmrc-cri-api/contraindicationMappings','/${CommonStackName}/verifiable-credential/issuer', '/check-hmrc-cri-api/contraIndicatorReasonsMapping')"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Query Session Item",
+      "ResultPath": "$.parameters",
+      "ResultSelector": {
+        "SessionTableName.$": "$.Payload[0].Value",
+        "MaxJwtTtl.$": "$.Payload[1].Value",
+        "JwtTtlUnit.$": "$.Payload[2].Value",
+        "verifiableCredentialKmsSigningKeyId.$": "$.Payload[3].Value",
+        "PersonIdentityTableName.$": "$.Payload[4].Value",
+        "contraindicationMappings.$": "$.Payload[5].Value",
+        "issuer.$": "$.Payload[6].Value",
         "contraindicatorReasonMappings.$": "$.Payload[7].Value"
-			}
-		},
-		"Query Session Item": {
-			"Type": "Task",
-			"Parameters": {
-				"TableName.$": "$.parameters.SessionTableName",
-				"IndexName": "access-token-index-with-event-data",
-				"KeyConditionExpression": "accessToken = :value",
-				"ExpressionAttributeValues": {
-					":value": {
-						"S.$": "$.bearerToken"
-					}
-				}
-			},
-			"Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
-			"ResultPath": "$.querySessionResult",
-			"Next": "Bearer Token Valid?"
-		},
-		"Bearer Token Valid?": {
-			"Type": "Choice",
-			"Choices": [
-				{
-					"Variable": "$.querySessionResult.Count",
-					"NumericGreaterThan": 0,
-					"Next": "Is Persistent Id Present?"
-				}
-			],
-			"Default": "Err: Invalid Bearer Token"
-		},
-		"Is Persistent Id Present?": {
-			"Type": "Choice",
-			"Choices": [
-				{
-					"Variable": "$.querySessionResult.Items[0].persistentSessionId",
-					"IsPresent": true,
-					"Next": "Get Audit UserInfo With Persistent Id"
-				}
-			],
-			"Default": "Get Audit UserInfo"
-		},
-		"Get Audit UserInfo": {
-			"Type": "Pass",
-			"Parameters": {
-				"govuk_signin_journey_id.$": "$.querySessionResult.Items[0].clientSessionId.S",
-				"ip_address.$": "$.querySessionResult.Items[0].clientIpAddress.S",
-				"session_id.$": "$.querySessionResult.Items[0].sessionId.S",
-				"user_id.$": "$.querySessionResult.Items[0].subject.S"
-			},
-			"ResultPath": "$.userAuditInfo",
-			"Next": "Filter Session Result"
-		},
-		"Get Audit UserInfo With Persistent Id": {
-			"Type": "Pass",
-			"Parameters": {
-				"govuk_signin_journey_id.$": "$.querySessionResult.Items[0].clientSessionId.S",
-				"ip_address.$": "$.querySessionResult.Items[0].clientIpAddress.S",
-				"persistent_session_id.$": "$.querySessionResult.Items[0].persistentSessionId.S",
-				"session_id.$": "$.querySessionResult.Items[0].sessionId.S",
-				"user_id.$": "$.querySessionResult.Items[0].subject.S"
-			},
-			"ResultPath": "$.userAuditInfo",
-			"Next": "Filter Session Result"
-		},
-		"Filter Session Result": {
-			"Type": "Pass",
-			"Next": "Create Credential Subject And Evidence",
-			"ResultPath": "$.querySession",
-			"Parameters": {
-				"sessionId.$": "$.querySessionResult.Items[0].sessionId.S",
-				"subject.$": "$.querySessionResult.Items[0].subject.S",
-				"userAuditInfo.$": "$.userAuditInfo"
-			}
-		},
-		"Err: Invalid Bearer Token": {
-			"Type": "Pass",
-			"End": true,
-			"Parameters": {
-				"error": "Invalid Bearer Token",
-				"httpStatus": 400
-			}
-		},
-		"Create Credential Subject And Evidence": {
-			"Type": "Parallel",
-			"Next": "Create VC Claim Set",
-			"Branches": [
-				{
-					"StartAt": "Fetch details from person identity",
-					"States": {
-						"Fetch details from person identity": {
-							"Type": "Task",
-							"Next": "Fetch Nino",
-							"Parameters": {
-								"TableName.$": "$.parameters.PersonIdentityTableName",
-								"KeyConditionExpression": "sessionId = :value",
-								"ExpressionAttributeValues": {
-									":value": {
-										"S.$": "$.querySession.sessionId"
-									}
-								}
-							},
-							"Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
-							"ResultPath": "$.userDetails"
-						},
-						"Fetch Nino": {
-							"Type": "Task",
-							"Resource": "arn:aws:states:::dynamodb:getItem",
-							"Parameters": {
-								"TableName": "${NinoUsersTable}",
-								"Key": {
-									"sessionId": {
-										"S.$": "$.userDetails.Items[0].sessionId.S"
-									}
-								}
-							},
-							"Next": "Create Credential Subject",
-							"ResultPath": "$.nino"
-						},
-						"Create Credential Subject": {
-							"Type": "Task",
-							"Resource": "arn:aws:states:::lambda:invoke",
-							"Parameters": {
-								"FunctionName": "${CredentialSubjectFunctionArn}",
-								"Payload": {
-									"userInfoEvent.$": "$.userDetails",
-									"nino.$": "$.nino.Item.nino.S"
-								}
-							},
-							"Retry": [
-								{
-									"ErrorEquals": [
-										"Lambda.ServiceException",
-										"Lambda.AWSLambdaException",
-										"Lambda.SdkClientException",
-										"Lambda.TooManyRequestsException"
-									],
-									"IntervalSeconds": 1,
-									"MaxAttempts": 3,
-									"BackoffRate": 2
-								}
-							],
-							"ResultSelector": {
-								"Payload.$": "$.Payload"
-							},
-							"ResultPath": "$.credentialSubject",
-							"End": true
-						}
-					}
-				},
-				{
-					"StartAt": "Fetch exp time and NBF",
-					"States": {
-						"Fetch exp time and NBF": {
-							"Type": "Task",
-							"Resource": "arn:aws:states:::lambda:invoke",
-							"Parameters": {
-								"FunctionName": "${TimeFunctionArn}",
-								"Payload": {
-									"ttlValue.$": "$.parameters.MaxJwtTtl",
-									"ttlUnit.$": "$.parameters.JwtTtlUnit"
-								}
-							},
-							"Retry": [
-								{
-									"ErrorEquals": [
-										"Lambda.ServiceException",
-										"Lambda.AWSLambdaException",
-										"Lambda.SdkClientException",
-										"Lambda.TooManyRequestsException"
-									],
-									"IntervalSeconds": 2,
-									"MaxAttempts": 6,
-									"BackoffRate": 2
-								}
-							],
-							"ResultPath": "$.time",
-							"End": true
-						}
-					}
-				},
-				{
-					"StartAt": "Fetch Failed Attempts",
-					"States": {
-						"Fetch Failed Attempts": {
-							"Type": "Task",
-							"Next": "Add Type to VC",
-							"Parameters": {
-								"TableName": "${UserAttemptsTable}",
-								"KeyConditionExpression": "sessionId = :value",
-								"FilterExpression": "attempt = :attempt",
-								"ExpressionAttributeValues": {
-									":value": {
-										"S.$": "$.querySession.sessionId"
-									},
-									":attempt": {
-										"S": "FAIL"
-									}
-								}
-							},
-							"Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
-							"ResultPath": "$.check-attempts-exist"
-						},
-						"Add Type to VC": {
-							"Type": "Pass",
-							"Next": "Did the user fail or pass the check?",
-							"Parameters": {
-								"type": [
-									"VerifiableCredential",
-									"IdentityCheckCredential"
-								],
-								"@context": [
-									"https://www.w3.org/2018/credentials/v1",
-									"https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
-								]
-							},
-							"ResultPath": "$.vctype"
-						},
-						"Did the user fail or pass the check?": {
-							"Type": "Choice",
-							"Choices": [
-								{
-									"Or": [
-										{
-											"Variable": "$.check-attempts-exist.Count",
-											"NumericGreaterThanEquals": 2
-										}
-									],
-									"Next": "Fetch CI"
-								}
-							],
-							"Default": "create VC evidence of a pass"
-						},
-						"create VC evidence of a pass": {
-							"Type": "Pass",
-							"Parameters": {
-								"type": "IdentityCheck",
-								"txn.$": "States.UUID()",
-								"strengthScore": 2,
-								"validityScore": 2,
-								"checkDetails": [
-									{
-										"checkMethod": "data"
-									}
-								]
-							},
-							"ResultPath": "$.evidence",
-							"Next": "create Audit evidence of a pass"
-						},
-						"create Audit evidence of a pass": {
-							"Type": "Pass",
-							"Parameters": {
-								"evidence.$": "$.evidence"
-							},
-							"ResultPath": "$.audit",
-							"End": true
-						},
-						"Fetch CI": {
-							"Type": "Task",
-							"Resource": "arn:aws:states:::lambda:invoke",
-							"Parameters": {
-								"FunctionName": "${CiMappingFunctionArn}",
-								"Payload": {
-									"contraIndicationMapping.$": "States.StringSplit($.parameters.contraindicationMappings,'||')",
-									"hmrcErrors.$": "$.check-attempts-exist.Items[*].text.S",
+      }
+    },
+    "Query Session Item": {
+      "Type": "Task",
+      "Parameters": {
+        "TableName.$": "$.parameters.SessionTableName",
+        "FilterExpression": "accessToken = :value",
+        "ExpressionAttributeValues": {
+          ":value": {
+            "S.$": "$.bearerToken"
+          }
+        }
+      },
+      "Resource": "arn:aws:states:::aws-sdk:dynamodb:scan",
+      "ResultPath": "$.querySessionResult",
+      "Next": "Bearer Token Valid?"
+    },
+    "Bearer Token Valid?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.querySessionResult.Count",
+          "NumericGreaterThan": 0,
+          "Next": "Is Persistent Id Present?"
+        }
+      ],
+      "Default": "Err: Invalid Bearer Token"
+    },
+    "Is Persistent Id Present?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.querySessionResult.Items[0].persistentSessionId",
+          "IsPresent": true,
+          "Next": "Get Audit UserInfo With Persistent Id"
+        }
+      ],
+      "Default": "Get Audit UserInfo"
+    },
+    "Get Audit UserInfo": {
+      "Type": "Pass",
+      "Parameters": {
+        "govuk_signin_journey_id.$": "$.querySessionResult.Items[0].clientSessionId.S",
+        "ip_address.$": "$.querySessionResult.Items[0].clientIpAddress.S",
+        "session_id.$": "$.querySessionResult.Items[0].sessionId.S",
+        "user_id.$": "$.querySessionResult.Items[0].subject.S"
+      },
+      "ResultPath": "$.userAuditInfo",
+      "Next": "Filter Session Result"
+    },
+    "Get Audit UserInfo With Persistent Id": {
+      "Type": "Pass",
+      "Parameters": {
+        "govuk_signin_journey_id.$": "$.querySessionResult.Items[0].clientSessionId.S",
+        "ip_address.$": "$.querySessionResult.Items[0].clientIpAddress.S",
+        "persistent_session_id.$": "$.querySessionResult.Items[0].persistentSessionId.S",
+        "session_id.$": "$.querySessionResult.Items[0].sessionId.S",
+        "user_id.$": "$.querySessionResult.Items[0].subject.S"
+      },
+      "ResultPath": "$.userAuditInfo",
+      "Next": "Filter Session Result"
+    },
+    "Filter Session Result": {
+      "Type": "Pass",
+      "Next": "Create Credential Subject And Evidence",
+      "ResultPath": "$.querySession",
+      "Parameters": {
+        "sessionId.$": "$.querySessionResult.Items[0].sessionId.S",
+        "subject.$": "$.querySessionResult.Items[0].subject.S",
+        "userAuditInfo.$": "$.userAuditInfo"
+      }
+    },
+    "Err: Invalid Bearer Token": {
+      "Type": "Pass",
+      "End": true,
+      "Parameters": {
+        "error": "Invalid Bearer Token",
+        "httpStatus": 400
+      }
+    },
+    "Create Credential Subject And Evidence": {
+      "Type": "Parallel",
+      "Next": "Create VC Claim Set",
+      "Branches": [
+        {
+          "StartAt": "Fetch details from person identity",
+          "States": {
+            "Fetch details from person identity": {
+              "Type": "Task",
+              "Next": "Fetch Nino",
+              "Parameters": {
+                "TableName.$": "$.parameters.PersonIdentityTableName",
+                "KeyConditionExpression": "sessionId = :value",
+                "ExpressionAttributeValues": {
+                  ":value": {
+                    "S.$": "$.querySession.sessionId"
+                  }
+                }
+              },
+              "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
+              "ResultPath": "$.userDetails"
+            },
+            "Fetch Nino": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::dynamodb:getItem",
+              "Parameters": {
+                "TableName": "${NinoUsersTable}",
+                "Key": {
+                  "sessionId": {
+                    "S.$": "$.userDetails.Items[0].sessionId.S"
+                  }
+                }
+              },
+              "Next": "Create Credential Subject",
+              "ResultPath": "$.nino"
+            },
+            "Create Credential Subject": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "${CredentialSubjectFunctionArn}",
+                "Payload": {
+                  "userInfoEvent.$": "$.userDetails",
+                  "nino.$": "$.nino.Item.nino.S"
+                }
+              },
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 1,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2
+                }
+              ],
+              "ResultSelector": {
+                "Payload.$": "$.Payload"
+              },
+              "ResultPath": "$.credentialSubject",
+              "End": true
+            }
+          }
+        },
+        {
+          "StartAt": "Fetch exp time and NBF",
+          "States": {
+            "Fetch exp time and NBF": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "${TimeFunctionArn}",
+                "Payload": {
+                  "ttlValue.$": "$.parameters.MaxJwtTtl",
+                  "ttlUnit.$": "$.parameters.JwtTtlUnit"
+                }
+              },
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 2,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2
+                }
+              ],
+              "ResultPath": "$.time",
+              "End": true
+            }
+          }
+        },
+        {
+          "StartAt": "Fetch Failed Attempts",
+          "States": {
+            "Fetch Failed Attempts": {
+              "Type": "Task",
+              "Next": "Add Type to VC",
+              "Parameters": {
+                "TableName": "${UserAttemptsTable}",
+                "KeyConditionExpression": "sessionId = :value",
+                "FilterExpression": "attempt = :attempt",
+                "ExpressionAttributeValues": {
+                  ":value": {
+                    "S.$": "$.querySession.sessionId"
+                  },
+                  ":attempt": {
+                    "S": "FAIL"
+                  }
+                }
+              },
+              "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
+              "ResultPath": "$.check-attempts-exist"
+            },
+            "Add Type to VC": {
+              "Type": "Pass",
+              "Next": "Did the user fail or pass the check?",
+              "Parameters": {
+                "type": [
+                  "VerifiableCredential",
+                  "IdentityCheckCredential"
+                ],
+                "@context": [
+                  "https://www.w3.org/2018/credentials/v1",
+                  "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
+                ]
+              },
+              "ResultPath": "$.vctype"
+            },
+            "Did the user fail or pass the check?": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Or": [
+                    {
+                      "Variable": "$.check-attempts-exist.Count",
+                      "NumericGreaterThanEquals": 2
+                    }
+                  ],
+                  "Next": "Fetch CI"
+                }
+              ],
+              "Default": "create VC evidence of a pass"
+            },
+            "Fetch CI": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "${CiMappingFunctionArn}",
+                "Payload": {
+                  "contraIndicationMapping.$": "States.StringSplit($.parameters.contraindicationMappings,'||')",
+                  "hmrcErrors.$": "$.check-attempts-exist.Items[*].text.S",
                   "contraIndicatorReasonsMapping.$": "States.StringToJson($.parameters.contraindicatorReasonMappings)"
-								}
-							},
-							"Next": "create VC evidence of a failure",
-							"ResultPath": "$.contraIndicators"
-						},
-						"create VC evidence of a failure": {
-							"Type": "Pass",
-							"Parameters": {
-								"type": "IdentityCheck",
-								"txn.$": "States.UUID()",
-								"strengthScore": 2,
-								"validityScore": 0,
-								"failedCheckDetails": [
-									{
-										"checkMethod": "data"
-									}
-								],
-								"ci.$": "States.ArrayUnique($.contraIndicators.Payload[*].ci)"
-							},
-							"Next": "create Audit evidence of a failure",
-							"ResultPath": "$.evidence"
-						},
-						"create Audit evidence of a failure": {
-							"Type": "Pass",
-							"Parameters": {
-								"evidence": {
-									"type": "IdentityCheck",
-									"txn.$": "States.UUID()",
-									"strengthScore": 2,
-									"validityScore": 0,
-									"failedCheckDetails": [
-										{
-											"checkMethod": "data"
-										}
-									],
-									"ci.$": "States.ArrayUnique($.contraIndicators.Payload[*].ci)",
-									"ciReasons.$": "States.ArrayUnique($.contraIndicators.Payload)"
-								}
-							},
-							"ResultPath": "$.audit",
-							"End": true
-						}
-					}
-				}
-			]
-		},
-		"Create VC Claim Set": {
-			"Type": "Pass",
-			"Next": "Sign VC claimsSet",
-			"Parameters": {
-				"audit.$": "$[2].audit",
-				"header": {
-					"kid.$": "$[0].parameters.verifiableCredentialKmsSigningKeyId",
-					"typ": "JWT",
-					"alg": "ES256"
-				},
-				"payload": {
-					"jti.$": "States.Format('urn:uuid:{}',States.UUID())",
-					"sub.$": "$[0].querySession.subject",
-					"iss.$": "$[0].parameters.issuer",
-					"nbf.$": "$[1].time.Payload.nbf",
-					"exp.$": "$[1].time.Payload.expiry",
-					"vc": {
-						"type.$": "$[2].vctype.type",
-						"@context.$": "$[2].vctype.@context",
-						"credentialSubject.$": "$[0].credentialSubject.Payload",
-						"evidence.$": "States.Array($[2].evidence)"
-					}
-				},
-				"user.$": "$[0].querySession.userAuditInfo"
-			}
-		},
-		"Sign VC claimsSet": {
-			"Type": "Task",
-			"Resource": "arn:aws:states:::lambda:invoke",
-			"Parameters": {
-				"Payload": {
-					"kid.$": "$.header.kid",
-					"header.$": "States.JsonToString($.header)",
-					"claimsSet.$": "States.JsonToString($.payload)"
-				},
-				"FunctionName": "${JwtSignerFunction}"
-			},
-			"Retry": [
-				{
-					"ErrorEquals": [
-						"Lambda.ServiceException",
-						"Lambda.AWSLambdaException",
-						"Lambda.SdkClientException",
-						"Lambda.TooManyRequestsException"
-					],
-					"IntervalSeconds": 1,
-					"MaxAttempts": 3,
-					"BackoffRate": 2
-				}
-			],
-			"Next": "Audit Event VC Issued Sent",
-			"ResultSelector": {
-				"Payload.$": "$.Payload"
-			},
-			"ResultPath": "$.jwt"
-		},
-		"Audit Event VC Issued Sent": {
-			"Type": "Task",
-			"Resource": "arn:aws:states:::events:putEvents",
-			"Parameters": {
-				"Entries": [
-					{
-						"Detail": {
-							"auditPrefix": "${AuditEventPrefix}",
-							"user.$": "$.user",
-							"issuer.$": "$.payload.iss",
-							"evidence.$": "States.Array($.audit.evidence)"
-						},
-						"DetailType": "${AuditEventNameVcIssued}",
-						"EventBusName": "${CheckHmrcEventBus}",
-						"Source": "${CheckHmrcEventBusSource}"
-					}
-				]
-			},
-			"Next": "Create Signed JWT",
-			"ResultPath": null
-		},
-		"Create Signed JWT": {
-			"Type": "Pass",
-			"Parameters": {
-				"jwt.$": "$.jwt.Payload",
-				"user.$": "$.user",
-				"issuer.$": "$.payload.iss",
-				"httpStatus": 200
-			},
-			"Next": "Audit Event End Sent"
-		},
-		"Audit Event End Sent": {
-			"Type": "Task",
-			"Resource": "arn:aws:states:::events:putEvents",
-			"Parameters": {
-				"Entries": [
-					{
-						"Detail": {
-							"auditPrefix": "${AuditEventPrefix}",
-							"user.$": "$.user",
-							"issuer.$": "$.issuer"
-						},
-						"DetailType": "${AuditEventNameEnd}",
-						"EventBusName": "${CheckHmrcEventBus}",
-						"Source": "${CheckHmrcEventBusSource}"
-					}
-				]
-			},
-			"End": true,
-			"ResultPath": null
-		}
-	}
+                }
+              },
+              "ResultPath": "$.contraIndicators",
+              "Next": "Evidence Requested?"
+            },
+            "Evidence Requested?": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "And": [
+                    {
+                      "Variable": "$.querySessionResult.Items[0].evidenceRequest",
+                      "IsPresent": true
+                    }
+                  ],
+                  "Next": "create VC evidence of a failure"
+                }
+              ],
+              "Default": "create VC evidence without CI of a failure"
+            },
+            "create VC evidence of a failure": {
+              "Type": "Pass",
+              "Next": "create Audit evidence of a failure",
+              "Parameters": {
+                "type": "IdentityCheck",
+                "txn.$": "States.UUID()",
+                "strengthScore": 2,
+                "validityScore": 0,
+                "failedCheckDetails": [
+                  {
+                    "checkMethod": "data"
+                  }
+                ],
+                "ci.$": "States.ArrayUnique($.contraIndicators.Payload[*].ci)"
+              },
+              "ResultPath": "$.evidence"
+            },
+            "create VC evidence of a pass": {
+              "Type": "Pass",
+              "Parameters": {
+                "type": "IdentityCheck",
+                "txn.$": "States.UUID()",
+                "strengthScore": 2,
+                "validityScore": 2,
+                "checkDetails": [
+                  {
+                    "checkMethod": "data"
+                  }
+                ]
+              },
+              "ResultPath": "$.evidence",
+              "Next": "create Audit evidence of a pass"
+            },
+            "create Audit evidence of a pass": {
+              "Type": "Pass",
+              "Parameters": {
+                "evidence.$": "$.evidence"
+              },
+              "ResultPath": "$.audit",
+              "End": true
+            },
+            "create VC evidence without CI of a failure": {
+              "Type": "Pass",
+              "Parameters": {
+                "type": "IdentityCheck",
+                "txn.$": "States.UUID()",
+                "strengthScore": 2,
+                "validityScore": 0,
+                "failedCheckDetails": [
+                  {
+                    "checkMethod": "data"
+                  }
+                ]
+              },
+              "Next": "create Audit evidence of a failure",
+              "ResultPath": "$.evidence"
+            },
+            "create Audit evidence of a failure": {
+              "Type": "Pass",
+              "Parameters": {
+                "evidence": {
+                  "type": "IdentityCheck",
+                  "txn.$": "States.UUID()",
+                  "strengthScore": 2,
+                  "validityScore": 0,
+                  "failedCheckDetails": [
+                    {
+                      "checkMethod": "data"
+                    }
+                  ],
+                  "ci.$": "States.ArrayUnique($.contraIndicators.Payload[*].ci)",
+                  "ciReasons.$": "States.ArrayUnique($.contraIndicators.Payload)"
+                }
+              },
+              "ResultPath": "$.audit",
+              "End": true
+            }
+          }
+        }
+      ]
+    },
+    "Create VC Claim Set": {
+      "Type": "Pass",
+      "Next": "Sign VC claimsSet",
+      "Parameters": {
+        "audit.$": "$[2].audit",
+        "header": {
+          "kid.$": "$[0].parameters.verifiableCredentialKmsSigningKeyId",
+          "typ": "JWT",
+          "alg": "ES256"
+        },
+        "payload": {
+          "jti.$": "States.Format('urn:uuid:{}',States.UUID())",
+          "sub.$": "$[0].querySession.subject",
+          "iss.$": "$[0].parameters.issuer",
+          "nbf.$": "$[1].time.Payload.nbf",
+          "exp.$": "$[1].time.Payload.expiry",
+          "vc": {
+            "type.$": "$[2].vctype.type",
+            "@context.$": "$[2].vctype.@context",
+            "credentialSubject.$": "$[0].credentialSubject.Payload",
+            "evidence.$": "States.Array($[2].evidence)"
+          }
+        },
+        "user.$": "$[0].querySession.userAuditInfo"
+      }
+    },
+    "Sign VC claimsSet": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "Payload": {
+          "kid.$": "$.header.kid",
+          "header.$": "States.JsonToString($.header)",
+          "claimsSet.$": "States.JsonToString($.payload)"
+        },
+        "FunctionName": "${JwtSignerFunction}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Audit Event VC Issued Sent",
+      "ResultSelector": {
+        "Payload.$": "$.Payload"
+      },
+      "ResultPath": "$.jwt"
+    },
+    "Audit Event VC Issued Sent": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::events:putEvents",
+      "Parameters": {
+        "Entries": [
+          {
+            "Detail": {
+              "auditPrefix": "IPV_CHECK_HMRC_CRI",
+              "user.$": "$.user",
+              "issuer.$": "$.payload.iss",
+              "evidence.$": "States.Array($.audit.evidence)"
+            },
+            "DetailType": "${AuditEventNameVcIssued}",
+            "EventBusName": "${CheckHmrcEventBus}",
+            "Source": "${CheckHmrcEventBusSource}"
+          }
+        ]
+      },
+      "Next": "Create Signed JWT",
+      "ResultPath": null
+    },
+    "Create Signed JWT": {
+      "Type": "Pass",
+      "Parameters": {
+        "jwt.$": "$.jwt.Payload",
+        "user.$": "$.user",
+        "issuer.$": "$.payload.iss",
+        "httpStatus": 200
+      },
+      "Next": "Audit Event End Sent"
+    },
+    "Audit Event End Sent": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::events:putEvents",
+      "Parameters": {
+        "Entries": [
+          {
+            "Detail": {
+              "auditPrefix": "IPV_CHECK_HMRC_CRI",
+              "user.$": "$.user",
+              "issuer.$": "$.issuer"
+            },
+            "DetailType": "${AuditEventNameEnd}",
+            "EventBusName": "${CheckHmrcEventBus}",
+            "Source": "${CheckHmrcEventBusSource}"
+          }
+        ]
+      },
+      "End": true,
+      "ResultPath": null
+    }
+  }
 }

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -263,7 +263,34 @@
                   "Next": "Fetch CI"
                 }
               ],
-              "Default": "create VC evidence of a pass"
+              "Default": "Evidence Requested ?"
+            },
+            "Evidence Requested ?": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Variable": "$.querySessionResult.Items[0].evidenceRequest",
+                  "IsPresent": true,
+                  "Next": "create VC evidence of pass"
+                }
+              ],
+              "Default": "create VC evidence of pass without scores"
+            },
+            "create VC evidence of pass": {
+              "Type": "Pass",
+              "Parameters": {
+                "type": "IdentityCheck",
+                "txn.$": "States.UUID()",
+                "strengthScore": 2,
+                "validityScore": 2,
+                "checkDetails": [
+                  {
+                    "checkMethod": "data"
+                  }
+                ]
+              },
+              "ResultPath": "$.evidence",
+              "Next": "create Audit evidence of a pass"
             },
             "Fetch CI": {
               "Type": "Task",
@@ -311,16 +338,15 @@
               },
               "ResultPath": "$.evidence"
             },
-            "create VC evidence of a pass": {
+            "create VC evidence of pass without scores": {
               "Type": "Pass",
               "Parameters": {
                 "type": "IdentityCheck",
                 "txn.$": "States.UUID()",
-                "strengthScore": 2,
-                "validityScore": 2,
                 "checkDetails": [
                   {
-                    "checkMethod": "data"
+                    "checkMethod": "data",
+                    "dataCheck": "record_check"
                   }
                 ]
               },
@@ -340,11 +366,10 @@
               "Parameters": {
                 "type": "IdentityCheck",
                 "txn.$": "States.UUID()",
-                "strengthScore": 2,
-                "validityScore": 0,
                 "failedCheckDetails": [
                   {
-                    "checkMethod": "data"
+                    "checkMethod": "data",
+                    "dataCheck": "record_check"
                   }
                 ]
               },


### PR DESCRIPTION
## Proposed changes

### What changed
The issue credential state machine now checks if `evidence_requested` is present in the session table. If it is, CIs are added to the VC. If the field is not present then no CI will be added to the VC.

Screenshot of the updated area:
![image](https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/assets/76599223/bafadb74-41e5-464a-9c38-ce6e344076df)

### Issue tracking
- [OJ-2453](https://govukverify.atlassian.net/browse/OJ-2453)

[OJ-2453]: https://govukverify.atlassian.net/browse/OJ-2453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ