### PR TITLE
OJ-2319: Added generic IP Address redaction

### DIFF
--- a/lambdas/pii-redact/src/pii-redactor.ts
+++ b/lambdas/pii-redact/src/pii-redactor.ts
@@ -39,6 +39,15 @@ const personalNumberPatterns = [
 
 const ipAddressPatterns = [
   {
+    regex:
+      /((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)/g,
+    replacement: "***",
+  },
+  {
+    regex: /\\"X-Forwarded-For\\":\s*\\"([^"]*)\\"/g,
+    replacement: '\\"X-Forwarded-For\\": \\"***\\"',
+  },
+  {
     regex: /\\"clientIpAddress\\":\s*\\"([^"]*)\\"/g,
     replacement: '\\"clientIpAddress\\": \\"***\\"',
   },


### PR DESCRIPTION
This PR uses a generic regex to censor IP addresses. This was added because the current way of censoring IP addresses in blocks we know of isn't going to capture areas we did not identify. 

OK-2319