### PR TITLE
OJ-2556: Eventbus Alarms

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -59,6 +59,72 @@ Conditions:
     - !Condition IsNotDevLikeEnvironment
     - !Equals [!Ref DeployAlarmsInDevEnvironment, "true"]
 
+Metadata: &DataProtectionPolicy
+  Name: data-protection-policy
+  Description: ""
+  Version: "2021-06-01"
+  Statement:
+    - Sid: audit-policy
+      DataIdentifier:
+        - arn:aws:dataprotection::aws:data-identifier/Address
+        - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
+        - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
+        - arn:aws:dataprotection::aws:data-identifier/IpAddress
+        - arn:aws:dataprotection::aws:data-identifier/Name
+        - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
+        - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
+        - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
+        - userId
+        - firstName
+        - lastName
+        - DOBInQuery
+        - addressPart1
+        - addressPart2
+        - subject
+        - givenNameOrFamilyName
+      Operation:
+        Audit:
+          FindingsDestination: { }
+    - Sid: redact-policy
+      DataIdentifier:
+        - arn:aws:dataprotection::aws:data-identifier/Address
+        - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
+        - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
+        - arn:aws:dataprotection::aws:data-identifier/IpAddress
+        - arn:aws:dataprotection::aws:data-identifier/Name
+        - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
+        - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
+        - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
+        - userId
+        - firstName
+        - lastName
+        - DOBInQuery
+        - addressPart1
+        - addressPart2
+        - subject
+        - givenNameOrFamilyName
+      Operation:
+        Deidentify:
+          MaskConfig: { }
+  Configuration:
+    CustomDataIdentifier:
+      - Name: userId
+        Regex: "\\\\\"user_id\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
+      - Name: firstName
+        Regex: "\\\\\"firstName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
+      - Name: lastName
+        Regex: "\\\\\"lastName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
+      - Name: DOBInQuery
+        Regex: "(?:\\\\\"birthDates\\\\\").*?\\\\\"S\\\\\":\\\\\"(\\d{4}-\\d{2}-\\d{2})\\\\\""
+      - Name: addressPart1
+        Regex: "\\\\\"buildingName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"addressLocality\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"buildingNumber\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
+      - Name: addressPart2
+        Regex: "\\\\\"postalCode\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"streetName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
+      - Name: subject
+        Regex: "\\\\\"subject\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
+      - Name: givenNameOrFamilyName
+        Regex: "(?:\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"GivenName\\\\\"}|\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"FamilyName\\\\\"}),\\\\\"value\\\\\":{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
+
 Mappings:
   # Only numeric values should be assigned here
   MaxJwtTtl:
@@ -353,70 +419,7 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CredentialSubjectFunction
       RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
       DataProtectionPolicy:
-        Name: data-protection-policy
-        Description: ""
-        Version: "2021-06-01"
-        Statement:
-          - Sid: audit-policy
-            DataIdentifier:
-              - arn:aws:dataprotection::aws:data-identifier/Address
-              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-              - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-              - arn:aws:dataprotection::aws:data-identifier/IpAddress
-              - arn:aws:dataprotection::aws:data-identifier/Name
-              - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-              - userId
-              - firstName
-              - lastName
-              - DOBInQuery
-              - addressPart1
-              - addressPart2
-              - subject
-              - givenNameOrFamilyName
-            Operation:
-              Audit:
-                FindingsDestination: { }
-          - Sid: redact-policy
-            DataIdentifier:
-              - arn:aws:dataprotection::aws:data-identifier/Address
-              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-              - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-              - arn:aws:dataprotection::aws:data-identifier/IpAddress
-              - arn:aws:dataprotection::aws:data-identifier/Name
-              - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-              - userId
-              - firstName
-              - lastName
-              - DOBInQuery
-              - addressPart1
-              - addressPart2
-              - subject
-              - givenNameOrFamilyName
-            Operation:
-              Deidentify:
-                MaskConfig: { }
-        Configuration:
-          CustomDataIdentifier:
-            - Name: userId
-              Regex: "\\\\\"user_id\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: firstName
-              Regex: "\\\\\"firstName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: lastName
-              Regex: "\\\\\"lastName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: DOBInQuery
-              Regex: "(?:\\\\\"birthDates\\\\\").*?\\\\\"S\\\\\":\\\\\"(\\d{4}-\\d{2}-\\d{2})\\\\\""
-            - Name: addressPart1
-              Regex: "\\\\\"buildingName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"addressLocality\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"buildingNumber\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: addressPart2
-              Regex: "\\\\\"postalCode\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"streetName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: subject
-              Regex: "\\\\\"subject\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: givenNameOrFamilyName
-              Regex: "(?:\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"GivenName\\\\\"}|\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"FamilyName\\\\\"}),\\\\\"value\\\\\":{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
+        <<: *DataProtectionPolicy
 
   CredentialSubjectFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -660,7 +663,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: "DeployAlarms"
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-BearerTokenHandlerFunction-FatalErrorAlarm"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-${OTGFunction}-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
@@ -668,7 +671,7 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       InsufficientDataActions: []
-      MetricName: BearerTokenHandlerFunction-Fatalerror
+      MetricName: !Sub ${OTGFunction}-Fatalerror
       Namespace: !Sub "${AWS::StackName}/LogMessages"
       Statistic: Sum
       Dimensions: []
@@ -723,70 +726,7 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction
       RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
       DataProtectionPolicy:
-        Name: data-protection-policy
-        Description: ""
-        Version: "2021-06-01"
-        Statement:
-          - Sid: audit-policy
-            DataIdentifier:
-              - arn:aws:dataprotection::aws:data-identifier/Address
-              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-              - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-              - arn:aws:dataprotection::aws:data-identifier/IpAddress
-              - arn:aws:dataprotection::aws:data-identifier/Name
-              - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-              - userId
-              - firstName
-              - lastName
-              - DOBInQuery
-              - addressPart1
-              - addressPart2
-              - subject
-              - givenNameOrFamilyName
-            Operation:
-              Audit:
-                FindingsDestination: { }
-          - Sid: redact-policy
-            DataIdentifier:
-              - arn:aws:dataprotection::aws:data-identifier/Address
-              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-              - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-              - arn:aws:dataprotection::aws:data-identifier/IpAddress
-              - arn:aws:dataprotection::aws:data-identifier/Name
-              - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-              - userId
-              - firstName
-              - lastName
-              - DOBInQuery
-              - addressPart1
-              - addressPart2
-              - subject
-              - givenNameOrFamilyName
-            Operation:
-              Deidentify:
-                MaskConfig: { }
-        Configuration:
-          CustomDataIdentifier:
-            - Name: userId
-              Regex: "\\\\\"user_id\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: firstName
-              Regex: "\\\\\"firstName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: lastName
-              Regex: "\\\\\"lastName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: DOBInQuery
-              Regex: "(?:\\\\\"birthDates\\\\\").*?\\\\\"S\\\\\":\\\\\"(\\d{4}-\\d{2}-\\d{2})\\\\\""
-            - Name: addressPart1
-              Regex: "\\\\\"buildingName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"addressLocality\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"buildingNumber\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: addressPart2
-              Regex: "\\\\\"postalCode\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"streetName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: subject
-              Regex: "\\\\\"subject\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: givenNameOrFamilyName
-              Regex: "(?:\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"GivenName\\\\\"}|\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"FamilyName\\\\\"}),\\\\\"value\\\\\":{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
+        <<: *DataProtectionPolicy
 
   MatchingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1046,7 +986,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: "DeployAlarms"
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-PublicNinoCheckApi-FatalErrorAlarm"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-${PublicNinoCheckApi}-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
@@ -1147,7 +1087,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: "DeployAlarms"
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-PrivateNinoCheckApi-FatalErrorAlarm"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-${PrivateNinoCheckApi}-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
@@ -1267,7 +1207,7 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Check Session failed 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-CheckSessionStateMachineAlarm"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-${CheckSessionStateMachine}-Alarm"
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 4
       EvaluationPeriods: 12
@@ -1368,70 +1308,7 @@ Resources:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoCheck-state-machine-logs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
       DataProtectionPolicy:
-        Name: data-protection-policy
-        Description: ""
-        Version: "2021-06-01"
-        Statement:
-          - Sid: audit-policy
-            DataIdentifier:
-              - arn:aws:dataprotection::aws:data-identifier/Address
-              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-              - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-              - arn:aws:dataprotection::aws:data-identifier/IpAddress
-              - arn:aws:dataprotection::aws:data-identifier/Name
-              - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-              - userId
-              - firstName
-              - lastName
-              - DOBInQuery
-              - addressPart1
-              - addressPart2
-              - subject
-              - givenNameOrFamilyName
-            Operation:
-              Audit:
-                FindingsDestination: { }
-          - Sid: redact-policy
-            DataIdentifier:
-              - arn:aws:dataprotection::aws:data-identifier/Address
-              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-              - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-              - arn:aws:dataprotection::aws:data-identifier/IpAddress
-              - arn:aws:dataprotection::aws:data-identifier/Name
-              - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-              - userId
-              - firstName
-              - lastName
-              - DOBInQuery
-              - addressPart1
-              - addressPart2
-              - subject
-              - givenNameOrFamilyName
-            Operation:
-              Deidentify:
-                MaskConfig: { }
-        Configuration:
-          CustomDataIdentifier:
-            - Name: userId
-              Regex: "\\\\\"user_id\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: firstName
-              Regex: "\\\\\"firstName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: lastName
-              Regex: "\\\\\"lastName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: DOBInQuery
-              Regex: "(?:\\\\\"birthDates\\\\\").*?\\\\\"S\\\\\":\\\\\"(\\d{4}-\\d{2}-\\d{2})\\\\\""
-            - Name: addressPart1
-              Regex: "\\\\\"buildingName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"addressLocality\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"buildingNumber\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: addressPart2
-              Regex: "\\\\\"postalCode\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"streetName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: subject
-              Regex: "\\\\\"subject\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: givenNameOrFamilyName
-              Regex: "(?:\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"GivenName\\\\\"}|\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"FamilyName\\\\\"}),\\\\\"value\\\\\":{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
+        <<: *DataProtectionPolicy
 
   NinoCheckStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1461,7 +1338,7 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "NINO Check failed 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-NinoCheckStateMachineAlarm"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-${NinoCheckStateMachine}-Alarm"
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 4
       EvaluationPeriods: 12
@@ -1525,70 +1402,7 @@ Resources:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-Abandon-state-machine-logs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
       DataProtectionPolicy:
-        Name: data-protection-policy
-        Description: ""
-        Version: "2021-06-01"
-        Statement:
-          - Sid: audit-policy
-            DataIdentifier:
-              - arn:aws:dataprotection::aws:data-identifier/Address
-              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-              - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-              - arn:aws:dataprotection::aws:data-identifier/IpAddress
-              - arn:aws:dataprotection::aws:data-identifier/Name
-              - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-              - userId
-              - firstName
-              - lastName
-              - DOBInQuery
-              - addressPart1
-              - addressPart2
-              - subject
-              - givenNameOrFamilyName
-            Operation:
-              Audit:
-                FindingsDestination: { }
-          - Sid: redact-policy
-            DataIdentifier:
-              - arn:aws:dataprotection::aws:data-identifier/Address
-              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-              - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-              - arn:aws:dataprotection::aws:data-identifier/IpAddress
-              - arn:aws:dataprotection::aws:data-identifier/Name
-              - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-              - userId
-              - firstName
-              - lastName
-              - DOBInQuery
-              - addressPart1
-              - addressPart2
-              - subject
-              - givenNameOrFamilyName
-            Operation:
-              Deidentify:
-                MaskConfig: { }
-        Configuration:
-          CustomDataIdentifier:
-            - Name: userId
-              Regex: "\\\\\"user_id\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: firstName
-              Regex: "\\\\\"firstName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: lastName
-              Regex: "\\\\\"lastName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: DOBInQuery
-              Regex: "(?:\\\\\"birthDates\\\\\").*?\\\\\"S\\\\\":\\\\\"(\\d{4}-\\d{2}-\\d{2})\\\\\""
-            - Name: addressPart1
-              Regex: "\\\\\"buildingName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"addressLocality\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"buildingNumber\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: addressPart2
-              Regex: "\\\\\"postalCode\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"streetName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: subject
-              Regex: "\\\\\"subject\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: givenNameOrFamilyName
-              Regex: "(?:\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"GivenName\\\\\"}|\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"FamilyName\\\\\"}),\\\\\"value\\\\\":{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
+        <<: *DataProtectionPolicy
 
   AbandonStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1618,7 +1432,7 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Abandon failed 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-AbandonStateMachineAlarm"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-${AbandonStateMachine}-Alarm"
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 4
       EvaluationPeriods: 12
@@ -1713,70 +1527,7 @@ Resources:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoIssueCredential-state-machine-logs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
       DataProtectionPolicy:
-        Name: data-protection-policy
-        Description: ""
-        Version: "2021-06-01"
-        Statement:
-          - Sid: audit-policy
-            DataIdentifier:
-              - arn:aws:dataprotection::aws:data-identifier/Address
-              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-              - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-              - arn:aws:dataprotection::aws:data-identifier/IpAddress
-              - arn:aws:dataprotection::aws:data-identifier/Name
-              - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-              - userId
-              - firstName
-              - lastName
-              - DOBInQuery
-              - addressPart1
-              - addressPart2
-              - subject
-              - givenNameOrFamilyName
-            Operation:
-              Audit:
-                FindingsDestination: { }
-          - Sid: redact-policy
-            DataIdentifier:
-              - arn:aws:dataprotection::aws:data-identifier/Address
-              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-              - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-              - arn:aws:dataprotection::aws:data-identifier/IpAddress
-              - arn:aws:dataprotection::aws:data-identifier/Name
-              - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-              - userId
-              - firstName
-              - lastName
-              - DOBInQuery
-              - addressPart1
-              - addressPart2
-              - subject
-              - givenNameOrFamilyName
-            Operation:
-              Deidentify:
-                MaskConfig: { }
-        Configuration:
-          CustomDataIdentifier:
-            - Name: userId
-              Regex: "\\\\\"user_id\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: firstName
-              Regex: "\\\\\"firstName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: lastName
-              Regex: "\\\\\"lastName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: DOBInQuery
-              Regex: "(?:\\\\\"birthDates\\\\\").*?\\\\\"S\\\\\":\\\\\"(\\d{4}-\\d{2}-\\d{2})\\\\\""
-            - Name: addressPart1
-              Regex: "\\\\\"buildingName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"addressLocality\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"buildingNumber\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: addressPart2
-              Regex: "\\\\\"postalCode\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"streetName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: subject
-              Regex: "\\\\\"subject\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: givenNameOrFamilyName
-              Regex: "(?:\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"GivenName\\\\\"}|\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"FamilyName\\\\\"}),\\\\\"value\\\\\":{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
+        <<: *DataProtectionPolicy
 
   NinoIssueCredentialLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1806,7 +1557,7 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "NINO Issue Credential failed 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-NinoIssueCredentialStateMachineAlarm"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-${NinoIssueCredentialStateMachine}-Alarm"
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 4
       EvaluationPeriods: 12
@@ -1826,70 +1577,7 @@ Resources:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-CheckSession-state-machine-logs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
       DataProtectionPolicy:
-        Name: data-protection-policy
-        Description: ""
-        Version: "2021-06-01"
-        Statement:
-          - Sid: audit-policy
-            DataIdentifier:
-              - arn:aws:dataprotection::aws:data-identifier/Address
-              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-              - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-              - arn:aws:dataprotection::aws:data-identifier/IpAddress
-              - arn:aws:dataprotection::aws:data-identifier/Name
-              - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-              - userId
-              - firstName
-              - lastName
-              - DOBInQuery
-              - addressPart1
-              - addressPart2
-              - subject
-              - givenNameOrFamilyName
-            Operation:
-              Audit:
-                FindingsDestination: { }
-          - Sid: redact-policy
-            DataIdentifier:
-              - arn:aws:dataprotection::aws:data-identifier/Address
-              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-              - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-              - arn:aws:dataprotection::aws:data-identifier/IpAddress
-              - arn:aws:dataprotection::aws:data-identifier/Name
-              - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-              - userId
-              - firstName
-              - lastName
-              - DOBInQuery
-              - addressPart1
-              - addressPart2
-              - subject
-              - givenNameOrFamilyName
-            Operation:
-              Deidentify:
-                MaskConfig: { }
-        Configuration:
-          CustomDataIdentifier:
-            - Name: userId
-              Regex: "\\\\\"user_id\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: firstName
-              Regex: "\\\\\"firstName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: lastName
-              Regex: "\\\\\"lastName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: DOBInQuery
-              Regex: "(?:\\\\\"birthDates\\\\\").*?\\\\\"S\\\\\":\\\\\"(\\d{4}-\\d{2}-\\d{2})\\\\\""
-            - Name: addressPart1
-              Regex: "\\\\\"buildingName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"addressLocality\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"buildingNumber\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: addressPart2
-              Regex: "\\\\\"postalCode\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"streetName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: subject
-              Regex: "\\\\\"subject\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: givenNameOrFamilyName
-              Regex: "(?:\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"GivenName\\\\\"}|\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"FamilyName\\\\\"}),\\\\\"value\\\\\":{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
+        <<: *DataProtectionPolicy
 
   CheckSessionStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -2062,8 +1750,8 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "TxMaAuditEventRule (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-TxMaAuditEventRule-alarm"
+      AlarmDescription: !Sub "${TxMaAuditEventRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-${TxMaAuditEventRule}-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
       ComparisonOperator: GreaterThanThreshold
@@ -2087,8 +1775,8 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "AuditEventRequestSentRule (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventRequestSentRule-alarm"
+      AlarmDescription: !Sub "${AuditEventRequestSentRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-${AuditEventRequestSentRule}-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
       ComparisonOperator: GreaterThanThreshold
@@ -2112,8 +1800,8 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "AuditEventResponseReceivedRule (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventResponseReceivedRule-alarm"
+      AlarmDescription: !Sub "${AuditEventResponseReceivedRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-${AuditEventResponseReceivedRule}-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
       ComparisonOperator: GreaterThanThreshold
@@ -2137,8 +1825,8 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "AuditEventVcIssuedRule (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventVcIssuedRule-alarm"
+      AlarmDescription: !Sub "${AuditEventVcIssuedRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-${AuditEventVcIssuedRule}-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
       ComparisonOperator: GreaterThanThreshold
@@ -2244,70 +1932,7 @@ Resources:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-AuditEvent-state-machine-logs
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
       DataProtectionPolicy:
-        Name: data-protection-policy
-        Description: ""
-        Version: "2021-06-01"
-        Statement:
-          - Sid: audit-policy
-            DataIdentifier:
-              - arn:aws:dataprotection::aws:data-identifier/Address
-              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-              - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-              - arn:aws:dataprotection::aws:data-identifier/IpAddress
-              - arn:aws:dataprotection::aws:data-identifier/Name
-              - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-              - userId
-              - firstName
-              - lastName
-              - DOBInQuery
-              - addressPart1
-              - addressPart2
-              - subject
-              - givenNameOrFamilyName
-            Operation:
-              Audit:
-                FindingsDestination: { }
-          - Sid: redact-policy
-            DataIdentifier:
-              - arn:aws:dataprotection::aws:data-identifier/Address
-              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-              - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-              - arn:aws:dataprotection::aws:data-identifier/IpAddress
-              - arn:aws:dataprotection::aws:data-identifier/Name
-              - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-              - userId
-              - firstName
-              - lastName
-              - DOBInQuery
-              - addressPart1
-              - addressPart2
-              - subject
-              - givenNameOrFamilyName
-            Operation:
-              Deidentify:
-                MaskConfig: { }
-        Configuration:
-          CustomDataIdentifier:
-            - Name: userId
-              Regex: "\\\\\"user_id\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: firstName
-              Regex: "\\\\\"firstName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: lastName
-              Regex: "\\\\\"lastName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: DOBInQuery
-              Regex: "(?:\\\\\"birthDates\\\\\").*?\\\\\"S\\\\\":\\\\\"(\\d{4}-\\d{2}-\\d{2})\\\\\""
-            - Name: addressPart1
-              Regex: "\\\\\"buildingName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"addressLocality\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"buildingNumber\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: addressPart2
-              Regex: "\\\\\"postalCode\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"streetName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-            - Name: subject
-              Regex: "\\\\\"subject\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-            - Name: givenNameOrFamilyName
-              Regex: "(?:\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"GivenName\\\\\"}|\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"FamilyName\\\\\"}),\\\\\"value\\\\\":{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
+        <<: *DataProtectionPolicy
 
   AuditEventStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1892,6 +1892,105 @@ Resources:
         - Name: EventBusName
           Value: !Ref CheckHmrcEventBus
 
+  AuditEventRequestSentPutEventsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      InsufficientDataActions: []
+      AlarmDescription: !Sub "AuditEventRequestSentPutEvents (PutEvents Failed) 4 or more requests in the last hour. ${SupportManualURL}"
+      MetricName: PutEventsApproximateFailedCount
+      ComparisonOperator: GreaterThanThreshold
+      Namespace: "AWS/Events"
+      Statistic: Sum
+      DatapointsToAlarm: 4
+      EvaluationPeriods: 12
+      Dimensions: []
+      Period: 300
+      Threshold: 0
+      TreatMissingData: missing
+
+  AuditEventResponseReceivedPutEventsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      InsufficientDataActions: []
+      AlarmDescription: !Sub "AuditEventResponseReceivedPutEvents (PutEvents Failed) 4 or more requests in the last hour. ${SupportManualURL}"
+      MetricName: PutEventsApproximateFailedCount
+      ComparisonOperator: GreaterThanThreshold
+      Namespace: "AWS/Events"
+      Statistic: Sum
+      DatapointsToAlarm: 4
+      EvaluationPeriods: 12
+      Dimensions: []
+      Period: 300
+      Threshold: 0
+      TreatMissingData: missing
+
+  AuditEventVcIssuedPutEventsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      InsufficientDataActions: []
+      AlarmDescription: !Sub "AuditEventVcIssuedPutEvents (PutEvents Failed) 4 or more requests in the last hour. ${SupportManualURL}"
+      MetricName: PutEventsApproximateFailedCount
+      ComparisonOperator: GreaterThanThreshold
+      Namespace: "AWS/Events"
+      Statistic: Sum
+      DatapointsToAlarm: 4
+      EvaluationPeriods: 12
+      Dimensions: []
+      Period: 300
+      Threshold: 0
+      TreatMissingData: missing
+
+  AuditEventAbandonedPutEventsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      InsufficientDataActions: []
+      AlarmDescription: !Sub "AuditEventAbandonedPutEvents (PutEvents Failed) 4 or more requests in the last hour. ${SupportManualURL}"
+      MetricName: PutEventsApproximateFailedCount
+      ComparisonOperator: GreaterThanThreshold
+      Namespace: "AWS/Events"
+      Statistic: Sum
+      DatapointsToAlarm: 4
+      EvaluationPeriods: 12
+      Dimensions: []
+      Period: 300
+      Threshold: 0
+      TreatMissingData: missing
+
+  AuditEventEndPutEventsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      InsufficientDataActions: []
+      AlarmDescription: !Sub "AuditEventEndPutEvents (PutEvents Failed) 4 or more requests in the last hour. ${SupportManualURL}"
+      MetricName: PutEventsApproximateFailedCount
+      ComparisonOperator: GreaterThanThreshold
+      Namespace: "AWS/Events"
+      Statistic: Sum
+      DatapointsToAlarm: 4
+      EvaluationPeriods: 12
+      Dimensions: []
+      Period: 300
+      Threshold: 0
+      TreatMissingData: missing
   ###############################################################################
 
   AuditEventStateMachine:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -239,7 +239,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/EpochTimeFunction
-      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
   EpochTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -263,7 +263,7 @@ Resources:
   EpochTimeFunctionEventErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${EpochTimeFunction}-Errors"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-EpochTimeFunction-Errors"
       AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${EpochTimeFunction} errors. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions: [!ImportValue platform-alarm-warning-alert-topic]
@@ -297,7 +297,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CiMappingFunction
-      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
   CiMappingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -321,7 +321,7 @@ Resources:
   CiMappingFunctionEventErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${CiMappingFunction}-Errors"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-CiMappingFunction-Errors"
       AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${CiMappingFunction} errors. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
@@ -357,7 +357,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CreateAuthCodeFunction
-      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
   CreateAuthCodeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -381,7 +381,7 @@ Resources:
   CreateAuthCodeFunctionEventErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${CreateAuthCodeFunction}-Errors"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-CreateAuthCodeFunction-Errors"
       AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${CreateAuthCodeFunction} errors. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
@@ -417,7 +417,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CredentialSubjectFunction
-      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
       DataProtectionPolicy:
         <<: *DataProtectionPolicy
 
@@ -443,7 +443,7 @@ Resources:
   CredentialSubjectFunctionEventErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${CredentialSubjectFunction}-Errors"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-CredentialSubjectFunction-Errors"
       AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${CredentialSubjectFunction} errors. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
@@ -479,7 +479,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CurrentTimeFunction
-      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
   CurrentTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -503,7 +503,7 @@ Resources:
   CurrentTimeFunctionEventErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${CurrentTimeFunction}-Errors"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-CurrentTimeFunction-Errors"
       AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${CurrentTimeFunction} errors. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
@@ -544,7 +544,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/JwtSignerFunction
-      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
   JwtSignerFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -568,7 +568,7 @@ Resources:
   JwtSignerFunctionEventErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${JwtSignerFunction}-Errors"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-JwtSignerFunction-Errors"
       AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${JwtSignerFunction} errors. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
@@ -628,7 +628,7 @@ Resources:
   OTGFunctionEventErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${OTGFunction}-Errors"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-OTGFunction-Errors"
       AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${OTGFunction} errors. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
@@ -663,8 +663,8 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: "DeployAlarms"
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${OTGFunction}-FatalErrorAlarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-OTGFunction-FatalErrorAlarm"
+      AlarmDescription: !Sub "Trigger an alarm when Fatal ${OTGFunction} Error occurs. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -724,7 +724,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction
-      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
       DataProtectionPolicy:
         <<: *DataProtectionPolicy
 
@@ -750,7 +750,7 @@ Resources:
   MatchingFunctionEventErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${MatchingFunction}-Errors"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-MatchingFunction-Errors"
       AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${MatchingFunction} errors. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
@@ -789,7 +789,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/SsmParametersFunction
-      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
   SsmParametersFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -813,7 +813,7 @@ Resources:
   SsmParametersFunctionEventErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${SsmParametersFunction}-Errors"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-SsmParametersFunction-Errors"
       AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${SsmParametersFunction} errors. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
@@ -849,7 +849,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/TimeFunction
-      RetentionInDays: !If [IsDevLikeEnvironment, 7, 30]
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
   TimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -873,7 +873,7 @@ Resources:
   TimeFunctionEventErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${TimeFunction}-Errors"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-TimeFunction-Errors"
       AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${TimeFunction} errors. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
@@ -986,8 +986,8 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: "DeployAlarms"
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${PublicNinoCheckApi}-FatalErrorAlarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-PublicNinoCheckApi-FatalErrorAlarm"
+      AlarmDescription: !Sub "Trigger an alarm when Fatal ${PublicNinoCheckApi} Error occurs. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-critical-alert-topic
@@ -1087,8 +1087,8 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: "DeployAlarms"
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${PrivateNinoCheckApi}-FatalErrorAlarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-PrivateNinoCheckApi-FatalErrorAlarm"
+      AlarmDescription: !Sub "Trigger an alarm when Fatal ${PrivateNinoCheckApi} Error occurs. ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-critical-alert-topic
@@ -1206,8 +1206,8 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "Check Session failed 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${CheckSessionStateMachine}-Alarm"
+      AlarmDescription: !Sub "${CheckSessionStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-CheckSessionStateMachine-Alarm"
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 4
       EvaluationPeriods: 12
@@ -1337,8 +1337,8 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "NINO Check failed 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${NinoCheckStateMachine}-Alarm"
+      AlarmDescription: !Sub "${NinoCheckStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-NinoCheckStateMachine-Alarm"
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 4
       EvaluationPeriods: 12
@@ -1431,8 +1431,8 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "Abandon failed 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${AbandonStateMachine}-Alarm"
+      AlarmDescription: !Sub "${AbandonStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-AbandonStateMachine-Alarm"
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 4
       EvaluationPeriods: 12
@@ -1556,8 +1556,8 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "NINO Issue Credential failed 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${NinoIssueCredentialStateMachine}-Alarm"
+      AlarmDescription: !Sub "${NinoIssueCredentialStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-NinoIssueCredentialStateMachine-Alarm"
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 4
       EvaluationPeriods: 12
@@ -1751,7 +1751,7 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "${TxMaAuditEventRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${TxMaAuditEventRule}-alarm"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-TxMaAuditEventRule-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
       ComparisonOperator: GreaterThanThreshold
@@ -1776,7 +1776,7 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "${AuditEventRequestSentRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${AuditEventRequestSentRule}-alarm"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventRequestSentRule-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
       ComparisonOperator: GreaterThanThreshold
@@ -1801,7 +1801,7 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "${AuditEventResponseReceivedRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${AuditEventResponseReceivedRule}-alarm"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventResponseReceivedRule-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
       ComparisonOperator: GreaterThanThreshold
@@ -1826,7 +1826,7 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "${AuditEventVcIssuedRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-${AuditEventVcIssuedRule}-alarm"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventVcIssuedRule-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
       ComparisonOperator: GreaterThanThreshold
@@ -1850,7 +1850,7 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "AuditEventEndRule (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmDescription: !Sub "${AuditEventEndRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
       AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventEndRule-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
@@ -1875,7 +1875,7 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "AuditEventAbandonedRule (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmDescription: !Sub "${AuditEventAbandonedRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
       AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventAbandonedRule-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
@@ -1892,7 +1892,8 @@ Resources:
         - Name: EventBusName
           Value: !Ref CheckHmrcEventBus
 
-  AuditEventRequestSentPutEventsAlarm:
+  CheckHmrcEventBusPutEventAlarm:
+    Condition: "DeployAlarms"
     Type: AWS::CloudWatch::Alarm
     Properties:
       OKActions:
@@ -1900,97 +1901,20 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       InsufficientDataActions: []
-      AlarmDescription: !Sub "AuditEventRequestSentPutEvents (PutEvents Failed) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmDescription: !Sub "${CheckHmrcEventBus} PutEvents (PutEvents Failed) 4 or more requests in the last hour. ${SupportManualURL}"
       MetricName: PutEventsApproximateFailedCount
       ComparisonOperator: GreaterThanThreshold
       Namespace: "AWS/Events"
       Statistic: Sum
       DatapointsToAlarm: 4
       EvaluationPeriods: 12
-      Dimensions: []
+      Dimensions:
+        - Name: EventBusName
+          Value: !Ref CheckHmrcEventBus
       Period: 300
       Threshold: 0
       TreatMissingData: missing
 
-  AuditEventResponseReceivedPutEventsAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      InsufficientDataActions: []
-      AlarmDescription: !Sub "AuditEventResponseReceivedPutEvents (PutEvents Failed) 4 or more requests in the last hour. ${SupportManualURL}"
-      MetricName: PutEventsApproximateFailedCount
-      ComparisonOperator: GreaterThanThreshold
-      Namespace: "AWS/Events"
-      Statistic: Sum
-      DatapointsToAlarm: 4
-      EvaluationPeriods: 12
-      Dimensions: []
-      Period: 300
-      Threshold: 0
-      TreatMissingData: missing
-
-  AuditEventVcIssuedPutEventsAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      InsufficientDataActions: []
-      AlarmDescription: !Sub "AuditEventVcIssuedPutEvents (PutEvents Failed) 4 or more requests in the last hour. ${SupportManualURL}"
-      MetricName: PutEventsApproximateFailedCount
-      ComparisonOperator: GreaterThanThreshold
-      Namespace: "AWS/Events"
-      Statistic: Sum
-      DatapointsToAlarm: 4
-      EvaluationPeriods: 12
-      Dimensions: []
-      Period: 300
-      Threshold: 0
-      TreatMissingData: missing
-
-  AuditEventAbandonedPutEventsAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      InsufficientDataActions: []
-      AlarmDescription: !Sub "AuditEventAbandonedPutEvents (PutEvents Failed) 4 or more requests in the last hour. ${SupportManualURL}"
-      MetricName: PutEventsApproximateFailedCount
-      ComparisonOperator: GreaterThanThreshold
-      Namespace: "AWS/Events"
-      Statistic: Sum
-      DatapointsToAlarm: 4
-      EvaluationPeriods: 12
-      Dimensions: []
-      Period: 300
-      Threshold: 0
-      TreatMissingData: missing
-
-  AuditEventEndPutEventsAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      InsufficientDataActions: []
-      AlarmDescription: !Sub "AuditEventEndPutEvents (PutEvents Failed) 4 or more requests in the last hour. ${SupportManualURL}"
-      MetricName: PutEventsApproximateFailedCount
-      ComparisonOperator: GreaterThanThreshold
-      Namespace: "AWS/Events"
-      Statistic: Sum
-      DatapointsToAlarm: 4
-      EvaluationPeriods: 12
-      Dimensions: []
-      Period: 300
-      Threshold: 0
-      TreatMissingData: missing
   ###############################################################################
 
   AuditEventStateMachine:


### PR DESCRIPTION
## Proposed changes 

A meaningful monitoring and alarms for the EventBridge Bus
This is the second PR for PutEvent to the EventBus

### What changed

Added PutEvents Failed Alarm for Audit Event Eventbridge Bus in Nino CRI, Eventbridge Bus has other alarms but this seems like a good place to start. This PR doesn't consider what happens to messages when things fails. 

See: https://gds.slack.com/archives/C06TX3H2XPS/p1715241837577809

- [OJ-2556](https://govukverify.atlassian.net/browse/OJ-2556)

[OJ-2556]: https://govukverify.atlassian.net/browse/OJ-2556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ