### PR TITLE
OJ-2556: Missed alarm name on EventBus alarm

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1912,6 +1912,7 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       InsufficientDataActions: []
       AlarmDescription: !Sub "${CheckHmrcEventBus} PutEvents (PutEvents Failed) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-CheckHmrcEventBusPutEvents-alarm"
       MetricName: PutEventsApproximateFailedCount
       ComparisonOperator: GreaterThanThreshold
       Namespace: "AWS/Events"


### PR DESCRIPTION
Missing AlarmName one the CheckHmrcEvent Bus Alarm

see: https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/pull/245

