### PR TITLE
OJ-2501: Adjust /Check endpoint to deal with headers

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -139,8 +139,17 @@ paths:
         requestTemplates:
           application/json:
             Fn::Sub: |-
+              #set($nino = $util.parseJson($input.json('$.nino').trim()))
+              #set($headers = {})
+              #foreach($header in $input.params().header.keySet())
+                #set($headerName = $util.escapeJavaScript($header))
+                #set($headerValue = $input.params().header.get($header))
+                #if($headerName.trim() && $headerValue.trim())
+                  $util.qr($headers.put($headerName, $headerValue))
+                #end
+              #end
               {
-                "input": "{\"nino\": \"$util.parseJson($input.json('$.nino').trim())\",\"sessionId\": \"$input.params('session-id').trim()\"}",
+                "input":"{\"nino\":\"$nino\",\"sessionId\":\"$input.params('session-id').trim()\",#set($headerKeys = $headers.keySet())#set($headerCount = $headerKeys.size())#foreach($headerKey in $headerKeys)#if($headerKey != 'session-id')\"$headerKey\": \"$headers.get($headerKey)\"#if($foreach.hasNext && $foreach.index != $headerCount - 1),#end#end#end}",
                 "stateMachineArn": "${NinoCheckStateMachine.Arn}"
               }
         responses:


### PR DESCRIPTION
This PR adjust VTL of /Check endpoint, to pull in
other header values like

i.e. txma-audit-encoded, X-Forwarded-For etc

### What changed

We need to be able to optionally pull in `txma-audit-encoded`