### PR TITLE
OJ-2501: Add txma audit header to check_session

### DIFF
--- a/integration-tests/step-functions/aws/abandon/abandon.test.ts
+++ b/integration-tests/step-functions/aws/abandon/abandon.test.ts
@@ -22,6 +22,7 @@ import { RetryConfig, pause, retry } from "../../../resources/util";
 describe("Abandon", () => {
   const input = {
     sessionId: "abandon-test",
+    "txma-audit-encoded": "test encoded header",
   };
   let output: Partial<{
     CommonStackName: string;

--- a/integration-tests/step-functions/aws/abandon/abandon.test.ts
+++ b/integration-tests/step-functions/aws/abandon/abandon.test.ts
@@ -170,6 +170,7 @@ describe("Abandon", () => {
       expect(source).toBe("review-hc.localdev.account.gov.uk");
       expect(detail).toEqual({
         auditPrefix: "IPV_HMRC_RECORD_CHECK_CRI",
+        deviceInformation: "test encoded header",
         user: {
           govuk_signin_journey_id: "252561a2-c6ef-47e7-87ab-93891a2a6a41",
           user_id: "test",

--- a/integration-tests/step-functions/aws/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/step-functions/aws/nino-check/nino-check-happy.test.ts
@@ -286,6 +286,7 @@ describe("nino-check-happy", () => {
       expect(requestSentSource).toBe("review-hc.localdev.account.gov.uk");
       expect(requestSentDetail).toEqual({
         auditPrefix: "IPV_HMRC_RECORD_CHECK_CRI",
+        deviceInformation: "test encoded header",
         nino: "AA000003D",
         user: {
           govuk_signin_journey_id: "252561a2-c6ef-47e7-87ab-93891a2a6a41",
@@ -358,6 +359,7 @@ describe("nino-check-happy", () => {
       expect(responseReceivedSource).toBe("review-hc.localdev.account.gov.uk");
       expect(responseReceivedDetail).toEqual({
         auditPrefix: "IPV_HMRC_RECORD_CHECK_CRI",
+        deviceInformation: "test encoded header",
         user: {
           govuk_signin_journey_id: "252561a2-c6ef-47e7-87ab-93891a2a6a41",
           user_id: "test",

--- a/integration-tests/step-functions/aws/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/step-functions/aws/nino-check/nino-check-happy.test.ts
@@ -21,6 +21,7 @@ describe("nino-check-happy", () => {
   const input = {
     sessionId: "check-happy",
     nino: "AA000003D",
+    "txma-audit-encoded": "test encoded header",
   };
 
   const testUser = {

--- a/integration-tests/step-functions/mocked/abandon/MockConfigFile.json
+++ b/integration-tests/step-functions/mocked/abandon/MockConfigFile.json
@@ -18,7 +18,7 @@
     "SessionFound": {
       "0": {
         "Return": {
-          "Output": "{\"status\":\"SESSION_OK\",\"userAuditInfo\":{\"govuk_signin_journey_id\":\"252561a2-c6ef-47e7-87ab-93891a2a6a41\",\"user_id\":\"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2\",\"persistent_session_id\":\"156714ef-f9df-48c2-ada8-540e7bce44f7\",\"session_id\":\"12345\",\"ip_address\":\"51.149.8.29\"},\"clientId\":\"dummy-client-id\"}"
+          "Output": "{\"status\":\"SESSION_OK\",\"userAuditInfo\":{\"govuk_signin_journey_id\":\"252561a2-c6ef-47e7-87ab-93891a2a6a41\",\"user_id\":\"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2\",\"persistent_session_id\":\"156714ef-f9df-48c2-ada8-540e7bce44f7\",\"session_id\":\"12345\",\"ip_address\":\"51.149.8.29\"},\"clientId\":\"dummy-client-id\", \"txmaAuditHeader\": \"test encoded header\"}"
         }
       }
     },

--- a/integration-tests/step-functions/mocked/abandon/abandon.test.ts
+++ b/integration-tests/step-functions/mocked/abandon/abandon.test.ts
@@ -20,6 +20,7 @@ describe("abandon", () => {
     it("should pass when session exists", async () => {
       const input = JSON.stringify({
         sessionId: "12345",
+        "txma-audit-encoded": "test encoded header",
       });
       const responseStepFunction =
         await sfnContainer.startStepFunctionExecution("Happy", input);

--- a/integration-tests/step-functions/mocked/check-session/check-session.test.ts
+++ b/integration-tests/step-functions/mocked/check-session/check-session.test.ts
@@ -30,7 +30,7 @@ describe("check-session", () => {
         responseStepFunction
       );
       expect(results[0].stateExitedEventDetails?.output).toBe(
-        '{"status":"SESSION_OK","clientId":"exampleClientId","userAuditInfo":{"govuk_signin_journey_id":"252561a2-c6ef-47e7-87ab-93891a2a6a41","user_id":"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2","persistent_session_id":"156714ef-f9df-48c2-ada8-540e7bce44f7","session_id":"12345","ip_address":"51.149.8.29"}}'
+        '{"status":"SESSION_OK","txmaAuditHeader":"{}","clientId":"exampleClientId","userAuditInfo":{"govuk_signin_journey_id":"252561a2-c6ef-47e7-87ab-93891a2a6a41","user_id":"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2","persistent_session_id":"156714ef-f9df-48c2-ada8-540e7bce44f7","session_id":"12345","ip_address":"51.149.8.29"}}'
       );
     });
     it("it should pass when a valid session exists and persistent_session_id is absent", async () => {
@@ -49,7 +49,7 @@ describe("check-session", () => {
         responseStepFunction
       );
       expect(results[0].stateExitedEventDetails?.output).toBe(
-        '{"status":"SESSION_OK","clientId":"exampleClientId","userAuditInfo":{"govuk_signin_journey_id":"252561a2-c6ef-47e7-87ab-93891a2a6a41","user_id":"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2","session_id":"12345","ip_address":"51.149.8.29"}}'
+        '{"status":"SESSION_OK","txmaAuditHeader":"{}","clientId":"exampleClientId","userAuditInfo":{"govuk_signin_journey_id":"252561a2-c6ef-47e7-87ab-93891a2a6a41","user_id":"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2","session_id":"12345","ip_address":"51.149.8.29"}}'
       );
     });
   });

--- a/integration-tests/step-functions/mocked/nino-check/MockConfigFile.json
+++ b/integration-tests/step-functions/mocked/nino-check/MockConfigFile.json
@@ -200,7 +200,7 @@
     "CheckSessionSuccess": {
       "0": {
         "Return": {
-          "Output": "{\"status\":\"SESSION_OK\",\"userAuditInfo\":{\"govuk_signin_journey_id\":\"252561a2-c6ef-47e7-87ab-93891a2a6a41\",\"user_id\":\"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2\",\"persistent_session_id\":\"156714ef-f9df-48c2-ada8-540e7bce44f7\",\"session_id\":\"12345\",\"ip_address\":\"51.149.8.29\"},\"clientId\":\"exampleClientId\"}"
+          "Output": "{\"status\":\"SESSION_OK\",\"userAuditInfo\":{\"govuk_signin_journey_id\":\"252561a2-c6ef-47e7-87ab-93891a2a6a41\",\"user_id\":\"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2\",\"persistent_session_id\":\"156714ef-f9df-48c2-ada8-540e7bce44f7\",\"session_id\":\"12345\",\"ip_address\":\"51.149.8.29\"},\"clientId\":\"exampleClientId\", \"txmaAuditHeader\": \"test encoded header\"}"
         }
       }
     },

--- a/integration-tests/step-functions/mocked/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/step-functions/mocked/nino-check/nino-check-happy.test.ts
@@ -20,6 +20,7 @@ describe("nino-check-happy", () => {
     const input = JSON.stringify({
       nino: "AA000003D",
       sessionId: "12345",
+      "txma-audit-encoded": "test encoded header",
     });
     const responseStepFunction = await sfnContainer.startStepFunctionExecution(
       "APIFailRetrySuccessTest",
@@ -42,6 +43,7 @@ describe("nino-check-happy", () => {
     const input = JSON.stringify({
       nino: "AA000003D",
       sessionId: "12345",
+      "txma-audit-encoded": "test encoded header",
     });
     const responseStepFunction = await sfnContainer.startStepFunctionExecution(
       happyPath,

--- a/step-functions/abandon.asl.json
+++ b/step-functions/abandon.asl.json
@@ -84,6 +84,7 @@
             "Detail": {
               "auditPrefix": "${AuditEventPrefix}",
               "user.$": "$.sessionCheck.userAuditInfo",
+              "deviceInformation.$": "$.sessionCheck.txmaAuditHeader",
               "issuer.$": "$.parameters.Issuer"
             },
             "DetailType": "${AuditEventNameAbandoned}",

--- a/step-functions/audit_event.asl.json
+++ b/step-functions/audit_event.asl.json
@@ -7,7 +7,8 @@
 			"Comment": "The details JSON object is stringified using States.JsonToString and then split it on ':\"' creating an array with key and value as items if a key called evidence is found DetailsContainsEvidence returns boolean value true",
 			"Parameters": {
 				"prefix.$": "$$.Execution.Input.detail.auditPrefix",
-				"type.$": "$$.Execution.Input.detail-type"
+				"type.$": "$$.Execution.Input.detail-type",
+				"deviceInformation.$": "$$.Execution.Input.detail.deviceInformation"
 			},
 			"Next": "Parallel"
 		},
@@ -122,12 +123,49 @@
 			"Comment": "This check uses the empty object returned from the CredentialSubjectFunction to determine there is no Restricted user info present",
 			"Choices": [
 				{
-					"Variable": "$[0].restricted.containsUserInfo",
-					"StringEquals": "{}",
+					"And": [
+						{
+							"Variable": "$[0].restricted.containsUserInfo",
+							"StringEquals": "{}"
+						},
+						{
+							"Variable": "$[0].deviceInformation",
+							"StringEquals": "{}"
+						}
+					],
 					"Next": "AuditEvent Without Restricted Info"
 				}
 			],
-			"Default": "Add Restricted Info to AuditEvent"
+			"Default": "Is Device Information Present?"
+		},
+		"Is Device Information Present?": {
+			"Type": "Choice",
+			"Choices": [
+				{
+					"Not": {
+						"Variable": "$[0].deviceInformation",
+						"StringEquals": "{}"
+					},
+					"Next": "Fromat Device Information"
+				}
+			],
+			"Default": "Set Default Value For Formatted Device Information"
+		},
+		"Set Default Value For Formatted Device Information": {
+			"Type": "Pass",
+			"Next": "Add Restricted Info to AuditEvent",
+			"Parameters": {},
+			"ResultPath": "$[0].formattedDeviceInformation"
+		},
+		"Fromat Device Information": {
+			"Type": "Pass",
+			"Next": "Add Restricted Info to AuditEvent",
+			"Parameters": {
+				"device_information": {
+					"encoded.$": "$[0].deviceInformation"
+				}
+			},
+			"ResultPath": "$[0].formattedDeviceInformation"
 		},
 		"AuditEvent Without Restricted Info": {
 			"Type": "Pass",
@@ -152,7 +190,7 @@
 				"event_timestamp_ms.$": "$[2].epochMilliseconds.value",
 				"component_id.$": "$$.Execution.Input.detail.issuer",
 				"user.$": "$$.Execution.Input.detail.user",
-				"restricted.$": "$[0].restricted.value"
+				"restricted.$": "States.JsonMerge($[0].restricted.value, $[0].formattedDeviceInformation, false)"
 			},
 			"ResultPath": "$[0].auditEvent",
 			"OutputPath": "$",

--- a/step-functions/check_session.asl.json
+++ b/step-functions/check_session.asl.json
@@ -1,135 +1,179 @@
 {
-  "Comment": "A description of my state machine",
-  "StartAt": "Check SessionId is present",
-  "States": {
-    "Check SessionId is present": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.sessionId",
-          "IsPresent": true,
-          "Next": "Fetch Current Time"
-        }
-      ],
-      "Default": "Err: No sessionId provided"
-    },
-    "Fetch Current Time": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "Parameters": {
-        "Payload.$": "$",
-        "FunctionName": "${CurrentTimeFunctionArn}"
-      },
-      "Next": "Fetch Session",
-      "ResultSelector": {
-        "value.$": "$.Payload"
-      },
-      "ResultPath": "$.currentTime"
-    },
-    "Fetch Session": {
-      "Type": "Task",
-      "Next": "Check Session Exists",
-      "Parameters": {
-        "TableName": "session-${CommonStackName}",
-        "KeyConditionExpression": "sessionId = :value",
-        "ExpressionAttributeValues": {
-          ":value": {
-            "S.$": "$.sessionId"
-          }
-        }
-      },
-      "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
-      "ResultSelector": {
-        "count.$": "$.Count",
-        "items.$": "$.Items"
-      },
-      "ResultPath": "$.sessionQuery"
-    },
-    "Check Session Exists": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.sessionQuery.count",
-          "NumericLessThanEquals": 0,
-          "Next": "Err: No session found"
-        }
-      ],
-      "Default": "Check Session Has Not Expired"
-    },
-    "Check Session Has Not Expired": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.currentTime.value",
-          "StringGreaterThanPath": "$.sessionQuery.items[0].expiryDate.N",
-          "Next": "Err: Session Expired"
-        }
-      ],
-      "Default": "Is Persistent SessionId Present?"
-    },
-    "Is Persistent SessionId Present?": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.sessionQuery.items[0].persistentSessionId",
-          "IsPresent": false,
-          "Next": "Get User Info Without Persistent Session Id"
-        }
-      ],
-      "Default": "Get User Session Info"
-    },
-    "Get User Info Without Persistent Session Id": {
-      "Type": "Pass",
-      "Parameters": {
-        "govuk_signin_journey_id.$": "$.sessionQuery.items[0].clientSessionId.S",
-        "ip_address.$": "$.sessionQuery.items[0].clientIpAddress.S",
-        "session_id.$": "$.sessionQuery.items[0].sessionId.S",
-        "user_id.$": "$.sessionQuery.items[0].subject.S"
-      },
-      "ResultPath": "$.UserSessionInfo",
-      "Next": "Session OK"
-    },
-    "Get User Session Info": {
-      "Type": "Pass",
-      "Parameters": {
-        "govuk_signin_journey_id.$": "$.sessionQuery.items[0].clientSessionId.S",
-        "ip_address.$": "$.sessionQuery.items[0].clientIpAddress.S",
-        "persistent_session_id.$": "$.sessionQuery.items[0].persistentSessionId.S",
-        "session_id.$": "$.sessionQuery.items[0].sessionId.S",
-        "user_id.$": "$.sessionQuery.items[0].subject.S"
-      },
-      "ResultPath": "$.UserSessionInfo",
-      "Next": "Session OK"
-    },
-    "Err: Session Expired": {
-      "Type": "Pass",
-      "End": true,
-      "Parameters": {
-        "status": "SESSION_EXPIRED"
-      }
-    },
-    "Err: No session found": {
-      "Type": "Pass",
-      "End": true,
-      "Parameters": {
-        "status": "SESSION_NOT_FOUND"
-      }
-    },
-    "Session OK": {
-      "Type": "Pass",
-      "End": true,
-      "Parameters": {
-        "status": "SESSION_OK",
-        "clientId.$": "$.sessionQuery.items[0].clientId.S",
-        "userAuditInfo.$": "$.UserSessionInfo"
-      }
-    },
-    "Err: No sessionId provided": {
-      "Type": "Pass",
-      "End": true,
-      "Result": {
-        "status": "SESSION_NOT_PROVIDED"
-      }
-    }
-  }
+	"Comment": "A description of my state machine",
+	"StartAt": "Check SessionId is present",
+	"States": {
+		"Check SessionId is present": {
+			"Type": "Choice",
+			"Choices": [
+				{
+					"Variable": "$.sessionId",
+					"IsPresent": true,
+					"Next": "Fetch Current Time"
+				}
+			],
+			"Default": "Err: No sessionId provided"
+		},
+		"Fetch Current Time": {
+			"Type": "Task",
+			"Resource": "arn:aws:states:::lambda:invoke",
+			"Parameters": {
+				"Payload.$": "$",
+				"FunctionName": "${CurrentTimeFunctionArn}"
+			},
+			"Next": "Fetch Session",
+			"ResultSelector": {
+				"value.$": "$.Payload"
+			},
+			"ResultPath": "$.currentTime"
+		},
+		"Fetch Session": {
+			"Type": "Task",
+			"Next": "Check Session Exists",
+			"Parameters": {
+				"TableName": "session-${CommonStackName}",
+				"KeyConditionExpression": "sessionId = :value",
+				"ExpressionAttributeValues": {
+					":value": {
+						"S.$": "$.sessionId"
+					}
+				}
+			},
+			"Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
+			"ResultSelector": {
+				"count.$": "$.Count",
+				"items.$": "$.Items"
+			},
+			"ResultPath": "$.sessionQuery"
+		},
+		"Check Session Exists": {
+			"Type": "Choice",
+			"Choices": [
+				{
+					"Variable": "$.sessionQuery.count",
+					"NumericLessThanEquals": 0,
+					"Next": "Err: No session found"
+				}
+			],
+			"Default": "Check Session Has Not Expired"
+		},
+		"Check Session Has Not Expired": {
+			"Type": "Choice",
+			"Choices": [
+				{
+					"Variable": "$.currentTime.value",
+					"StringGreaterThanPath": "$.sessionQuery.items[0].expiryDate.N",
+					"Next": "Err: Session Expired"
+				}
+			],
+			"Default": "Parallel (1)"
+		},
+		"Parallel (1)": {
+			"Type": "Parallel",
+			"Next": "Session OK",
+			"Branches": [
+				{
+					"StartAt": "Is Persistent SessionId Present?",
+					"States": {
+						"Is Persistent SessionId Present?": {
+							"Type": "Choice",
+							"Choices": [
+								{
+									"Variable": "$.sessionQuery.items[0].persistentSessionId",
+									"IsPresent": true,
+									"Next": "Get User Session Info"
+								}
+							],
+							"Default": "Get User Info Without Persistent Session Id"
+						},
+						"Get User Info Without Persistent Session Id": {
+							"Type": "Pass",
+							"Parameters": {
+								"govuk_signin_journey_id.$": "$.sessionQuery.items[0].clientSessionId.S",
+								"ip_address.$": "$.sessionQuery.items[0].clientIpAddress.S",
+								"session_id.$": "$.sessionQuery.items[0].sessionId.S",
+								"user_id.$": "$.sessionQuery.items[0].subject.S"
+							},
+							"ResultPath": "$.UserSessionInfo",
+							"End": true
+						},
+						"Get User Session Info": {
+							"Type": "Pass",
+							"Parameters": {
+								"govuk_signin_journey_id.$": "$.sessionQuery.items[0].clientSessionId.S",
+								"ip_address.$": "$.sessionQuery.items[0].clientIpAddress.S",
+								"persistent_session_id.$": "$.sessionQuery.items[0].persistentSessionId.S",
+								"session_id.$": "$.sessionQuery.items[0].sessionId.S",
+								"user_id.$": "$.sessionQuery.items[0].subject.S"
+							},
+							"ResultPath": "$.UserSessionInfo",
+							"End": true
+						}
+					}
+				},
+				{
+					"StartAt": "Check for TxMA Audit Device Header",
+					"States": {
+						"Check for TxMA Audit Device Header": {
+							"Type": "Choice",
+							"Choices": [
+								{
+									"Variable": "$$.Execution.Input.txma-audit-encoded",
+									"IsPresent": true,
+									"Next": "Found TxMa Audit Header"
+								}
+							],
+							"Default": "TxMa Audit Header Not Found"
+						},
+						"Found TxMa Audit Header": {
+							"Type": "Pass",
+							"Parameters": {
+								"value.$": "$$.Execution.Input.txma-audit-encoded"
+							},
+							"ResultPath": "$.TxmaAuditHeader",
+							"End": true
+						},
+						"TxMa Audit Header Not Found": {
+							"Type": "Pass",
+							"Parameters": {
+								"value": "{}"
+							},
+							"ResultPath": "$.TxmaAuditHeader",
+							"End": true
+						}
+					}
+				}
+			]
+		},
+		"Err: Session Expired": {
+			"Type": "Pass",
+			"End": true,
+			"Parameters": {
+				"status": "SESSION_EXPIRED"
+			}
+		},
+		"Err: No session found": {
+			"Type": "Pass",
+			"End": true,
+			"Parameters": {
+				"status": "SESSION_NOT_FOUND"
+			}
+		},
+		"Session OK": {
+			"Type": "Pass",
+			"End": true,
+			"Parameters": {
+				"status": "SESSION_OK",
+				"clientId.$": "$[0].sessionQuery.items[0].clientId.S",
+				"userAuditInfo.$": "$[0].UserSessionInfo",
+				"txmaAuditHeader.$": "$[1].TxmaAuditHeader.value"
+			}
+		},
+		"Err: No sessionId provided": {
+			"Type": "Pass",
+			"End": true,
+			"Result": {
+				"status": "SESSION_NOT_PROVIDED"
+			}
+		}
+	}
 }

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -198,6 +198,7 @@
             "Detail": {
               "auditPrefix": "${AuditEventPrefix}",
               "user.$": "$.sessionCheck.userAuditInfo",
+              "deviceInformation.$": "$.sessionCheck.txmaAuditHeader",
               "nino.$": "$.nino",
               "userInfoEvent.$": "$.userInfo",
               "issuer.$": "$.parameters.Issuer"
@@ -263,6 +264,7 @@
             "Detail": {
               "auditPrefix": "${AuditEventPrefix}",
               "user.$": "$.sessionCheck.userAuditInfo",
+              "deviceInformation.$": "$.sessionCheck.txmaAuditHeader",
               "issuer.$": "$.parameters.Issuer"
             },
             "DetailType": "${AuditEventNameResponseReceived}",


### PR DESCRIPTION
## Proposed changes

### What changed

Check input for the txma header if present get the header value if not set an empty string {}. To use, the header can be published as part of the event that need it.

### Why did it change

To allow the inclusion of device information in audit events

### Screenshots 

![image](https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/assets/3749690/98085f00-5b66-4cf3-8537-1fe1893e0a5c)

![image](https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/assets/3749690/8445a3e2-fffe-4f17-ae6f-f7d64c1e5451)

<img width="639" alt="Screenshot 2024-05-08 at 5 05 57 PM" src="https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/assets/40401118/ee5096f5-329c-4162-8800-bcd21488617a">
<img width="631" alt="Screenshot 2024-05-08 at 4 59 01 PM" src="https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/assets/40401118/0ebeaa33-0023-4450-9b68-d38522c6dd06">
<img width="672" alt="Screenshot 2024-05-08 at 5 11 45 PM" src="https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/assets/40401118/a40061c1-da7f-437d-802a-5bb67dfa364f">


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2501](https://govukverify.atlassian.net/browse/OJ-2501)



[OJ-2501]: https://govukverify.atlassian.net/browse/OJ-2501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ