### PR TITLE
OJ-2420: Enable Audit EventBus up to staging environment only

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -52,7 +52,10 @@ Conditions:
   IsLocalDevEnvironment: !Equals [!Ref Environment, localdev]
   IsDevLikeEnvironment:
     !Or [!Condition IsLocalDevEnvironment, !Condition IsDevEnvironment]
-
+  IsUpToStagingEnvironment: !Or
+    - !Condition IsDevLikeEnvironment
+    - !Equals [!Ref Environment, build]
+    - !Equals [!Ref Environment, staging]
   IsProdEnvironment: !Equals
     - !Ref Environment
     - production
@@ -1533,7 +1536,7 @@ Resources:
     Properties:
       EventBusName: !Ref CheckHmrcEventBus
       Description: Capture the audit event RESPONSE_RECEIVED
-      State: !If [IsDevLikeEnvironment, ENABLED, !Ref EventBusState]
+      State: !If [IsUpToStagingEnvironment, ENABLED, !Ref EventBusState]
       EventPattern:
         source:
           - !FindInMap [Audit, Source, !Ref Environment]
@@ -1548,7 +1551,7 @@ Resources:
     Properties:
       EventBusName: !Ref CheckHmrcEventBus
       Description: Capture the audit event REQUEST_SENT
-      State: !If [IsDevLikeEnvironment, ENABLED, !Ref EventBusState]
+      State: !If [IsUpToStagingEnvironment, ENABLED, !Ref EventBusState]
       EventPattern:
         source:
           - !FindInMap [Audit, Source, !Ref Environment]
@@ -1563,7 +1566,7 @@ Resources:
     Properties:
       EventBusName: !Ref CheckHmrcEventBus
       Description: Capture the audit event VC_ISSUED
-      State: !If [IsDevLikeEnvironment, ENABLED, !Ref EventBusState]
+      State: !If [IsUpToStagingEnvironment, ENABLED, !Ref EventBusState]
       EventPattern:
         source:
           - !FindInMap [Audit, Source, !Ref Environment]
@@ -1578,7 +1581,7 @@ Resources:
     Properties:
       EventBusName: !Ref CheckHmrcEventBus
       Description: Capture the END event
-      State: !If [IsDevLikeEnvironment, ENABLED, !Ref EventBusState]
+      State: !If [IsUpToStagingEnvironment, ENABLED, !Ref EventBusState]
       EventPattern:
         source:
           - !FindInMap [Audit, Source, !Ref Environment]
@@ -1593,7 +1596,7 @@ Resources:
     Properties:
       EventBusName: !Ref CheckHmrcEventBus
       Description: Capture the ABANDONED event
-      State: !If [IsDevLikeEnvironment, ENABLED, !Ref EventBusState]
+      State: !If [IsUpToStagingEnvironment, ENABLED, !Ref EventBusState]
       EventPattern:
         source:
           - !FindInMap [Audit, Source, !Ref Environment]


### PR DESCRIPTION
## Proposed changes

Enable Audit EventBus up to staging

### Why did it change

Enabling up to staging, would allow testing integration with TxMA Team. Once this is done the condition can be removed entirely. i.e. The EventBusState would be set to ENABLED by default, then enabled by default in all environments

### Issue tracking

- [OJ-2420](https://govukverify.atlassian.net/browse/OJ-2420)


- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2420]: https://govukverify.atlassian.net/browse/OJ-2420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ