### PR TITLE
OJ-2453: Swap fail and success states for evidence requested

### DIFF
--- a/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
+++ b/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
@@ -331,10 +331,8 @@ describe("nino-issue-credential-happy", () => {
         evidence: [
           {
             checkDetails: [{ checkMethod: "data" }],
-            strengthScore: 2,
             txn: expect.any(String),
             type: "IdentityCheck",
-            validityScore: 2,
           },
         ],
       },

--- a/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
+++ b/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
@@ -330,7 +330,7 @@ describe("nino-issue-credential-happy", () => {
         ...customClaims,
         evidence: [
           {
-            checkDetails: [{ checkMethod: "data" }],
+            checkDetails: [{ checkMethod: "data", "dataCheck": "record_check", }],
             txn: expect.any(String),
             type: "IdentityCheck",
           },

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -271,10 +271,10 @@
                 {
                   "Variable": "$.querySessionResult.Items[0].evidenceRequest",
                   "IsPresent": true,
-                  "Next": "create VC evidence of pass"
+                  "Next": "create VC evidence of pass without scores"
                 }
               ],
-              "Default": "create VC evidence of pass without scores"
+              "Default": "create VC evidence of pass"
             },
             "create VC evidence of pass": {
               "Type": "Pass",
@@ -286,6 +286,21 @@
                 "checkDetails": [
                   {
                     "checkMethod": "data"
+                  }
+                ]
+              },
+              "ResultPath": "$.evidence",
+              "Next": "create Audit evidence of a pass"
+            },
+            "create VC evidence of pass without scores": {
+              "Type": "Pass",
+              "Parameters": {
+                "type": "IdentityCheck",
+                "txn.$": "States.UUID()",
+                "checkDetails": [
+                  {
+                    "checkMethod": "data",
+                    "dataCheck": "record_check"
                   }
                 ]
               },
@@ -316,10 +331,10 @@
                       "IsPresent": true
                     }
                   ],
-                  "Next": "create VC evidence of a failure"
+                  "Next": "create VC evidence without CI of a failure"
                 }
               ],
-              "Default": "create VC evidence without CI of a failure"
+              "Default": "create VC evidence of a failure"
             },
             "create VC evidence of a failure": {
               "Type": "Pass",
@@ -338,29 +353,6 @@
               },
               "ResultPath": "$.evidence"
             },
-            "create VC evidence of pass without scores": {
-              "Type": "Pass",
-              "Parameters": {
-                "type": "IdentityCheck",
-                "txn.$": "States.UUID()",
-                "checkDetails": [
-                  {
-                    "checkMethod": "data",
-                    "dataCheck": "record_check"
-                  }
-                ]
-              },
-              "ResultPath": "$.evidence",
-              "Next": "create Audit evidence of a pass"
-            },
-            "create Audit evidence of a pass": {
-              "Type": "Pass",
-              "Parameters": {
-                "evidence.$": "$.evidence"
-              },
-              "ResultPath": "$.audit",
-              "End": true
-            },
             "create VC evidence without CI of a failure": {
               "Type": "Pass",
               "Parameters": {
@@ -375,6 +367,14 @@
               },
               "Next": "create Audit evidence of a failure",
               "ResultPath": "$.evidence"
+            },
+            "create Audit evidence of a pass": {
+              "Type": "Pass",
+              "Parameters": {
+                "evidence.$": "$.evidence"
+              },
+              "ResultPath": "$.audit",
+              "End": true
             },
             "create Audit evidence of a failure": {
               "Type": "Pass",


### PR DESCRIPTION
## Proposed changes

### Why did it change
The pass states that are used for evidence requested have been flipped as they were giving CIs when evidence requested was present and no CIs when it was not present. 