### PR TITLE
removed conditional and modified RetentionInDays values to 30

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -169,7 +169,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/EpochTimeFunction
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedEpochTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -228,7 +228,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CiMappingFunction
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedCiMappingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -289,7 +289,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CreateAuthCodeFunction
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedCreateAuthCodeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -350,7 +350,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CredentialSubjectFunction
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedCredentialSubjectFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -411,7 +411,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CurrentTimeFunction
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedCurrentTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -477,7 +477,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/JwtSignerFunction
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedJwtSignerFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -538,7 +538,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/OTGFunction
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedOTGFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -659,7 +659,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedMatchingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -723,7 +723,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/SsmParametersFunction
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedSsmParametersFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -784,7 +784,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/TimeFunction
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -895,7 +895,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PublicNinoCheckApi}-public-AccessLogs"
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedPublicNinoCheckApiLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -996,7 +996,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PrivateNinoCheckApi}-private-AccessLogs"
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedPrivateNinoCheckApiLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1242,7 +1242,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoCheck-state-machine-logs"
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedNinoCheckStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1334,7 +1334,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-Abandon-state-machine-logs"
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedAbandonStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1457,7 +1457,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoIssueCredential-state-machine-logs"
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedNinoIssueCredentialLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1505,7 +1505,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-CheckSession-state-machine-logs"
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedCheckSessionStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1882,7 +1882,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-AuditEvent-state-machine-logs
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedAuditEventStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -2017,103 +2017,103 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/EpochTimeFunction-pii-redacted
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedCiMappingFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CiMappingFunction-pii-redacted
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedCreateAuthCodeFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CreateAuthCodeFunction-pii-redacted
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedCredentialSubjectFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CredentialSubjectFunction-pii-redacted
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedCurrentTimeFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CurrentTimeFunction-pii-redacted
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedJwtSignerFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/JwtSignerFunction-pii-redacted
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedOTGFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/OTGFunction-pii-redacted
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedMatchingFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction-pii-redacted
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedSsmParametersFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/SsmParametersFunction-pii-redacted
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedTimeFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/TimeFunction-pii-redacted
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedPublicNinoCheckApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PublicNinoCheckApi}-public-AccessLogs-pii-redacted"
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedPrivateNinoCheckApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PrivateNinoCheckApi}-private-AccessLogs-pii-redacted"
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedNinoCheckStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoCheck-state-machine-logs-pii-redacted"
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedAbandonStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-Abandon-state-machine-logs-pii-redacted"
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedNinoIssueCredentialLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoIssueCredential-state-machine-logs-pii-redacted"
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedCheckSessionStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-CheckSession-state-machine-logs-pii-redacted"
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactedAuditEventStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-AuditEvent-state-machine-logs-pii-redacted
-      RetentionInDays: 
+      RetentionInDays: 30
 
   ####################################################################
   #                                                                  #
@@ -2167,7 +2167,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/PIIRedactFunction
-      RetentionInDays: 
+      RetentionInDays: 30
 
   PIIRedactFunctionCloudWatchPermissions:
     Type: AWS::Lambda::Permission

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -173,7 +173,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/EpochTimeFunction
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedEpochTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -232,7 +232,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CiMappingFunction
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedCiMappingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -293,7 +293,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CreateAuthCodeFunction
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedCreateAuthCodeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -354,7 +354,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CredentialSubjectFunction
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedCredentialSubjectFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -415,7 +415,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CurrentTimeFunction
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedCurrentTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -481,7 +481,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/JwtSignerFunction
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedJwtSignerFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -542,7 +542,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/OTGFunction
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedOTGFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -663,7 +663,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedMatchingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -727,7 +727,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/SsmParametersFunction
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedSsmParametersFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -788,7 +788,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/TimeFunction
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -899,7 +899,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PublicNinoCheckApi}-public-AccessLogs"
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedPublicNinoCheckApiLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1000,7 +1000,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PrivateNinoCheckApi}-private-AccessLogs"
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedPrivateNinoCheckApiLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1246,7 +1246,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoCheck-state-machine-logs"
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedNinoCheckStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1338,7 +1338,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-Abandon-state-machine-logs"
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedAbandonStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1461,7 +1461,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoIssueCredential-state-machine-logs"
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedNinoIssueCredentialLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1509,7 +1509,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-CheckSession-state-machine-logs"
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedCheckSessionStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1886,7 +1886,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-AuditEvent-state-machine-logs
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedAuditEventStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -2021,103 +2021,103 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/EpochTimeFunction-pii-redacted
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedCiMappingFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CiMappingFunction-pii-redacted
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedCreateAuthCodeFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CreateAuthCodeFunction-pii-redacted
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedCredentialSubjectFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CredentialSubjectFunction-pii-redacted
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedCurrentTimeFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CurrentTimeFunction-pii-redacted
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedJwtSignerFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/JwtSignerFunction-pii-redacted
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedOTGFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/OTGFunction-pii-redacted
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedMatchingFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction-pii-redacted
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedSsmParametersFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/SsmParametersFunction-pii-redacted
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedTimeFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/TimeFunction-pii-redacted
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedPublicNinoCheckApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PublicNinoCheckApi}-public-AccessLogs-pii-redacted"
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedPrivateNinoCheckApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PrivateNinoCheckApi}-private-AccessLogs-pii-redacted"
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedNinoCheckStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoCheck-state-machine-logs-pii-redacted"
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedAbandonStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-Abandon-state-machine-logs-pii-redacted"
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedNinoIssueCredentialLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoIssueCredential-state-machine-logs-pii-redacted"
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedCheckSessionStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-CheckSession-state-machine-logs-pii-redacted"
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactedAuditEventStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-AuditEvent-state-machine-logs-pii-redacted
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   ####################################################################
   #                                                                  #
@@ -2171,7 +2171,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/PIIRedactFunction
-      RetentionInDays: !If [IsProdEnvironment, 30, 7]
+      RetentionInDays: 30
 
   PIIRedactFunctionCloudWatchPermissions:
     Type: AWS::Lambda::Permission

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -48,10 +48,6 @@ Conditions:
   IsLocalDevEnvironment: !Equals [!Ref Environment, localdev]
   IsDevLikeEnvironment:
     !Or [!Condition IsLocalDevEnvironment, !Condition IsDevEnvironment]
-  IsProdEnvironment: !Equals
-    - !Ref Environment
-    - production
-
   IsNotDevLikeEnvironment: !Not
     - !Condition IsDevLikeEnvironment
 
@@ -173,7 +169,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/EpochTimeFunction
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedEpochTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -232,7 +228,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CiMappingFunction
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedCiMappingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -293,7 +289,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CreateAuthCodeFunction
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedCreateAuthCodeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -354,7 +350,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CredentialSubjectFunction
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedCredentialSubjectFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -415,7 +411,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CurrentTimeFunction
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedCurrentTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -481,7 +477,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/JwtSignerFunction
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedJwtSignerFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -542,7 +538,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/OTGFunction
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedOTGFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -663,7 +659,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedMatchingFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -727,7 +723,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/SsmParametersFunction
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedSsmParametersFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -788,7 +784,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/TimeFunction
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedTimeFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -899,7 +895,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PublicNinoCheckApi}-public-AccessLogs"
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedPublicNinoCheckApiLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1000,7 +996,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PrivateNinoCheckApi}-private-AccessLogs"
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedPrivateNinoCheckApiLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1246,7 +1242,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoCheck-state-machine-logs"
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedNinoCheckStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1338,7 +1334,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-Abandon-state-machine-logs"
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedAbandonStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1461,7 +1457,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoIssueCredential-state-machine-logs"
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedNinoIssueCredentialLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1509,7 +1505,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-CheckSession-state-machine-logs"
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedCheckSessionStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -1886,7 +1882,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-AuditEvent-state-machine-logs
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedAuditEventStateMachineLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -2021,103 +2017,103 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/EpochTimeFunction-pii-redacted
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedCiMappingFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CiMappingFunction-pii-redacted
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedCreateAuthCodeFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CreateAuthCodeFunction-pii-redacted
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedCredentialSubjectFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CredentialSubjectFunction-pii-redacted
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedCurrentTimeFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CurrentTimeFunction-pii-redacted
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedJwtSignerFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/JwtSignerFunction-pii-redacted
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedOTGFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/OTGFunction-pii-redacted
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedMatchingFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/MatchingFunction-pii-redacted
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedSsmParametersFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/SsmParametersFunction-pii-redacted
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedTimeFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/TimeFunction-pii-redacted
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedPublicNinoCheckApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PublicNinoCheckApi}-public-AccessLogs-pii-redacted"
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedPrivateNinoCheckApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/apigateway/${AWS::StackName}-${PrivateNinoCheckApi}-private-AccessLogs-pii-redacted"
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedNinoCheckStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoCheck-state-machine-logs-pii-redacted"
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedAbandonStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-Abandon-state-machine-logs-pii-redacted"
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedNinoIssueCredentialLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-NinoIssueCredential-state-machine-logs-pii-redacted"
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedCheckSessionStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-CheckSession-state-machine-logs-pii-redacted"
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactedAuditEventStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-AuditEvent-state-machine-logs-pii-redacted
-      RetentionInDays: 30
+      RetentionInDays: 
 
   ####################################################################
   #                                                                  #
@@ -2171,7 +2167,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/PIIRedactFunction
-      RetentionInDays: 30
+      RetentionInDays: 
 
   PIIRedactFunctionCloudWatchPermissions:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
Increase log group's RetentionInDays to 30. Currently any log retention that is set under 30 days will be set to 30 by a Lambda attached to the LZA Lambda run - [INCIDEN-627](https://govukverify.atlassian.net/browse/INCIDEN-627?focusedCommentId=125675)

What changed
RetentionInDays: changed RetentionInDays: 30

Check ticket https://govukverify.atlassian.net/jira/software/c/projects/PSREC/boards/555?selectedIssue=PSREC-243 and associated epic https://govukverify.atlassian.net/browse/PSREC-314

Why did it change
LZA lambda unpicks log retentions lower than 30 days.

Issue tracking
[INCIDEN-627](https://govukverify.atlassian.net/browse/INCIDEN-627?focusedCommentId=125675)

Environment variables or secrets
[ ] No environment variables or secrets were added or changed

[ ] Documented in the [https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/blob/main/infrastructure/README.md](url)
[ ] Added to deployment steps
[ ] Added to local startup config

Other considerations
[ ] Update [https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/blob/main/infrastructure/README.md] with any new instructions or tasks

[INCIDEN-627]: https://govukverify.atlassian.net/browse/INCIDEN-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INCIDEN-627]: https://govukverify.atlassian.net/browse/INCIDEN-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ