### PR TITLE
OJ-2556: Added Alarm for FailedInvocation Metric to EventBridge Rules (PART 1)

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -52,14 +52,11 @@ Conditions:
     - !Ref Environment
     - production
 
-  IsNotDevEnvironment: !Not
-    - !Condition IsDevEnvironment
-
   IsNotDevLikeEnvironment: !Not
     - !Condition IsDevLikeEnvironment
 
   DeployAlarms: !Or
-    - !Condition IsNotDevEnvironment
+    - !Condition IsNotDevLikeEnvironment
     - !Equals [!Ref DeployAlarmsInDevEnvironment, "true"]
 
 Mappings:
@@ -1668,6 +1665,7 @@ Resources:
   #                                                                  #
   ####################################################################
   TxMaAuditEventRuleAlarm:
+    Condition: "DeployAlarms"
     Type: AWS::CloudWatch::Alarm
     Properties:
       OKActions:
@@ -1692,6 +1690,7 @@ Resources:
           Value: !Ref CheckHmrcEventBus
 
   AuditEventRequestSentRuleAlarm:
+    Condition: "DeployAlarms"
     Type: AWS::CloudWatch::Alarm
     Properties:
       OKActions:
@@ -1716,6 +1715,7 @@ Resources:
           Value: !Ref CheckHmrcEventBus
 
   AuditEventResponseReceivedRuleAlarm:
+    Condition: "DeployAlarms"
     Type: AWS::CloudWatch::Alarm
     Properties:
       OKActions:
@@ -1740,6 +1740,7 @@ Resources:
           Value: !Ref CheckHmrcEventBus
 
   AuditEventVcIssuedRuleAlarm:
+    Condition: "DeployAlarms"
     Type: AWS::CloudWatch::Alarm
     Properties:
       OKActions:
@@ -1764,6 +1765,7 @@ Resources:
           Value: !Ref CheckHmrcEventBus
 
   AuditEventEndRuleAlarm:
+    Condition: "DeployAlarms"
     Type: AWS::CloudWatch::Alarm
     Properties:
       OKActions:
@@ -1788,6 +1790,7 @@ Resources:
           Value: !Ref CheckHmrcEventBus
 
   AuditEventAbandonedRuleAlarm:
+    Condition: "DeployAlarms"
     Type: AWS::CloudWatch::Alarm
     Properties:
       OKActions:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1598,6 +1598,46 @@ Resources:
         - Arn: !Ref AuditEventStateMachine
           Id: AuditEventStateMachineAbandonedTarget
           RoleArn: !GetAtt EventBridgeStateMachineExecutionRole.Arn
+  TxMaAuditEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      EventBusName: !Ref CheckHmrcEventBus
+      Description: Capture all the TxMA Audit event
+      State: ENABLED
+      EventPattern:
+        source:
+          - !FindInMap [Audit, Source, !Ref Environment]
+        detail:
+          timestamp: [{ "exists": true }]
+          event_timestamp_ms: [{ "exists": true }]
+      Targets:
+        - Arn: !Sub
+            - "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${auditEventQueueName}"
+            - auditEventQueueName: !ImportValue "AuditEventQueueName"
+          Id: AuditEventQueue
+          InputPath: "$.detail"
+  EventBridgeToSqsPolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: SQS:SendMessage
+            Resource: !Sub
+              - "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${auditEventQueueName}"
+              - auditEventQueueName: !ImportValue "AuditEventQueueName"
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action:
+              - "kms:Decrypt"
+              - "kms:GenerateDataKey"
+            Resource:
+              - !ImportValue AuditEventQueueEncryptionKeyArn
+      Queues:
+        - !ImportValue "AuditEventQueueName"
   EventBridgeStateMachineExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -1756,7 +1796,8 @@ Resources:
       DefinitionSubstitutions:
         CredentialSubjectFunctionArn: !GetAtt CredentialSubjectFunction.Arn
         EpochTimeArn: !GetAtt EpochTimeFunction.Arn
-        SqsAuditEventQueueUrl: !ImportValue AuditEventQueueUrl
+        CheckHmrcEventBus: !Ref CheckHmrcEventBus
+        CheckHmrcEventBusSource: !FindInMap [Audit, Source, !Ref Environment]
       Logging:
         Destinations:
           - CloudWatchLogsLogGroup:
@@ -1768,16 +1809,8 @@ Resources:
             FunctionName: !Ref CredentialSubjectFunction
         - LambdaInvokePolicy:
             FunctionName: !Ref EpochTimeFunction
-        - SQSSendMessagePolicy:
-            QueueName: !ImportValue AuditEventQueueName
-        - Statement:
-            - Sid: auditEventQueueKmsEncryptionKeyPermission
-              Effect: Allow
-              Action:
-                - "kms:Decrypt"
-                - "kms:GenerateDataKey"
-              Resource:
-                - !ImportValue AuditEventQueueEncryptionKeyArn
+        - EventBridgePutEventsPolicy:
+            EventBusName: !Ref CheckHmrcEventBus
         - Statement:
             Effect: Allow
             Action: logs:*

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -183,7 +183,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref EpochTimeFunctionLogGroup
 
@@ -241,7 +241,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref CiMappingFunctionLogGroup
 
@@ -301,7 +301,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref CreateAuthCodeFunctionLogGroup
 
@@ -361,7 +361,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref CredentialSubjectFunctionLogGroup
 
@@ -421,7 +421,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref CurrentTimeFunctionLogGroup
 
@@ -486,7 +486,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref JwtSignerFunctionLogGroup
 
@@ -546,7 +546,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref OTGFunctionLogGroup
 
@@ -588,8 +588,7 @@ Resources:
       LogGroupName: !Ref OTGFunctionLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
       MetricTransformations:
-        -
-          MetricValue: "1"
+        - MetricValue: "1"
           MetricNamespace: !Sub "${AWS::StackName}/LogMessages"
           MetricName: "OTGFunction-Fatalerror"
 
@@ -606,11 +605,11 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      InsufficientDataActions: [ ]
+      InsufficientDataActions: []
       MetricName: BearerTokenHandlerFunction-Fatalerror
       Namespace: !Sub "${AWS::StackName}/LogMessages"
       Statistic: Sum
-      Dimensions: [ ]
+      Dimensions: []
       Period: 60
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
@@ -667,7 +666,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref MatchingFunctionLogGroup
 
@@ -730,7 +729,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref SsmParametersFunctionLogGroup
 
@@ -790,7 +789,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref TimeFunctionLogGroup
 
@@ -900,7 +899,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref PublicNinoCheckApiAccessLogGroup
 
@@ -1001,7 +1000,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref PrivateNinoCheckApiAccessLogGroup
 
@@ -1247,7 +1246,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref NinoCheckStateMachineLogGroup
 
@@ -1255,7 +1254,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref NinoCheckStateMachineLogGroup
-      FilterPattern: "{$.type = \"ExecutionFailed\"}"
+      FilterPattern: '{$.type = "ExecutionFailed"}'
       MetricTransformations:
         - MetricValue: "1"
           MetricName: "NinoCheckStateMachine}-Error"
@@ -1339,7 +1338,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref AbandonStateMachineLogGroup
 
@@ -1347,7 +1346,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref AbandonStateMachineLogGroup
-      FilterPattern: "{$.type = \"ExecutionFailed\"}"
+      FilterPattern: '{$.type = "ExecutionFailed"}'
       MetricTransformations:
         - MetricValue: "1"
           MetricName: "AbandonStateMachine}-Error"
@@ -1462,7 +1461,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref NinoIssueCredentialLogGroup
 
@@ -1470,7 +1469,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref NinoIssueCredentialLogGroup
-      FilterPattern: "{$.type = \"ExecutionFailed\"}"
+      FilterPattern: '{$.type = "ExecutionFailed"}'
       MetricTransformations:
         - MetricValue: "1"
           MetricName: "NinoIssueCredentialStateMachine}-Error"
@@ -1510,7 +1509,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref CheckSessionStateMachineLogGroup
 
@@ -1598,11 +1597,12 @@ Resources:
         - Arn: !Ref AuditEventStateMachine
           Id: AuditEventStateMachineAbandonedTarget
           RoleArn: !GetAtt EventBridgeStateMachineExecutionRole.Arn
+
   TxMaAuditEventRule:
     Type: AWS::Events::Rule
     Properties:
       EventBusName: !Ref CheckHmrcEventBus
-      Description: Capture all the TxMA Audit event
+      Description: Publish all formatted events from AuditEvent Step Function to TxMA audit Queue
       State: ENABLED
       EventPattern:
         source:
@@ -1638,6 +1638,7 @@ Resources:
               - !ImportValue AuditEventQueueEncryptionKeyArn
       Queues:
         - !ImportValue "AuditEventQueueName"
+
   EventBridgeStateMachineExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -1666,6 +1667,30 @@ Resources:
   # Audit Event Consumer Rule Alarms                                 #
   #                                                                  #
   ####################################################################
+  TxMaAuditEventRuleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "TxMaAuditEventRule (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-TxMaAuditEventRule-alarm"
+      MetricName: "FailedInvocations"
+      Namespace: "AWS/Events"
+      ComparisonOperator: GreaterThanThreshold
+      Statistic: Sum
+      DatapointsToAlarm: 4
+      EvaluationPeriods: 12
+      Period: 300
+      Threshold: 0
+      TreatMissingData: missing
+      Dimensions:
+        - Name: RuleName
+          Value: !Select [1, !Split ["|", !Ref TxMaAuditEventRule]]
+        - Name: EventBusName
+          Value: !Ref CheckHmrcEventBus
+
   AuditEventRequestSentRuleAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -1831,7 +1856,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref AuditEventStateMachineLogGroup
 

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1520,7 +1520,7 @@ Resources:
       Name: !Sub ${AWS::StackName}-CheckHmrcEventBus
   ##################################################################
   #                                                                  #
-  # Audit Event Consumer                                             #
+  # Nino Check Audit Event Consumer                                  #
   #                                                                  #
   ####################################################################
   AuditEventResponseReceivedRule:
@@ -1621,6 +1621,132 @@ Resources:
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary
         - !Ref AWS::NoValue
+  ##################################################################
+  #                                                                  #
+  # Audit Event Consumer Rule Alarms                                 #
+  #                                                                  #
+  ####################################################################
+  AuditEventRequestSentRuleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "AuditEventRequestSentRule (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventRequestSentRule-alarm"
+      MetricName: "FailedInvocations"
+      Namespace: "AWS/Events"
+      ComparisonOperator: GreaterThanThreshold
+      Statistic: Sum
+      DatapointsToAlarm: 4
+      EvaluationPeriods: 12
+      Period: 300
+      Threshold: 0
+      TreatMissingData: missing
+      Dimensions:
+        - Name: RuleName
+          Value: !Select [1, !Split ["|", !Ref AuditEventRequestSentRule]]
+        - Name: EventBusName
+          Value: !Ref CheckHmrcEventBus
+
+  AuditEventResponseReceivedRuleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "AuditEventResponseReceivedRule (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventResponseReceivedRule-alarm"
+      MetricName: "FailedInvocations"
+      Namespace: "AWS/Events"
+      ComparisonOperator: GreaterThanThreshold
+      Statistic: Sum
+      DatapointsToAlarm: 4
+      EvaluationPeriods: 12
+      Period: 300
+      Threshold: 0
+      TreatMissingData: missing
+      Dimensions:
+        - Name: RuleName
+          Value: !Select [1, !Split ["|", !Ref AuditEventResponseReceivedRule]]
+        - Name: EventBusName
+          Value: !Ref CheckHmrcEventBus
+
+  AuditEventVcIssuedRuleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "AuditEventVcIssuedRule (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventVcIssuedRule-alarm"
+      MetricName: "FailedInvocations"
+      Namespace: "AWS/Events"
+      ComparisonOperator: GreaterThanThreshold
+      Statistic: Sum
+      DatapointsToAlarm: 4
+      EvaluationPeriods: 12
+      Period: 300
+      Threshold: 0
+      TreatMissingData: missing
+      Dimensions:
+        - Name: RuleName
+          Value: !Select [1, !Split ["|", !Ref AuditEventVcIssuedRule]]
+        - Name: EventBusName
+          Value: !Ref CheckHmrcEventBus
+
+  AuditEventEndRuleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "AuditEventEndRule (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventEndRule-alarm"
+      MetricName: "FailedInvocations"
+      Namespace: "AWS/Events"
+      ComparisonOperator: GreaterThanThreshold
+      Statistic: Sum
+      DatapointsToAlarm: 4
+      EvaluationPeriods: 12
+      Period: 300
+      Threshold: 0
+      TreatMissingData: missing
+      Dimensions:
+        - Name: RuleName
+          Value: !Select [1, !Split ["|", !Ref AuditEventEndRule]]
+        - Name: EventBusName
+          Value: !Ref CheckHmrcEventBus
+
+  AuditEventAbandonedRuleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "AuditEventAbandonedRule (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventAbandonedRule-alarm"
+      MetricName: "FailedInvocations"
+      Namespace: "AWS/Events"
+      ComparisonOperator: GreaterThanThreshold
+      Statistic: Sum
+      DatapointsToAlarm: 4
+      EvaluationPeriods: 12
+      Period: 300
+      Threshold: 0
+      TreatMissingData: missing
+      Dimensions:
+        - Name: RuleName
+          Value: !Select [1, !Split ["|", !Ref AuditEventAbandonedRule]]
+        - Name: EventBusName
+          Value: !Ref CheckHmrcEventBus
+
+  ###############################################################################
 
   AuditEventStateMachine:
     Type: AWS::Serverless::StateMachine

--- a/step-functions/audit_event.asl.json
+++ b/step-functions/audit_event.asl.json
@@ -191,12 +191,19 @@
 		},
 		"publish event to TxMa Queue": {
 			"Type": "Task",
-      "InputPath": "$[0]",
-			"Resource": "arn:aws:states:::sqs:sendMessage",
+      "InputPath": "$[0].auditEvent",
+			"Resource": "arn:aws:states:::events:putEvents",
 			"Parameters": {
-				"QueueUrl": "${SqsAuditEventQueueUrl}",
-				"MessageBody.$": "$.auditEvent"
+				"Entries": [
+					{
+						"Detail.$": "$",
+						"DetailType.$": "$.event_name",
+						"EventBusName": "${CheckHmrcEventBus}",
+            "Source": "${CheckHmrcEventBusSource}"
+					}
+				]
 			},
+      "ResultPath": null,
 			"End": true
 		}
 	}


### PR DESCRIPTION

## Proposed changes 

A meaningful monitoring and alarms for the EventBridge rules

### What changed

Added FailedInvocation Alarm for Audit Event Eventbridge Rules in Nino CRI, Eventbridge rules have many alarms but this seems like a good place to start. This PR doesn't consider what happens to messages when things fails. 

NB: The way events are made available to the TxMA queue has been refactored in this PR. This now uses a new Event bridge rule `TxMaAuditEventRule` , which needs a FailedInvocation Alarm also included in this PR

See: https://gds.slack.com/archives/C06TX3H2XPS/p1715241837577809

- [OJ-2556](https://govukverify.atlassian.net/browse/OJ-2556)



[OJ-2556]: https://govukverify.atlassian.net/browse/OJ-2556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ