### PR TITLE
OJ-2319: Created new log groups for PII and PII Redact Lambda

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -59,72 +59,6 @@ Conditions:
     - !Condition IsNotDevLikeEnvironment
     - !Equals [!Ref DeployAlarmsInDevEnvironment, "true"]
 
-Metadata: &DataProtectionPolicy
-  Name: data-protection-policy
-  Description: ""
-  Version: "2021-06-01"
-  Statement:
-    - Sid: audit-policy
-      DataIdentifier:
-        - arn:aws:dataprotection::aws:data-identifier/Address
-        - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-        - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-        - arn:aws:dataprotection::aws:data-identifier/IpAddress
-        - arn:aws:dataprotection::aws:data-identifier/Name
-        - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-        - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-        - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-        - userId
-        - firstName
-        - lastName
-        - DOBInQuery
-        - addressPart1
-        - addressPart2
-        - subject
-        - givenNameOrFamilyName
-      Operation:
-        Audit:
-          FindingsDestination: { }
-    - Sid: redact-policy
-      DataIdentifier:
-        - arn:aws:dataprotection::aws:data-identifier/Address
-        - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
-        - arn:aws:dataprotection::aws:data-identifier/DateOfBirth
-        - arn:aws:dataprotection::aws:data-identifier/IpAddress
-        - arn:aws:dataprotection::aws:data-identifier/Name
-        - arn:aws:dataprotection::aws:data-identifier/NationalInsuranceNumber-GB
-        - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
-        - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
-        - userId
-        - firstName
-        - lastName
-        - DOBInQuery
-        - addressPart1
-        - addressPart2
-        - subject
-        - givenNameOrFamilyName
-      Operation:
-        Deidentify:
-          MaskConfig: { }
-  Configuration:
-    CustomDataIdentifier:
-      - Name: userId
-        Regex: "\\\\\"user_id\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-      - Name: firstName
-        Regex: "\\\\\"firstName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-      - Name: lastName
-        Regex: "\\\\\"lastName\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-      - Name: DOBInQuery
-        Regex: "(?:\\\\\"birthDates\\\\\").*?\\\\\"S\\\\\":\\\\\"(\\d{4}-\\d{2}-\\d{2})\\\\\""
-      - Name: addressPart1
-        Regex: "\\\\\"buildingName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"addressLocality\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"buildingNumber\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-      - Name: addressPart2
-        Regex: "\\\\\"postalCode\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\"|\\\\\"streetName\\\\\":\\{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-      - Name: subject
-        Regex: "\\\\\"subject\\\\\"\\s*:\\s*\\\\\"([^\"]*)\\\\\""
-      - Name: givenNameOrFamilyName
-        Regex: "(?:\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"GivenName\\\\\"}|\\\\\"type\\\\\":{\\\\\"S\\\\\":\\\\\"FamilyName\\\\\"}),\\\\\"value\\\\\":{\\\\\"S\\\\\":\\\\\"([^\"]*)\\\\\""
-
 Mappings:
   # Only numeric values should be assigned here
   MaxJwtTtl:
@@ -241,14 +175,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/EpochTimeFunction
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
-  EpochTimeFunctionLogsSubscriptionFilterCSLS:
+  PIIRedactedEpochTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref EpochTimeFunctionLogGroup
+      LogGroupName: !Ref PIIRedactedEpochTimeFunctionLogGroup
 
   EpochTimeFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -300,14 +234,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CiMappingFunction
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
-  CiMappingFunctionLogsSubscriptionFilterCSLS:
+  PIIRedactedCiMappingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref CiMappingFunctionLogGroup
+      LogGroupName: !Ref PIIRedactedCiMappingFunctionLogGroup
 
   CiMappingFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -361,14 +295,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CreateAuthCodeFunction
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
-  CreateAuthCodeFunctionLogsSubscriptionFilterCSLS:
+  PIIRedactedCreateAuthCodeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref CreateAuthCodeFunctionLogGroup
+      LogGroupName: !Ref PIIRedactedCreateAuthCodeFunctionLogGroup
 
   CreateAuthCodeFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -421,17 +355,15 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CredentialSubjectFunction
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
-      DataProtectionPolicy:
-        <<: *DataProtectionPolicy
 
-  CredentialSubjectFunctionLogsSubscriptionFilterCSLS:
+  PIIRedactedCredentialSubjectFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref CredentialSubjectFunctionLogGroup
+      LogGroupName: !Ref PIIRedactedCredentialSubjectFunctionLogGroup
 
   CredentialSubjectFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -485,14 +417,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CurrentTimeFunction
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
-  CurrentTimeFunctionLogsSubscriptionFilterCSLS:
+  PIIRedactedCurrentTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref CurrentTimeFunctionLogGroup
+      LogGroupName: !Ref PIIRedactedCurrentTimeFunctionLogGroup
 
   CurrentTimeFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -551,14 +483,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/JwtSignerFunction
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
-  JwtSignerFunctionLogsSubscriptionFilterCSLS:
+  PIIRedactedJwtSignerFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref JwtSignerFunctionLogGroup
+      LogGroupName: !Ref PIIRedactedJwtSignerFunctionLogGroup
 
   JwtSignerFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -612,14 +544,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/OTGFunction
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
-  OTGFunctionLogsSubscriptionFilterCSLS:
+  PIIRedactedOTGFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref OTGFunctionLogGroup
+      LogGroupName: !Ref PIIRedactedOTGFunctionLogGroup
 
   OTGFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -732,17 +664,15 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
-      DataProtectionPolicy:
-        <<: *DataProtectionPolicy
 
-  MatchingFunctionLogsSubscriptionFilterCSLS:
+  PIIRedactedMatchingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref MatchingFunctionLogGroup
+      LogGroupName: !Ref PIIRedactedMatchingFunctionLogGroup
 
   MatchingFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -799,14 +729,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/SsmParametersFunction
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
-  SsmParametersFunctionLogsSubscriptionFilterCSLS:
+  PIIRedactedSsmParametersFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref SsmParametersFunctionLogGroup
+      LogGroupName: !Ref PIIRedactedSsmParametersFunctionLogGroup
 
   SsmParametersFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -860,14 +790,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/TimeFunction
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
-  TimeFunctionLogsSubscriptionFilterCSLS:
+  PIIRedactedTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref TimeFunctionLogGroup
+      LogGroupName: !Ref PIIRedactedTimeFunctionLogGroup
 
   TimeFunctionEventErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -971,14 +901,14 @@ Resources:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PublicNinoCheckApi}-public-AccessLogs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
-  PublicNinoCheckApiLogsSubscriptionFilterCSLS:
+  PIIRedactedPublicNinoCheckApiLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref PublicNinoCheckApiAccessLogGroup
+      LogGroupName: !Ref PIIRedactedPublicNinoCheckApiAccessLogGroup
 
   PublicNinoCheckApiFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -1072,14 +1002,14 @@ Resources:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PrivateNinoCheckApi}-private-AccessLogs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
 
-  PrivateNinoCheckApiLogsSubscriptionFilterCSLS:
+  PIIRedactedPrivateNinoCheckApiLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref PrivateNinoCheckApiAccessLogGroup
+      LogGroupName: !Ref PIIRedactedPrivateNinoCheckApiAccessLogGroup
 
   PrivateNinoCheckApiFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -1317,17 +1247,15 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoCheck-state-machine-logs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
-      DataProtectionPolicy:
-        <<: *DataProtectionPolicy
 
-  NinoCheckStateMachineLogsSubscriptionFilterCSLS:
+  PIIRedactedNinoCheckStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref NinoCheckStateMachineLogGroup
+      LogGroupName: !Ref PIIRedactedNinoCheckStateMachineLogGroup
 
   NinoCheckStateMachineFailedMetric:
     Type: AWS::Logs::MetricFilter
@@ -1411,17 +1339,15 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-Abandon-state-machine-logs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
-      DataProtectionPolicy:
-        <<: *DataProtectionPolicy
 
-  AbandonStateMachineLogsSubscriptionFilterCSLS:
+  PIIRedactedAbandonStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref AbandonStateMachineLogGroup
+      LogGroupName: !Ref PIIRedactedAbandonStateMachineLogGroup
 
   AbandonStateMachineFailedMetric:
     Type: AWS::Logs::MetricFilter
@@ -1536,17 +1462,15 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoIssueCredential-state-machine-logs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
-      DataProtectionPolicy:
-        <<: *DataProtectionPolicy
 
-  NinoIssueCredentialLogsSubscriptionFilterCSLS:
+  PIIRedactedNinoIssueCredentialLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref NinoIssueCredentialLogGroup
+      LogGroupName: !Ref PIIRedactedNinoIssueCredentialLogGroup
 
   NinoIssueCredentialStateMachineFailedMetric:
     Type: AWS::Logs::MetricFilter
@@ -1586,17 +1510,15 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-CheckSession-state-machine-logs"
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
-      DataProtectionPolicy:
-        <<: *DataProtectionPolicy
 
-  CheckSessionStateMachineLogsSubscriptionFilterCSLS:
+  PIIRedactedCheckSessionStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref CheckSessionStateMachineLogGroup
+      LogGroupName: !Ref PIIRedactedCheckSessionStateMachineLogGroup
 
   CheckHmrcEventBus:
     Type: AWS::Events::EventBus
@@ -1965,17 +1887,15 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-AuditEvent-state-machine-logs
       RetentionInDays: !If [IsProdEnvironment, 30, 7]
-      DataProtectionPolicy:
-        <<: *DataProtectionPolicy
 
-  AuditEventStateMachineLogsSubscriptionFilterCSLS:
+  PIIRedactedAuditEventStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevLikeEnvironment
     Properties:
       DestinationArn:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
-      LogGroupName: !Ref AuditEventStateMachineLogGroup
+      LogGroupName: !Ref PIIRedactedAuditEventStateMachineLogGroup
 
   ####################################################################
   #                                                                  #
@@ -2091,6 +2011,326 @@ Resources:
         - MetricValue: 1
           MetricName: AbandonedAuthMetric
           MetricNamespace: !Ref CriIdentifier
+
+  ####################################################################
+  #                                                                  #
+  # Log Groups for Slunk (PII Redacted)                              #
+  #                                                                  #
+  ####################################################################
+  PIIRedactedEpochTimeFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/EpochTimeFunction-pii-redacted
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedCiMappingFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CiMappingFunction-pii-redacted
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedCreateAuthCodeFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CreateAuthCodeFunction-pii-redacted
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedCredentialSubjectFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CredentialSubjectFunction-pii-redacted
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedCurrentTimeFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CurrentTimeFunction-pii-redacted
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedJwtSignerFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/JwtSignerFunction-pii-redacted
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedOTGFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/OTGFunction-pii-redacted
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedMatchingFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction-pii-redacted
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedSsmParametersFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/SsmParametersFunction-pii-redacted
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedTimeFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/TimeFunction-pii-redacted
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedPublicNinoCheckApiAccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PublicNinoCheckApi}-public-AccessLogs-pii-redacted"
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedPrivateNinoCheckApiAccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PrivateNinoCheckApi}-private-AccessLogs-pii-redacted"
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedNinoCheckStateMachineLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoCheck-state-machine-logs-pii-redacted"
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedAbandonStateMachineLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-Abandon-state-machine-logs-pii-redacted"
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedNinoIssueCredentialLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoIssueCredential-state-machine-logs-pii-redacted"
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedCheckSessionStateMachineLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-CheckSession-state-machine-logs-pii-redacted"
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactedAuditEventStateMachineLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-AuditEvent-state-machine-logs-pii-redacted
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  ####################################################################
+  #                                                                  #
+  # PIIRedactFunction SubscriptionFilter                             #
+  #                                                                  #
+  ####################################################################
+  InvokeLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AWSXrayFullAccess
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaRole
+
+  PIIRedactFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Sourcemap: true
+    Properties:
+      Handler: lambdas/pii-redact/src/pii-redact-handler.lambdaHandler
+      LoggingConfig:
+        LogGroup: !Sub /aws/lambda/${AWS::StackName}/PIIRedactFunction
+      CodeSigningConfigArn:
+        !If [ EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
+      Policies:
+        - Statement:
+            Effect: Allow
+            Action: logs:*
+            Resource: "*"
+        - Statement:
+            Effect: Allow
+            Action: lambda:*
+            Resource: "*"
+
+  PIIRedactFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/PIIRedactFunction
+      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+
+  PIIRedactFunctionCloudWatchPermissions:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt PIIRedactFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: !Join [ ".", [ "logs", !Ref "AWS::Region", "amazonaws.com" ] ]
+      SourceAccount: !Ref AWS::AccountId
+
+  EpochTimeFunctionLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref EpochTimeFunctionLogGroup
+
+  CiMappingFunctionLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref CiMappingFunctionLogGroup
+
+  CreateAuthCodeFunctionLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref CreateAuthCodeFunctionLogGroup
+
+  CredentialSubjectFunctionLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref CredentialSubjectFunctionLogGroup
+
+  CurrentTimeFunctionLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref CurrentTimeFunctionLogGroup
+
+  JwtSignerFunctionLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref JwtSignerFunctionLogGroup
+
+  OTGFunctionLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref OTGFunctionLogGroup
+
+  MatchingFunctionLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref MatchingFunctionLogGroup
+
+  SsmParametersFunctionLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref SsmParametersFunctionLogGroup
+
+  TimeFunctionLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref TimeFunctionLogGroup
+
+  PublicNinoCheckApiLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref PublicNinoCheckApiAccessLogGroup
+
+  PrivateNinoCheckApiLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref PrivateNinoCheckApiAccessLogGroup
+
+  NinoCheckStateMachineLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref NinoCheckStateMachineLogGroup
+
+  AbandonStateMachineLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref AbandonStateMachineLogGroup
+
+  NinoIssueCredentialLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref NinoIssueCredentialLogGroup
+
+  CheckSessionStateMachineLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref CheckSessionStateMachineLogGroup
+
+  AuditEventStateMachineLogsSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: PIIRedactFunctionCloudWatchPermissions
+    Properties:
+      FilterName: "PII Redaction"
+      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      FilterPattern: ""
+      LogGroupName: !Ref AuditEventStateMachineLogGroup
 
 ##################################################################
 #                                                                  #

--- a/lambdas/pii-redact/jest.config.ts
+++ b/lambdas/pii-redact/jest.config.ts
@@ -1,0 +1,7 @@
+import type { Config } from "jest";
+import baseConfig from "../../jest.config.base";
+
+export default {
+  ...baseConfig,
+  displayName: "lambdas/pii-redact",
+} satisfies Config;

--- a/lambdas/pii-redact/package.json
+++ b/lambdas/pii-redact/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "pii-redact",
+  "description": "",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "unit": "jest --silent",
+    "test": "npm run unit --",
+    "test:coverage": "npm run unit -- --coverage",
+    "deploy": "../../deploy.sh",
+    "compile": "tsc"
+  },
+  "dependencies": {}
+}

--- a/lambdas/pii-redact/src/pii-redact-handler.ts
+++ b/lambdas/pii-redact/src/pii-redact-handler.ts
@@ -1,0 +1,114 @@
+import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { Logger } from "@aws-lambda-powertools/logger";
+import * as zlib from 'zlib';
+import { CloudWatchLogsDecodedData } from "aws-lambda";
+import { CloudWatchLogsEvent,  } from "aws-lambda/trigger/cloudwatch-logs";
+import {
+  CloudWatchLogsClient,
+  PutLogEventsCommand,
+  PutLogEventsCommandOutput,
+  CreateLogStreamCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+const logger = new Logger();
+const cloudwatch = new CloudWatchLogsClient();
+
+const ninoRegex = /\\"nino\\":\s*\\"([^"]*)\\"/g;
+const ipAddressRegex = /\\"ip_address\\":\s*\\"([^"]*)\\"/g;
+const userIdRegex = /\\"user_id\\":\s*\\"([^"]*)\\"/g;
+const firstNameRegex = /\\"firstName\\":\s*\\"([^"]*)\\"/g;
+const lastNameRegex = /\\"lastName\\":\s*\\"([^"]*)\\"/g;
+const birthDates = /\\"birthDates\\"\s*:\s*\{\s*\\"L\\"\s*:\s*\[\s*\{\s*\\"M\\"\s*:\s*\{\s*\\"value\\"\s*:\s*\{\s*\\"S\\"\s*:\s*\\"(\d{4}-\d{2}-\d{2})\\"\s*}\s*}\s*}\s*]\s*}/g;
+const subjectRegex = /\\"subject\\":\s*\\"([^"]*)\\"/g;
+const tokenRegex = /\\"token\\":\s*\\"([^"]*)\\"/g;
+const dateOfBirthRegex = /\\"dateOfBirth\\":\s*\\"([^"]*)\\"/g;
+
+const buildingNameRegex = /\\"buildingName\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
+const addressLocalityRegex = /\\"addressLocality\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
+const buildingNumberRegex = /\\"buildingNumber\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
+const postalCodeRegex = /\\"postalCode\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
+const streetNameRegex = /\\"streetName\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
+
+const givenNameRegex = /\\"type\\":{\\"S\\":\\"GivenName\\"},\s*\\"value\\":{\\"S\\":\\"([^"]*)\\"/g;
+const familyNameRegex = /\\"type\\":{\\"S\\":\\"FamilyName\\"},\s*\\"value\\":{\\"S\\":\\"([^"]*)\\"/g;
+
+export class PiiRedactHandler implements LambdaInterface {
+  public async handler(
+    event: CloudWatchLogsEvent,
+    _context: unknown
+  ): Promise<any> {
+    try {
+      logger.info("Received " + JSON.stringify(event));
+
+      const logDataBase64 = event.awslogs.data;
+      const logDataBuffer = Buffer.from(logDataBase64, 'base64');
+      const decompressedData = zlib.unzipSync(logDataBuffer).toString('utf-8');
+      const logEvents: CloudWatchLogsDecodedData = JSON.parse(decompressedData);
+      const piiRedactLogGroup = logEvents.logGroup + "-pii-redacted"
+      const logStream = logEvents.logStream;
+
+      try {
+        await cloudwatch.send(new CreateLogStreamCommand({
+          logGroupName: piiRedactLogGroup,
+          logStreamName: logStream
+        }));
+      } catch (error: any) {
+        const message = error instanceof Error ? error.message : String(error);
+        if(!message.includes("The specified log stream already exists")) {
+          throw error;
+        }
+        logger.info(logStream + " already exists")
+      }
+
+      for (const logEvent of logEvents.logEvents) {
+        logEvent.message = this.redactPII(logEvent.message);
+      }
+
+      logger.info("Putting redacted logs into " + piiRedactLogGroup);
+
+      try {
+        const response: PutLogEventsCommandOutput = await cloudwatch.send(new PutLogEventsCommand({
+          logGroupName: piiRedactLogGroup,
+          logStreamName: logStream,
+          logEvents: logEvents.logEvents.map(event => ({
+            message: event.message,
+            timestamp: event.timestamp
+          }))
+        }));
+        logger.info(JSON.stringify(response));
+      } catch (error) {
+        logger.error(`Error putting log events into ${piiRedactLogGroup}: ${error}`);
+        throw error;
+      }
+
+      return {};
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Error in PiiRedactHandler: ${message}`);
+      throw error;
+    }
+  }
+
+  public redactPII(message: string): string {
+    return message
+      .replaceAll(userIdRegex, '"user_id": "***"')
+      .replaceAll(dateOfBirthRegex, '"dateOfBirth": "***"')
+      .replaceAll(firstNameRegex, '"firstName": "***"')
+      .replaceAll(lastNameRegex, '"lastName": "***"')
+      .replaceAll(birthDates, '"birthDates": "***"')
+      .replaceAll(buildingNameRegex, '"buildingName": { "S": "***"')
+      .replaceAll(addressLocalityRegex, '"addressLocality": { "S": "***"')
+      .replaceAll(buildingNumberRegex, '"buildingNumber": { "S": "***"')
+      .replaceAll(postalCodeRegex, '"postalCode": { "S": "***"')
+      .replaceAll(streetNameRegex, '"streetName": { "S": "***"')
+      .replaceAll(subjectRegex, '"subject": "***"')
+      .replaceAll(givenNameRegex, '"type": { "S": "GivenName" }, "value": { "S": "***"')
+      .replaceAll(familyNameRegex, '"type": { "S": "FamilyName" }, "value": { "S": "***"')
+      .replaceAll(ninoRegex, '"nino": "***"')
+      .replaceAll(ipAddressRegex, '"ip_address": "***"')
+      .replaceAll(tokenRegex, '"token": "***"');
+  }
+}
+
+const handlerClass = new PiiRedactHandler();
+export const lambdaHandler = handlerClass.handler.bind(handlerClass);

--- a/lambdas/pii-redact/src/pii-redact-handler.ts
+++ b/lambdas/pii-redact/src/pii-redact-handler.ts
@@ -9,36 +9,10 @@ import {
   PutLogEventsCommandOutput,
   CreateLogStreamCommand,
 } from "@aws-sdk/client-cloudwatch-logs";
+import { redactPII } from "./pii-redactor";
 
 const logger = new Logger();
 const cloudwatch = new CloudWatchLogsClient();
-
-const ninoRegex = /\\"nino\\":\s*\\"([^"]*)\\"/g;
-const ipAddressRegex = /\\"ip_address\\":\s*\\"([^"]*)\\"/g;
-const userIdRegex = /\\"user_id\\":\s*\\"([^"]*)\\"/g;
-const firstNameRegex = /\\"firstName\\":\s*\\"([^"]*)\\"/g;
-const lastNameRegex = /\\"lastName\\":\s*\\"([^"]*)\\"/g;
-const birthDates =
-  /\\"birthDates\\"\s*:\s*\{\s*\\"L\\"\s*:\s*\[\s*\{\s*\\"M\\"\s*:\s*\{\s*\\"value\\"\s*:\s*\{\s*\\"S\\"\s*:\s*\\"(\d{4}-\d{2}-\d{2})\\"\s*}\s*}\s*}\s*]\s*}/g;
-const subjectRegex = /\\"subject\\":\s*\\"([^"]*)\\"/g;
-const tokenRegex = /\\"token\\":\s*\\"([^"]*)\\"/g;
-const dateOfBirthRegex = /\\"dateOfBirth\\":\s*\\"([^"]*)\\"/g;
-
-const buildingNameRegex =
-  /\\"buildingName\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
-const addressLocalityRegex =
-  /\\"addressLocality\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
-const buildingNumberRegex =
-  /\\"buildingNumber\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
-const postalCodeRegex =
-  /\\"postalCode\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
-const streetNameRegex =
-  /\\"streetName\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
-
-const givenNameRegex =
-  /\\"type\\":{\\"S\\":\\"GivenName\\"},\s*\\"value\\":{\\"S\\":\\"([^"]*)\\"/g;
-const familyNameRegex =
-  /\\"type\\":{\\"S\\":\\"FamilyName\\"},\s*\\"value\\":{\\"S\\":\\"([^"]*)\\"/g;
 
 export class PiiRedactHandler implements LambdaInterface {
   public async handler(
@@ -71,7 +45,7 @@ export class PiiRedactHandler implements LambdaInterface {
       }
 
       for (const logEvent of logEvents.logEvents) {
-        logEvent.message = this.redactPII(logEvent.message);
+        logEvent.message = redactPII(logEvent.message);
       }
 
       logger.info("Putting redacted logs into " + piiRedactLogGroup);
@@ -101,32 +75,6 @@ export class PiiRedactHandler implements LambdaInterface {
       logger.error(`Error in PiiRedactHandler: ${message}`);
       throw error;
     }
-  }
-
-  public redactPII(message: string): string {
-    return message
-      .replaceAll(userIdRegex, '"user_id": "***"')
-      .replaceAll(dateOfBirthRegex, '"dateOfBirth": "***"')
-      .replaceAll(firstNameRegex, '"firstName": "***"')
-      .replaceAll(lastNameRegex, '"lastName": "***"')
-      .replaceAll(birthDates, '"birthDates": "***"')
-      .replaceAll(buildingNameRegex, '"buildingName": { "S": "***"')
-      .replaceAll(addressLocalityRegex, '"addressLocality": { "S": "***"')
-      .replaceAll(buildingNumberRegex, '"buildingNumber": { "S": "***"')
-      .replaceAll(postalCodeRegex, '"postalCode": { "S": "***"')
-      .replaceAll(streetNameRegex, '"streetName": { "S": "***"')
-      .replaceAll(subjectRegex, '"subject": "***"')
-      .replaceAll(
-        givenNameRegex,
-        '"type": { "S": "GivenName" }, "value": { "S": "***"'
-      )
-      .replaceAll(
-        familyNameRegex,
-        '"type": { "S": "FamilyName" }, "value": { "S": "***"'
-      )
-      .replaceAll(ninoRegex, '"nino": "***"')
-      .replaceAll(ipAddressRegex, '"ip_address": "***"')
-      .replaceAll(tokenRegex, '"token": "***"');
   }
 }
 

--- a/lambdas/pii-redact/src/pii-redactor.ts
+++ b/lambdas/pii-redact/src/pii-redactor.ts
@@ -4,7 +4,7 @@ const userIdRegex = /\\"user_id\\":\s*\\"([^"]*)\\"/g;
 const firstNameRegex = /\\"firstName\\":\s*\\"([^"]*)\\"/g;
 const lastNameRegex = /\\"lastName\\":\s*\\"([^"]*)\\"/g;
 const birthDates =
-  /\\"birthDates\\"\s*:\s*\{\s*\\"L\\"\s*:\s*\[\s*\{\s*\\"M\\"\s*:\s*\{\s*\\"value\\"\s*:\s*\{\s*\\"S\\"\s*:\s*\\"(\d{4}-\d{2}-\d{2})\\"\s*}\s*}\s*}\s*]\s*}/g;
+  /\\"birthDates\\"\s*:\s*\{\s*\\"L\\"\s*:\s*\[\s*\{\s*\\"M\\"\s*:\s*\{\s*\\"value\\"\s*:\s*\{\s*\\"S\\"\s*:\s*\\"(\d{4}-\d{2}-\d{2})\\".*]\s*}/g;
 const subjectRegex = /\\"subject\\":\s*\\"([^"]*)\\"/g;
 const tokenRegex = /\\"token\\":\s*\\"([^"]*)\\"/g;
 const dateOfBirthRegex = /\\"dateOfBirth\\":\s*\\"([^"]*)\\"/g;

--- a/lambdas/pii-redact/src/pii-redactor.ts
+++ b/lambdas/pii-redact/src/pii-redactor.ts
@@ -1,0 +1,52 @@
+const ninoRegex = /\\"nino\\":\s*\\"([^"]*)\\"/g;
+const ipAddressRegex = /\\"ip_address\\":\s*\\"([^"]*)\\"/g;
+const userIdRegex = /\\"user_id\\":\s*\\"([^"]*)\\"/g;
+const firstNameRegex = /\\"firstName\\":\s*\\"([^"]*)\\"/g;
+const lastNameRegex = /\\"lastName\\":\s*\\"([^"]*)\\"/g;
+const birthDates =
+  /\\"birthDates\\"\s*:\s*\{\s*\\"L\\"\s*:\s*\[\s*\{\s*\\"M\\"\s*:\s*\{\s*\\"value\\"\s*:\s*\{\s*\\"S\\"\s*:\s*\\"(\d{4}-\d{2}-\d{2})\\"\s*}\s*}\s*}\s*]\s*}/g;
+const subjectRegex = /\\"subject\\":\s*\\"([^"]*)\\"/g;
+const tokenRegex = /\\"token\\":\s*\\"([^"]*)\\"/g;
+const dateOfBirthRegex = /\\"dateOfBirth\\":\s*\\"([^"]*)\\"/g;
+
+const buildingNameRegex =
+  /\\"buildingName\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
+const addressLocalityRegex =
+  /\\"addressLocality\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
+const buildingNumberRegex =
+  /\\"buildingNumber\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
+const postalCodeRegex =
+  /\\"postalCode\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
+const streetNameRegex =
+  /\\"streetName\\"\s*:\s*{\s*\\"S\\"\s*:\s*\\"([^"]*)\\"/g;
+
+const givenNameRegex =
+  /\\"type\\":{\\"S\\":\\"GivenName\\"},\s*\\"value\\":{\\"S\\":\\"([^"]*)\\"/g;
+const familyNameRegex =
+  /\\"type\\":{\\"S\\":\\"FamilyName\\"},\s*\\"value\\":{\\"S\\":\\"([^"]*)\\"/g;
+
+export const redactPII = (message: string) => {
+  return message
+    .replaceAll(userIdRegex, '"user_id": "***"')
+    .replaceAll(dateOfBirthRegex, '"dateOfBirth": "***"')
+    .replaceAll(firstNameRegex, '"firstName": "***"')
+    .replaceAll(lastNameRegex, '"lastName": "***"')
+    .replaceAll(birthDates, '"birthDates": "***"')
+    .replaceAll(buildingNameRegex, '"buildingName": { "S": "***"')
+    .replaceAll(addressLocalityRegex, '"addressLocality": { "S": "***"')
+    .replaceAll(buildingNumberRegex, '"buildingNumber": { "S": "***"')
+    .replaceAll(postalCodeRegex, '"postalCode": { "S": "***"')
+    .replaceAll(streetNameRegex, '"streetName": { "S": "***"')
+    .replaceAll(subjectRegex, '"subject": "***"')
+    .replaceAll(
+      givenNameRegex,
+      '"type": { "S": "GivenName" }, "value": { "S": "***"'
+    )
+    .replaceAll(
+      familyNameRegex,
+      '"type": { "S": "FamilyName" }, "value": { "S": "***"'
+    )
+    .replaceAll(ninoRegex, '"nino": "***"')
+    .replaceAll(ipAddressRegex, '"ip_address": "***"')
+    .replaceAll(tokenRegex, '"token": "***"');
+};

--- a/lambdas/pii-redact/tests/pii-redact-handler.test.ts
+++ b/lambdas/pii-redact/tests/pii-redact-handler.test.ts
@@ -1,0 +1,102 @@
+import { PiiRedactHandler } from "../src/pii-redact-handler";
+import * as zlib from "node:zlib";
+
+let shouldMockThrowError = false;
+
+jest.mock("@aws-sdk/client-cloudwatch-logs", () => {
+  const actual = jest.requireActual("@aws-sdk/client-cloudwatch-logs");
+  return {
+    ...actual,
+    CloudWatchLogsClient: jest.fn(() => ({
+      send: jest.fn().mockImplementation((command) => {
+        if (
+          shouldMockThrowError &&
+          command instanceof actual.CreateLogStreamCommand
+        ) {
+          throw new Error("Error creating log stream");
+        }
+        return {
+          message: "",
+        };
+      }),
+    })),
+  };
+});
+
+describe("pii-redact-handler", () => {
+  async function encode(payload: string) {
+    return await new Promise<string>((resolve, reject) => {
+      zlib.deflate(payload, (_, compressedData) => {
+        if (compressedData) {
+          const compressedString =
+            Buffer.from(compressedData).toString("binary");
+          const base64CompressedEvent = Buffer.from(
+            compressedString,
+            "binary"
+          ).toString("base64");
+          resolve(base64CompressedEvent);
+        } else {
+          reject(new Error("Failed to compress data"));
+        }
+      });
+    });
+  }
+
+  it("should not fail when running the handler", async () => {
+    const piiData = {
+      owner: undefined,
+      logGroup: "dummy-log-group",
+      logStream: "dummy-log-stream",
+      subscriptionFilters: undefined,
+      messageType: undefined,
+      logEvents: [
+        {
+          id: undefined,
+          timestamp: undefined,
+          message: "test",
+          extractedFields: undefined,
+        },
+      ],
+    };
+    const compressedData = await encode(JSON.stringify(piiData));
+    const event = {
+      awslogs: {
+        data: compressedData,
+      },
+    };
+    const handler = new PiiRedactHandler();
+    const result = await handler.handler(event, {});
+    expect(result).toStrictEqual({});
+  });
+
+  it("should throw when an error occurs creating a log stream", async () => {
+    shouldMockThrowError = true;
+    const piiData = {
+      owner: undefined,
+      logGroup: "dummy-log-group",
+      logStream: "dummy-log-stream",
+      subscriptionFilters: undefined,
+      messageType: undefined,
+      logEvents: [
+        {
+          id: undefined,
+          timestamp: undefined,
+          message: "test",
+          extractedFields: undefined,
+        },
+      ],
+    };
+    const compressedData = await encode(JSON.stringify(piiData));
+    const event = {
+      awslogs: {
+        data: compressedData,
+      },
+    };
+    const handler = new PiiRedactHandler();
+
+    await expect(handler.handler(event, {})).rejects.toThrow(
+      new Error("Error creating log stream")
+    );
+    shouldMockThrowError = false;
+  });
+});

--- a/lambdas/pii-redact/tests/redact-pii.test.ts
+++ b/lambdas/pii-redact/tests/redact-pii.test.ts
@@ -1,0 +1,99 @@
+import { redactPII } from "../src/pii-redactor";
+
+describe("redact-pii", () => {
+  it("should redact nino field", async () => {
+    const ninoRedacted = '{"nino": "***"}';
+    const nino = '{\\"nino\\":\\"AA000003D\\"}';
+    expect(redactPII(nino)).toStrictEqual(ninoRedacted);
+  });
+
+  it("should redact ip_address field", async () => {
+    const ipRedacted = '{"ip_address": "***"}';
+    const ipSingle = '{\\"ip_address\\":\\"35.179.16.44\\"}';
+    expect(redactPII(ipSingle)).toStrictEqual(ipRedacted);
+    const ipMulti = '{\\"ip_address\\":\\"35.179.16.44, 10.0.12.199\\"}';
+    expect(redactPII(ipMulti)).toStrictEqual(ipRedacted);
+  });
+
+  it("should redact userId field", async () => {
+    const userIdRedacted = '{"user_id": "***"}';
+    const userId =
+      '{\\"user_id\\":\\"urn:fdc:gov.uk:2022:6fe97b75-05a3-43e1-aa82-bb6140eaee3a\\"}';
+    expect(redactPII(userId)).toStrictEqual(userIdRedacted);
+  });
+
+  it("should redact firstName field", async () => {
+    const firstNameRedacted = '{"firstName": "***"}';
+    const firstName = '{\\"firstName\\":\\"Joe\\"}';
+    expect(redactPII(firstName)).toStrictEqual(firstNameRedacted);
+  });
+
+  it("should redact lastName field", async () => {
+    const lastNameRedacted = '{"lastName": "***"}';
+    const lastName = '{\\"lastName\\":\\"Bloggs\\"}';
+    expect(redactPII(lastName)).toStrictEqual(lastNameRedacted);
+  });
+
+  it("should redact birthDates field", async () => {
+    const birthDatesRedacted = '{"birthDates": "***"}';
+    const birthDates =
+      '{\\"birthDates\\":{\\"L\\":[{\\"M\\":{\\"value\\":{\\"S\\":\\"1970-01-01\\"}}}]}}';
+    expect(redactPII(birthDates)).toStrictEqual(birthDatesRedacted);
+  });
+
+  it("should redact subject field", async () => {
+    const subjectRedacted = '{"subject": "***"}';
+    const subject = '{\\"subject\\":\\"subject\\"}';
+    expect(redactPII(subject)).toStrictEqual(subjectRedacted);
+  });
+
+  it("should redact token field", async () => {
+    const tokenRedacted = '{"token": "***"}';
+    const token = '{\\"token\\":\\"goodToken\\"}';
+    expect(redactPII(token)).toStrictEqual(tokenRedacted);
+  });
+
+  it("should redact dateOfBirth field", async () => {
+    const dateOfBirthRedacted = '{"dateOfBirth": "***"}';
+    const dateOfBirth = '{\\"dateOfBirth\\":\\"1970-01-01\\"}';
+    expect(redactPII(dateOfBirth)).toStrictEqual(dateOfBirthRedacted);
+  });
+
+  it("should redact buildingName field", async () => {
+    const buildingNameRedacted = '{"buildingName": { "S": "***"}}';
+    const buildingName = '{\\"buildingName\\":{\\"S\\":\\"GDS\\"}}';
+    expect(redactPII(buildingName)).toStrictEqual(buildingNameRedacted);
+  });
+
+  it("should redact addressLocality field", async () => {
+    const addressLocalityRedacted = '{"addressLocality": { "S": "***"}}';
+    const addressLocality = '{\\"addressLocality\\":{\\"S\\":\\"Test\\"}}';
+    expect(redactPII(addressLocality)).toStrictEqual(addressLocalityRedacted);
+  });
+
+  it("should redact buildingNumber field", async () => {
+    const buildingNumberRedacted = '{"buildingNumber": { "S": "***"}}';
+    const buildingNumber = '{\\"buildingNumber\\":{\\"S\\":\\"1\\"}}';
+    expect(redactPII(buildingNumber)).toStrictEqual(buildingNumberRedacted);
+  });
+
+  it("should redact postalCode field", async () => {
+    const postalCodeRedacted = '{"postalCode": { "S": "***"}}';
+    const postalCode = '{\\"postalCode\\":{\\"S\\":\\"LU3\\"}}';
+    expect(redactPII(postalCode)).toStrictEqual(postalCodeRedacted);
+  });
+
+  it("should redact streetName field", async () => {
+    const streetNameRedacted = '{"streetName": { "S": "***"}}';
+    const streetName = '{\\"streetName\\":{\\"S\\":\\"whitechapel\\"}}';
+    expect(redactPII(streetName)).toStrictEqual(streetNameRedacted);
+  });
+
+  it("should redact names field", async () => {
+    const namesRedacted =
+      '{\\"names\\":{\\"L\\":[{\\"M\\":{\\"nameParts\\":{\\"L\\":[{\\"M\\":{"type": { "S": "GivenName" }, "value": { "S": "***"}}},{\\"M\\":{"type": { "S": "FamilyName" }, "value": { "S": "***"}}}]}}}]}';
+    const names =
+      '{\\"names\\":{\\"L\\":[{\\"M\\":{\\"nameParts\\":{\\"L\\":[{\\"M\\":{\\"type\\":{\\"S\\":\\"GivenName\\"},\\"value\\":{\\"S\\":\\"Jim\\"}}},{\\"M\\":{\\"type\\":{\\"S\\":\\"FamilyName\\"},\\"value\\":{\\"S\\":\\"Ferguson\\"}}}]}}}]}';
+    expect(redactPII(names)).toStrictEqual(namesRedacted);
+  });
+});

--- a/lambdas/pii-redact/tests/redact-pii.test.ts
+++ b/lambdas/pii-redact/tests/redact-pii.test.ts
@@ -96,4 +96,24 @@ describe("redact-pii", () => {
       '{\\"names\\":{\\"L\\":[{\\"M\\":{\\"nameParts\\":{\\"L\\":[{\\"M\\":{\\"type\\":{\\"S\\":\\"GivenName\\"},\\"value\\":{\\"S\\":\\"Jim\\"}}},{\\"M\\":{\\"type\\":{\\"S\\":\\"FamilyName\\"},\\"value\\":{\\"S\\":\\"Ferguson\\"}}}]}}}]}';
     expect(redactPII(names)).toStrictEqual(namesRedacted);
   });
+
+  it("should not redact govuk_signin_journey_id field", async () => {
+    const govSigninJourneyID =
+      '{\\"userAuditInfo\\":{\\"govuk_signin_journey_id\\":\\"02d56902-96bb-4669-ba18-be6c2b002f36\\"}';
+    expect(redactPII(govSigninJourneyID)).toStrictEqual(govSigninJourneyID);
+  });
+
+  it("should not redact sessionCheck field", async () => {
+    const sessionCheck =
+      '{"\\sessionCheck\\":{\\"status\\":\\"SESSION_OK\\",\\"clientId\\":\\"ipv-core-stub-aws-prod\\",\\"userAuditInfo\\":{}}}';
+    expect(redactPII(sessionCheck)).toStrictEqual(sessionCheck);
+  });
+
+  it("should not redact date fields", async () => {
+    const dateWithBrackets = '\\"Date\\":[\\"Sat, 11 May 2024 11:24:11 GMT\\"]';
+    expect(redactPII(dateWithBrackets)).toStrictEqual(dateWithBrackets);
+    const dateWithoutBrackets =
+      '\\"Date\\":\\"Sat, 11 May 2024 11:24:24 GMT\\",';
+    expect(redactPII(dateWithoutBrackets)).toStrictEqual(dateWithoutBrackets);
+  });
 });

--- a/lambdas/pii-redact/tsconfig.json
+++ b/lambdas/pii-redact/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "target": "es2022",
+    "strict": true,
+    "preserveConstEnums": true,
+    "sourceMap": true,
+    "module": "es2022",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["jest", "node", "aws-lambda"],
+    "outDir": "./build/",
+    "noImplicitAny": true
+  },
+  "exclude": ["node_modules", "build", "coverage"],
+  "include": ["src", "tests"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@aws-lambda-powertools/metrics": "1.14.2",
         "@aws-lambda-powertools/parameters": "1.17.0",
         "@aws-lambda-powertools/tracer": "1.14.2",
+        "@aws-sdk/client-cloudwatch-logs": "3.574.0",
         "@aws-sdk/client-ssm": "3.363.0",
         "esbuild": "0.19.5",
         "jose": "^5.2.2"
@@ -565,6 +566,7 @@
     },
     "lambdas/matching": {},
     "lambdas/otg-api": {},
+    "lambdas/pii-redact": {},
     "lambdas/ssm-parameters": {},
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -1242,6 +1244,718 @@
         "aws-crt": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs": {
+      "version": "3.574.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.574.0.tgz",
+      "integrity": "sha512-zWiFT75OkDinxgCxfoHzE4ZPu6rlE4MT6gxi8EgO1hrscJvdxW+2uZJ+e6KZqaN/WGs/sbPQqsWPYYpHLMrNOg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.574.0",
+        "@aws-sdk/client-sts": "3.574.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/eventstream-serde-browser": "^2.2.0",
+        "@smithy/eventstream-serde-config-resolver": "^2.2.0",
+        "@smithy/eventstream-serde-node": "^2.2.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/client-sso": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.572.0.tgz",
+      "integrity": "sha512-S+xhScao5MD79AkrcHmFpEDk+CgoiuB/31WFcTcnrTio5TOUONAaT0QyscOIwRp7BZ7Aez7TBM+loTteJ+TQvg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.574.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.574.0.tgz",
+      "integrity": "sha512-WcR8AnFhx7bqhYwfSl3OrF0Pu0LfHGgSOnmmORHqRF7ykguE09M/WUlCCjTGmZjJZ1we3uF5Xg8Jg12eiD+bmw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.574.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/client-sts": {
+      "version": "3.574.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.574.0.tgz",
+      "integrity": "sha512-WNDSG9nipap/L1gGDkCQvU2u413HmVxMJKr41lBCibioz42Z4i6XkCr1etYwIjuVfGF6QPrsEsYLqRwlAC/BQg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.574.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/core": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.572.0.tgz",
+      "integrity": "sha512-DBmf94qfN0dfaLl5EnNcq6TakWfOtVXYifHoTbX+VBwESj3rlY4W+W4mAnvBgAqDjlLFy7bBljmx+vnjnV73lg==",
+      "dependencies": {
+        "@smithy/core": "^1.4.2",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.568.0.tgz",
+      "integrity": "sha512-MVTQoZwPnP1Ev5A7LG+KzeU6sCB8BcGkZeDT1z1V5Wt7GPq0MgFQTSSjhImnB9jqRSZkl1079Bt3PbO6lfIS8g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.568.0.tgz",
+      "integrity": "sha512-gL0NlyI2eW17hnCrh45hZV+qjtBquB+Bckiip9R6DIVRKqYcoILyiFhuOgf2bXeF23gVh6j18pvUvIoTaFWs5w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.572.0.tgz",
+      "integrity": "sha512-anlYZnpmVkfp9Gan+LcEkQvmRf/m0KcbR11th8sBEyI5lxMaHKXhnAtC/hEGT7e3L6rgNOrFYTPuSvllITD/Pg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-http": "3.568.0",
+        "@aws-sdk/credential-provider-ini": "3.572.0",
+        "@aws-sdk/credential-provider-process": "3.572.0",
+        "@aws-sdk/credential-provider-sso": "3.572.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.572.0.tgz",
+      "integrity": "sha512-S6C/S6xYesDakEuzYvlY1DMMKLtKQxdbbygq3hfeG2R0jUt9KpRLsQXK8qrBuVCKa3WcnjN/30hp4g/iUWFU/w==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/client-sts": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.572.0.tgz",
+      "integrity": "sha512-jCQuH2qkbWoSY4wckLSfzf3OPh7zc7ZckEbIGGVUQar/JVff6EIbpQ+uNG29DDEOpdPPd8rrJsVuUlA/nvJdXA==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.572.0.tgz",
+      "integrity": "sha512-05KzbAp77fEiQXqMeodXeMbT83FOqSyBrfSEMz6U8uBXeJCy8zPUjN3acqcbG55/HNJHUvg1cftqzy+fUz71gA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-process": "3.572.0",
+        "@aws-sdk/credential-provider-sso": "3.572.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "3.572.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.572.0.tgz",
+      "integrity": "sha512-hXcOytf0BadSm/MMy7MV8mmY0+Jv3mkavsHNBx0R82hw5ollD0I3JyOAaCtdUpztF0I72F8K+q8SpJQZ+EwArw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.572.0.tgz",
+      "integrity": "sha512-iIlnpJiDXFp3XC4hJNSiNurnU24mr3iLB3HoNa9efr944bo6XBl9FQdk3NssIkqzSmgyoB2CEUx/daBHz4XSow==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.572.0",
+        "@aws-sdk/token-providers": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.572.0.tgz",
+      "integrity": "sha512-S6C/S6xYesDakEuzYvlY1DMMKLtKQxdbbygq3hfeG2R0jUt9KpRLsQXK8qrBuVCKa3WcnjN/30hp4g/iUWFU/w==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/client-sts": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.572.0.tgz",
+      "integrity": "sha512-jCQuH2qkbWoSY4wckLSfzf3OPh7zc7ZckEbIGGVUQar/JVff6EIbpQ+uNG29DDEOpdPPd8rrJsVuUlA/nvJdXA==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.572.0.tgz",
+      "integrity": "sha512-IkSu8p32tQZhKqwmfLZLGfYwNhsS/HUQBLnDMHJlr9VifmDqlTurcr+DwMCaMimuFhcLeb45vqTymKf/ro/OBw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "3.572.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.568.0.tgz",
+      "integrity": "sha512-ZJSmTmoIdg6WqAULjYzaJ3XcbgBzVy36lir6Y0UBMRGaxDgos1AARuX6EcYzXOl+ksLvxt/xMQ+3aYh1LWfKSw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.568.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.567.0.tgz",
+      "integrity": "sha512-zQHHj2N3in9duKghH7AuRNrOMLnKhW6lnmb7dznou068DJtDr76w475sHp2TF0XELsOGENbbBsOlN/S5QBFBVQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.568.0.tgz",
+      "integrity": "sha512-BinH72RG7K3DHHC1/tCulocFv+ZlQ9SrPF9zYT0T1OT95JXuHhB7fH8gEABrc6DAtOdJJh2fgxQjPy5tzPtsrA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.567.0.tgz",
+      "integrity": "sha512-rFk3QhdT4IL6O/UWHmNdjJiURutBCy+ogGqaNHf/RELxgXH3KmYorLwCe0eFb5hq8f6vr3zl4/iH7YtsUOuo1w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.572.0.tgz",
+      "integrity": "sha512-R4bBbLp1ywtF1kJoOX1juDMztKPWeQHNj6XuTvtruFDn1RdfnBlbM3+9rguRfH5s4V+xfl8SSWchnyo2cI00xg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.572.0.tgz",
+      "integrity": "sha512-xkZMIxek44F4YW5r9otD1O5Y/kDkgAb6JNJePkP1qPVojrkCmin3OFYAOZgGm+T4DZAQ5rWhpaqTAWmnRumYfw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/types": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.572.0.tgz",
+      "integrity": "sha512-AIEC7ItIWBqkJLtqcSd0HG8tvdh3zVwqnKPHNrcfFay0Xonqx3p/qTCDwGosh5CM5hDGzyOSRA5PkacEDBTz9w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.567.0.tgz",
+      "integrity": "sha512-cqP0uXtZ7m7hRysf3fRyJwcY1jCgQTpJy7BHB5VpsE7DXlXHD5+Ur5L42CY7UrRPrB6lc6YGFqaAOs5ghMcLyA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.568.0.tgz",
+      "integrity": "sha512-NVoZoLnKF+eXPBvXg+KqixgJkPSrerR6Gqmbjwqbv14Ini+0KNKB0/MXas1mDGvvEgtNkHI/Cb9zlJ3KXpti2A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
@@ -10008,7 +10722,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.4.2.tgz",
       "integrity": "sha512-2fek3I0KZHWJlRLvRTqxTEri+qV0GRHrJIoLFuBMZB4EMg4WgeBGfF0X6abnrNYpq55KJ6R4D6x4f0vLnhzinA==",
-      "dev": true,
       "dependencies": {
         "@smithy/middleware-endpoint": "^2.5.1",
         "@smithy/middleware-retry": "^2.3.1",
@@ -10032,6 +10745,68 @@
         "@smithy/property-provider": "^2.2.0",
         "@smithy/types": "^2.12.0",
         "@smithy/url-parser": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
+      "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.2.0.tgz",
+      "integrity": "sha512-UaPf8jKbcP71BGiO0CdeLmlg+RhWnlN8ipsMSdwvqBFigl5nil3rHOI/5GE3tfiuX8LvY5Z9N0meuU7Rab7jWw==",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.2.0.tgz",
+      "integrity": "sha512-RHhbTw/JW3+r8QQH7PrganjNCiuiEZmpi6fYUAetFfPLfZ6EkiA08uN3EFfcyKubXQxOwTeJRZSQmDDCdUshaA==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.2.0.tgz",
+      "integrity": "sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.2.0.tgz",
+      "integrity": "sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17066,6 +17841,10 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pii-redact": {
+      "resolved": "lambdas/pii-redact",
+      "link": true
+    },
     "node_modules/pirates": {
       "version": "4.0.6",
       "dev": true,
@@ -19667,6 +20446,625 @@
             "@smithy/types": "^2.9.1",
             "tslib": "^2.5.0"
           }
+        }
+      }
+    },
+    "@aws-sdk/client-cloudwatch-logs": {
+      "version": "3.574.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.574.0.tgz",
+      "integrity": "sha512-zWiFT75OkDinxgCxfoHzE4ZPu6rlE4MT6gxi8EgO1hrscJvdxW+2uZJ+e6KZqaN/WGs/sbPQqsWPYYpHLMrNOg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.574.0",
+        "@aws-sdk/client-sts": "3.574.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/eventstream-serde-browser": "^2.2.0",
+        "@smithy/eventstream-serde-config-resolver": "^2.2.0",
+        "@smithy/eventstream-serde-node": "^2.2.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "dependencies": {
+        "@aws-sdk/client-sso": {
+          "version": "3.572.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.572.0.tgz",
+          "integrity": "sha512-S+xhScao5MD79AkrcHmFpEDk+CgoiuB/31WFcTcnrTio5TOUONAaT0QyscOIwRp7BZ7Aez7TBM+loTteJ+TQvg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/core": "3.572.0",
+            "@aws-sdk/middleware-host-header": "3.567.0",
+            "@aws-sdk/middleware-logger": "3.568.0",
+            "@aws-sdk/middleware-recursion-detection": "3.567.0",
+            "@aws-sdk/middleware-user-agent": "3.572.0",
+            "@aws-sdk/region-config-resolver": "3.572.0",
+            "@aws-sdk/types": "3.567.0",
+            "@aws-sdk/util-endpoints": "3.572.0",
+            "@aws-sdk/util-user-agent-browser": "3.567.0",
+            "@aws-sdk/util-user-agent-node": "3.568.0",
+            "@smithy/config-resolver": "^2.2.0",
+            "@smithy/core": "^1.4.2",
+            "@smithy/fetch-http-handler": "^2.5.0",
+            "@smithy/hash-node": "^2.2.0",
+            "@smithy/invalid-dependency": "^2.2.0",
+            "@smithy/middleware-content-length": "^2.2.0",
+            "@smithy/middleware-endpoint": "^2.5.1",
+            "@smithy/middleware-retry": "^2.3.1",
+            "@smithy/middleware-serde": "^2.3.0",
+            "@smithy/middleware-stack": "^2.2.0",
+            "@smithy/node-config-provider": "^2.3.0",
+            "@smithy/node-http-handler": "^2.5.0",
+            "@smithy/protocol-http": "^3.3.0",
+            "@smithy/smithy-client": "^2.5.1",
+            "@smithy/types": "^2.12.0",
+            "@smithy/url-parser": "^2.2.0",
+            "@smithy/util-base64": "^2.3.0",
+            "@smithy/util-body-length-browser": "^2.2.0",
+            "@smithy/util-body-length-node": "^2.3.0",
+            "@smithy/util-defaults-mode-browser": "^2.2.1",
+            "@smithy/util-defaults-mode-node": "^2.3.1",
+            "@smithy/util-endpoints": "^1.2.0",
+            "@smithy/util-middleware": "^2.2.0",
+            "@smithy/util-retry": "^2.2.0",
+            "@smithy/util-utf8": "^2.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.574.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.574.0.tgz",
+          "integrity": "sha512-WcR8AnFhx7bqhYwfSl3OrF0Pu0LfHGgSOnmmORHqRF7ykguE09M/WUlCCjTGmZjJZ1we3uF5Xg8Jg12eiD+bmw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/client-sts": "3.574.0",
+            "@aws-sdk/core": "3.572.0",
+            "@aws-sdk/credential-provider-node": "3.572.0",
+            "@aws-sdk/middleware-host-header": "3.567.0",
+            "@aws-sdk/middleware-logger": "3.568.0",
+            "@aws-sdk/middleware-recursion-detection": "3.567.0",
+            "@aws-sdk/middleware-user-agent": "3.572.0",
+            "@aws-sdk/region-config-resolver": "3.572.0",
+            "@aws-sdk/types": "3.567.0",
+            "@aws-sdk/util-endpoints": "3.572.0",
+            "@aws-sdk/util-user-agent-browser": "3.567.0",
+            "@aws-sdk/util-user-agent-node": "3.568.0",
+            "@smithy/config-resolver": "^2.2.0",
+            "@smithy/core": "^1.4.2",
+            "@smithy/fetch-http-handler": "^2.5.0",
+            "@smithy/hash-node": "^2.2.0",
+            "@smithy/invalid-dependency": "^2.2.0",
+            "@smithy/middleware-content-length": "^2.2.0",
+            "@smithy/middleware-endpoint": "^2.5.1",
+            "@smithy/middleware-retry": "^2.3.1",
+            "@smithy/middleware-serde": "^2.3.0",
+            "@smithy/middleware-stack": "^2.2.0",
+            "@smithy/node-config-provider": "^2.3.0",
+            "@smithy/node-http-handler": "^2.5.0",
+            "@smithy/protocol-http": "^3.3.0",
+            "@smithy/smithy-client": "^2.5.1",
+            "@smithy/types": "^2.12.0",
+            "@smithy/url-parser": "^2.2.0",
+            "@smithy/util-base64": "^2.3.0",
+            "@smithy/util-body-length-browser": "^2.2.0",
+            "@smithy/util-body-length-node": "^2.3.0",
+            "@smithy/util-defaults-mode-browser": "^2.2.1",
+            "@smithy/util-defaults-mode-node": "^2.3.1",
+            "@smithy/util-endpoints": "^1.2.0",
+            "@smithy/util-middleware": "^2.2.0",
+            "@smithy/util-retry": "^2.2.0",
+            "@smithy/util-utf8": "^2.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.574.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.574.0.tgz",
+          "integrity": "sha512-WNDSG9nipap/L1gGDkCQvU2u413HmVxMJKr41lBCibioz42Z4i6XkCr1etYwIjuVfGF6QPrsEsYLqRwlAC/BQg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/client-sso-oidc": "3.574.0",
+            "@aws-sdk/core": "3.572.0",
+            "@aws-sdk/credential-provider-node": "3.572.0",
+            "@aws-sdk/middleware-host-header": "3.567.0",
+            "@aws-sdk/middleware-logger": "3.568.0",
+            "@aws-sdk/middleware-recursion-detection": "3.567.0",
+            "@aws-sdk/middleware-user-agent": "3.572.0",
+            "@aws-sdk/region-config-resolver": "3.572.0",
+            "@aws-sdk/types": "3.567.0",
+            "@aws-sdk/util-endpoints": "3.572.0",
+            "@aws-sdk/util-user-agent-browser": "3.567.0",
+            "@aws-sdk/util-user-agent-node": "3.568.0",
+            "@smithy/config-resolver": "^2.2.0",
+            "@smithy/core": "^1.4.2",
+            "@smithy/fetch-http-handler": "^2.5.0",
+            "@smithy/hash-node": "^2.2.0",
+            "@smithy/invalid-dependency": "^2.2.0",
+            "@smithy/middleware-content-length": "^2.2.0",
+            "@smithy/middleware-endpoint": "^2.5.1",
+            "@smithy/middleware-retry": "^2.3.1",
+            "@smithy/middleware-serde": "^2.3.0",
+            "@smithy/middleware-stack": "^2.2.0",
+            "@smithy/node-config-provider": "^2.3.0",
+            "@smithy/node-http-handler": "^2.5.0",
+            "@smithy/protocol-http": "^3.3.0",
+            "@smithy/smithy-client": "^2.5.1",
+            "@smithy/types": "^2.12.0",
+            "@smithy/url-parser": "^2.2.0",
+            "@smithy/util-base64": "^2.3.0",
+            "@smithy/util-body-length-browser": "^2.2.0",
+            "@smithy/util-body-length-node": "^2.3.0",
+            "@smithy/util-defaults-mode-browser": "^2.2.1",
+            "@smithy/util-defaults-mode-node": "^2.3.1",
+            "@smithy/util-endpoints": "^1.2.0",
+            "@smithy/util-middleware": "^2.2.0",
+            "@smithy/util-retry": "^2.2.0",
+            "@smithy/util-utf8": "^2.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/core": {
+          "version": "3.572.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.572.0.tgz",
+          "integrity": "sha512-DBmf94qfN0dfaLl5EnNcq6TakWfOtVXYifHoTbX+VBwESj3rlY4W+W4mAnvBgAqDjlLFy7bBljmx+vnjnV73lg==",
+          "requires": {
+            "@smithy/core": "^1.4.2",
+            "@smithy/protocol-http": "^3.3.0",
+            "@smithy/signature-v4": "^2.3.0",
+            "@smithy/smithy-client": "^2.5.1",
+            "@smithy/types": "^2.12.0",
+            "fast-xml-parser": "4.2.5",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.568.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.568.0.tgz",
+          "integrity": "sha512-MVTQoZwPnP1Ev5A7LG+KzeU6sCB8BcGkZeDT1z1V5Wt7GPq0MgFQTSSjhImnB9jqRSZkl1079Bt3PbO6lfIS8g==",
+          "requires": {
+            "@aws-sdk/types": "3.567.0",
+            "@smithy/property-provider": "^2.2.0",
+            "@smithy/types": "^2.12.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-http": {
+          "version": "3.568.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.568.0.tgz",
+          "integrity": "sha512-gL0NlyI2eW17hnCrh45hZV+qjtBquB+Bckiip9R6DIVRKqYcoILyiFhuOgf2bXeF23gVh6j18pvUvIoTaFWs5w==",
+          "requires": {
+            "@aws-sdk/types": "3.567.0",
+            "@smithy/fetch-http-handler": "^2.5.0",
+            "@smithy/node-http-handler": "^2.5.0",
+            "@smithy/property-provider": "^2.2.0",
+            "@smithy/protocol-http": "^3.3.0",
+            "@smithy/smithy-client": "^2.5.1",
+            "@smithy/types": "^2.12.0",
+            "@smithy/util-stream": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.572.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.572.0.tgz",
+          "integrity": "sha512-anlYZnpmVkfp9Gan+LcEkQvmRf/m0KcbR11th8sBEyI5lxMaHKXhnAtC/hEGT7e3L6rgNOrFYTPuSvllITD/Pg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.568.0",
+            "@aws-sdk/credential-provider-http": "3.568.0",
+            "@aws-sdk/credential-provider-ini": "3.572.0",
+            "@aws-sdk/credential-provider-process": "3.572.0",
+            "@aws-sdk/credential-provider-sso": "3.572.0",
+            "@aws-sdk/credential-provider-web-identity": "3.568.0",
+            "@aws-sdk/types": "3.567.0",
+            "@smithy/credential-provider-imds": "^2.3.0",
+            "@smithy/property-provider": "^2.2.0",
+            "@smithy/shared-ini-file-loader": "^2.4.0",
+            "@smithy/types": "^2.12.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@aws-sdk/client-sso-oidc": {
+              "version": "3.572.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.572.0.tgz",
+              "integrity": "sha512-S6C/S6xYesDakEuzYvlY1DMMKLtKQxdbbygq3hfeG2R0jUt9KpRLsQXK8qrBuVCKa3WcnjN/30hp4g/iUWFU/w==",
+              "peer": true,
+              "requires": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.572.0",
+                "@aws-sdk/core": "3.572.0",
+                "@aws-sdk/credential-provider-node": "3.572.0",
+                "@aws-sdk/middleware-host-header": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
+                "@aws-sdk/middleware-recursion-detection": "3.567.0",
+                "@aws-sdk/middleware-user-agent": "3.572.0",
+                "@aws-sdk/region-config-resolver": "3.572.0",
+                "@aws-sdk/types": "3.567.0",
+                "@aws-sdk/util-endpoints": "3.572.0",
+                "@aws-sdk/util-user-agent-browser": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/core": "^1.4.2",
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/hash-node": "^2.2.0",
+                "@smithy/invalid-dependency": "^2.2.0",
+                "@smithy/middleware-content-length": "^2.2.0",
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-retry": "^2.3.1",
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-body-length-browser": "^2.2.0",
+                "@smithy/util-body-length-node": "^2.3.0",
+                "@smithy/util-defaults-mode-browser": "^2.2.1",
+                "@smithy/util-defaults-mode-node": "^2.3.1",
+                "@smithy/util-endpoints": "^1.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+              }
+            },
+            "@aws-sdk/client-sts": {
+              "version": "3.572.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.572.0.tgz",
+              "integrity": "sha512-jCQuH2qkbWoSY4wckLSfzf3OPh7zc7ZckEbIGGVUQar/JVff6EIbpQ+uNG29DDEOpdPPd8rrJsVuUlA/nvJdXA==",
+              "peer": true,
+              "requires": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.572.0",
+                "@aws-sdk/core": "3.572.0",
+                "@aws-sdk/credential-provider-node": "3.572.0",
+                "@aws-sdk/middleware-host-header": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
+                "@aws-sdk/middleware-recursion-detection": "3.567.0",
+                "@aws-sdk/middleware-user-agent": "3.572.0",
+                "@aws-sdk/region-config-resolver": "3.572.0",
+                "@aws-sdk/types": "3.567.0",
+                "@aws-sdk/util-endpoints": "3.572.0",
+                "@aws-sdk/util-user-agent-browser": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/core": "^1.4.2",
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/hash-node": "^2.2.0",
+                "@smithy/invalid-dependency": "^2.2.0",
+                "@smithy/middleware-content-length": "^2.2.0",
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-retry": "^2.3.1",
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-body-length-browser": "^2.2.0",
+                "@smithy/util-body-length-node": "^2.3.0",
+                "@smithy/util-defaults-mode-browser": "^2.2.1",
+                "@smithy/util-defaults-mode-node": "^2.3.1",
+                "@smithy/util-endpoints": "^1.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+              }
+            },
+            "@aws-sdk/credential-provider-ini": {
+              "version": "3.572.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.572.0.tgz",
+              "integrity": "sha512-05KzbAp77fEiQXqMeodXeMbT83FOqSyBrfSEMz6U8uBXeJCy8zPUjN3acqcbG55/HNJHUvg1cftqzy+fUz71gA==",
+              "requires": {
+                "@aws-sdk/credential-provider-env": "3.568.0",
+                "@aws-sdk/credential-provider-process": "3.572.0",
+                "@aws-sdk/credential-provider-sso": "3.572.0",
+                "@aws-sdk/credential-provider-web-identity": "3.568.0",
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/credential-provider-imds": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.572.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.572.0.tgz",
+          "integrity": "sha512-hXcOytf0BadSm/MMy7MV8mmY0+Jv3mkavsHNBx0R82hw5ollD0I3JyOAaCtdUpztF0I72F8K+q8SpJQZ+EwArw==",
+          "requires": {
+            "@aws-sdk/types": "3.567.0",
+            "@smithy/property-provider": "^2.2.0",
+            "@smithy/shared-ini-file-loader": "^2.4.0",
+            "@smithy/types": "^2.12.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.572.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.572.0.tgz",
+          "integrity": "sha512-iIlnpJiDXFp3XC4hJNSiNurnU24mr3iLB3HoNa9efr944bo6XBl9FQdk3NssIkqzSmgyoB2CEUx/daBHz4XSow==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.572.0",
+            "@aws-sdk/token-providers": "3.572.0",
+            "@aws-sdk/types": "3.567.0",
+            "@smithy/property-provider": "^2.2.0",
+            "@smithy/shared-ini-file-loader": "^2.4.0",
+            "@smithy/types": "^2.12.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@aws-sdk/client-sso-oidc": {
+              "version": "3.572.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.572.0.tgz",
+              "integrity": "sha512-S6C/S6xYesDakEuzYvlY1DMMKLtKQxdbbygq3hfeG2R0jUt9KpRLsQXK8qrBuVCKa3WcnjN/30hp4g/iUWFU/w==",
+              "peer": true,
+              "requires": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.572.0",
+                "@aws-sdk/core": "3.572.0",
+                "@aws-sdk/credential-provider-node": "3.572.0",
+                "@aws-sdk/middleware-host-header": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
+                "@aws-sdk/middleware-recursion-detection": "3.567.0",
+                "@aws-sdk/middleware-user-agent": "3.572.0",
+                "@aws-sdk/region-config-resolver": "3.572.0",
+                "@aws-sdk/types": "3.567.0",
+                "@aws-sdk/util-endpoints": "3.572.0",
+                "@aws-sdk/util-user-agent-browser": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/core": "^1.4.2",
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/hash-node": "^2.2.0",
+                "@smithy/invalid-dependency": "^2.2.0",
+                "@smithy/middleware-content-length": "^2.2.0",
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-retry": "^2.3.1",
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-body-length-browser": "^2.2.0",
+                "@smithy/util-body-length-node": "^2.3.0",
+                "@smithy/util-defaults-mode-browser": "^2.2.1",
+                "@smithy/util-defaults-mode-node": "^2.3.1",
+                "@smithy/util-endpoints": "^1.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+              }
+            },
+            "@aws-sdk/client-sts": {
+              "version": "3.572.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.572.0.tgz",
+              "integrity": "sha512-jCQuH2qkbWoSY4wckLSfzf3OPh7zc7ZckEbIGGVUQar/JVff6EIbpQ+uNG29DDEOpdPPd8rrJsVuUlA/nvJdXA==",
+              "peer": true,
+              "requires": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.572.0",
+                "@aws-sdk/core": "3.572.0",
+                "@aws-sdk/credential-provider-node": "3.572.0",
+                "@aws-sdk/middleware-host-header": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
+                "@aws-sdk/middleware-recursion-detection": "3.567.0",
+                "@aws-sdk/middleware-user-agent": "3.572.0",
+                "@aws-sdk/region-config-resolver": "3.572.0",
+                "@aws-sdk/types": "3.567.0",
+                "@aws-sdk/util-endpoints": "3.572.0",
+                "@aws-sdk/util-user-agent-browser": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/core": "^1.4.2",
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/hash-node": "^2.2.0",
+                "@smithy/invalid-dependency": "^2.2.0",
+                "@smithy/middleware-content-length": "^2.2.0",
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-retry": "^2.3.1",
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-body-length-browser": "^2.2.0",
+                "@smithy/util-body-length-node": "^2.3.0",
+                "@smithy/util-defaults-mode-browser": "^2.2.1",
+                "@smithy/util-defaults-mode-node": "^2.3.1",
+                "@smithy/util-endpoints": "^1.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+              }
+            },
+            "@aws-sdk/token-providers": {
+              "version": "3.572.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.572.0.tgz",
+              "integrity": "sha512-IkSu8p32tQZhKqwmfLZLGfYwNhsS/HUQBLnDMHJlr9VifmDqlTurcr+DwMCaMimuFhcLeb45vqTymKf/ro/OBw==",
+              "requires": {
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.568.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.568.0.tgz",
+          "integrity": "sha512-ZJSmTmoIdg6WqAULjYzaJ3XcbgBzVy36lir6Y0UBMRGaxDgos1AARuX6EcYzXOl+ksLvxt/xMQ+3aYh1LWfKSw==",
+          "requires": {
+            "@aws-sdk/types": "3.567.0",
+            "@smithy/property-provider": "^2.2.0",
+            "@smithy/types": "^2.12.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.567.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.567.0.tgz",
+          "integrity": "sha512-zQHHj2N3in9duKghH7AuRNrOMLnKhW6lnmb7dznou068DJtDr76w475sHp2TF0XELsOGENbbBsOlN/S5QBFBVQ==",
+          "requires": {
+            "@aws-sdk/types": "3.567.0",
+            "@smithy/protocol-http": "^3.3.0",
+            "@smithy/types": "^2.12.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.568.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.568.0.tgz",
+          "integrity": "sha512-BinH72RG7K3DHHC1/tCulocFv+ZlQ9SrPF9zYT0T1OT95JXuHhB7fH8gEABrc6DAtOdJJh2fgxQjPy5tzPtsrA==",
+          "requires": {
+            "@aws-sdk/types": "3.567.0",
+            "@smithy/types": "^2.12.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.567.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.567.0.tgz",
+          "integrity": "sha512-rFk3QhdT4IL6O/UWHmNdjJiURutBCy+ogGqaNHf/RELxgXH3KmYorLwCe0eFb5hq8f6vr3zl4/iH7YtsUOuo1w==",
+          "requires": {
+            "@aws-sdk/types": "3.567.0",
+            "@smithy/protocol-http": "^3.3.0",
+            "@smithy/types": "^2.12.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.572.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.572.0.tgz",
+          "integrity": "sha512-R4bBbLp1ywtF1kJoOX1juDMztKPWeQHNj6XuTvtruFDn1RdfnBlbM3+9rguRfH5s4V+xfl8SSWchnyo2cI00xg==",
+          "requires": {
+            "@aws-sdk/types": "3.567.0",
+            "@aws-sdk/util-endpoints": "3.572.0",
+            "@smithy/protocol-http": "^3.3.0",
+            "@smithy/types": "^2.12.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/region-config-resolver": {
+          "version": "3.572.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.572.0.tgz",
+          "integrity": "sha512-xkZMIxek44F4YW5r9otD1O5Y/kDkgAb6JNJePkP1qPVojrkCmin3OFYAOZgGm+T4DZAQ5rWhpaqTAWmnRumYfw==",
+          "requires": {
+            "@aws-sdk/types": "3.567.0",
+            "@smithy/node-config-provider": "^2.3.0",
+            "@smithy/types": "^2.12.0",
+            "@smithy/util-config-provider": "^2.3.0",
+            "@smithy/util-middleware": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.567.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+          "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+          "requires": {
+            "@smithy/types": "^2.12.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.572.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.572.0.tgz",
+          "integrity": "sha512-AIEC7ItIWBqkJLtqcSd0HG8tvdh3zVwqnKPHNrcfFay0Xonqx3p/qTCDwGosh5CM5hDGzyOSRA5PkacEDBTz9w==",
+          "requires": {
+            "@aws-sdk/types": "3.567.0",
+            "@smithy/types": "^2.12.0",
+            "@smithy/util-endpoints": "^1.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.567.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.567.0.tgz",
+          "integrity": "sha512-cqP0uXtZ7m7hRysf3fRyJwcY1jCgQTpJy7BHB5VpsE7DXlXHD5+Ur5L42CY7UrRPrB6lc6YGFqaAOs5ghMcLyA==",
+          "requires": {
+            "@aws-sdk/types": "3.567.0",
+            "@smithy/types": "^2.12.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.568.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.568.0.tgz",
+          "integrity": "sha512-NVoZoLnKF+eXPBvXg+KqixgJkPSrerR6Gqmbjwqbv14Ini+0KNKB0/MXas1mDGvvEgtNkHI/Cb9zlJ3KXpti2A==",
+          "requires": {
+            "@aws-sdk/types": "3.567.0",
+            "@smithy/node-config-provider": "^2.3.0",
+            "@smithy/types": "^2.12.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
         }
       }
     },
@@ -26729,7 +28127,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.4.2.tgz",
       "integrity": "sha512-2fek3I0KZHWJlRLvRTqxTEri+qV0GRHrJIoLFuBMZB4EMg4WgeBGfF0X6abnrNYpq55KJ6R4D6x4f0vLnhzinA==",
-      "dev": true,
       "requires": {
         "@smithy/middleware-endpoint": "^2.5.1",
         "@smithy/middleware-retry": "^2.3.1",
@@ -26750,6 +28147,56 @@
         "@smithy/property-provider": "^2.2.0",
         "@smithy/types": "^2.12.0",
         "@smithy/url-parser": "^2.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-codec": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
+      "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
+      "requires": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-serde-browser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.2.0.tgz",
+      "integrity": "sha512-UaPf8jKbcP71BGiO0CdeLmlg+RhWnlN8ipsMSdwvqBFigl5nil3rHOI/5GE3tfiuX8LvY5Z9N0meuU7Rab7jWw==",
+      "requires": {
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-serde-config-resolver": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.2.0.tgz",
+      "integrity": "sha512-RHhbTw/JW3+r8QQH7PrganjNCiuiEZmpi6fYUAetFfPLfZ6EkiA08uN3EFfcyKubXQxOwTeJRZSQmDDCdUshaA==",
+      "requires": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-serde-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.2.0.tgz",
+      "integrity": "sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==",
+      "requires": {
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/eventstream-serde-universal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.2.0.tgz",
+      "integrity": "sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==",
+      "requires": {
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       }
     },
@@ -28075,7 +29522,7 @@
       "requires": {
         "@aws-sdk/client-cloudformation": "^3.405.0",
         "@aws-sdk/client-dynamodb": "^3.398.0",
-        "@aws-sdk/client-eventbridge": "*",
+        "@aws-sdk/client-eventbridge": "^3.569.0",
         "@aws-sdk/client-kms": "^3.451.0",
         "@aws-sdk/client-secrets-manager": "^3.454.0",
         "@aws-sdk/client-sfn": "^3.405.0",
@@ -31968,6 +33415,9 @@
     "picomatch": {
       "version": "2.3.1",
       "dev": true
+    },
+    "pii-redact": {
+      "version": "file:lambdas/pii-redact"
     },
     "pirates": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@aws-lambda-powertools/parameters": "1.17.0",
     "@aws-lambda-powertools/tracer": "1.14.2",
     "@aws-sdk/client-ssm": "3.363.0",
+    "@aws-sdk/client-cloudwatch-logs": "3.574.0",
     "esbuild": "0.19.5",
     "jose": "^5.2.2"
   },


### PR DESCRIPTION
## Proposed changes

### What changed
The way we censor PII. 

* New log groups for PII redacted logs for Splunk
* Subscription Filter to a new Lambda that handles the censoring

The way the logic here works is:

1. Created new log groups that contain PII redacted logs
2. Updated the CSLS subscriptions to use those new log groups so Splunk gets redacted logs
3. Created a PII redact lambda 
4. Set a subscription filter to the original log groups that calls the lambda. 

The lambda created receives the logs, masks the PII and forwards the logs to the PII redacted variant. 

### Why did it change
We need structured JSON in Splunk which the old way didn't do properly. 

### Issue tracking
- [OJ-2319](https://govukverify.atlassian.net/browse/OJ-2319)


[OJ-2319]: https://govukverify.atlassian.net/browse/OJ-2319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ