### PR TITLE
BAU: Fix intermittent failures with event bridge tests

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -57,7 +57,7 @@ jobs:
 
   eventbridge-abandon-tests:
     name: Run tests
-    needs: deploy
+    needs: [deploy, apigw-tests]
     uses: ./.github/workflows/run-evn-abn-tests.yml
     permissions:
       id-token: write
@@ -68,7 +68,7 @@ jobs:
 
   eventbridge-nino-check-tests:
     name: Run tests
-    needs: deploy
+    needs: [deploy, eventbridge-abandon-tests ]
     uses: ./.github/workflows/run-evn-nino-tests.yml
     permissions:
       id-token: write
@@ -79,7 +79,7 @@ jobs:
 
   eventbridge-issue-credential-check-tests:
     name: Run tests
-    needs: deploy
+    needs: [deploy, eventbridge-nino-check-tests ]
     uses: ./.github/workflows/run-evn-cred-tests.yml
     permissions:
       id-token: write

--- a/.github/workflows/run-evn-abn-tests.yml
+++ b/.github/workflows/run-evn-abn-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       stack-name: { required: true, type: string }
-      aws-region: { required: false, type: string }
+      aws-region: { required: true, type: string }
 
 permissions:
   id-token: write

--- a/.github/workflows/run-evn-nino-tests.yml
+++ b/.github/workflows/run-evn-nino-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       stack-name: { required: true, type: string }
-      aws-region: { required: false, type: string }
+      aws-region: { required: true, type: string }
 
 permissions:
   id-token: write

--- a/.github/workflows/run-sfn-aws-tests.yml
+++ b/.github/workflows/run-sfn-aws-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       stack-name: { required: true, type: string }
-      aws-region: { required: false, type: string }
+      aws-region: { required: true, type: string }
 
 permissions:
   id-token: write

--- a/integration-tests/eventbridge/abandon/abandon-publish.test.ts
+++ b/integration-tests/eventbridge/abandon/abandon-publish.test.ts
@@ -12,7 +12,7 @@ import { removeTargetFromRule } from "../../resources/event-bridge-helper";
 import { pause, retry } from "../../resources/util";
 
 describe("Abandon Step Function", () => {
-  jest.setTimeout(600_000);
+  jest.setTimeout(30_0000); // 5 minutes
 
   const input = {
     sessionId: "abandon-test-publish",

--- a/integration-tests/eventbridge/nino_issue_credential/nino-issue-credential-publish.test.ts
+++ b/integration-tests/eventbridge/nino_issue_credential/nino-issue-credential-publish.test.ts
@@ -149,6 +149,7 @@ describe("Nino Check Hmrc Issue Credential", () => {
       checkHmrcEventBus
     );
   });
+
   afterEach(async () => {
     await clearItemsFromTables(
       {
@@ -164,23 +165,33 @@ describe("Nino Check Hmrc Issue Credential", () => {
         items: { sessionId: "issue-credential-happy-publish" },
       }
     );
+
     await clearAttemptsTable(
       "issue-credential-happy-publish",
       output.UserAttemptsTable
     );
-    await Promise.all([
-      removeTargetFromRule(targetId, checkHmrcEventBus, vcIssuedRuleName),
-      removeTargetFromRule(targetId, checkHmrcEventBus, endEventRuleName),
-      removeTargetFromRule(targetId, checkHmrcEventBus, txMaAuditEventRuleName),
-    ]);
+
+    await removeTargetFromRule(targetId, checkHmrcEventBus, vcIssuedRuleName);
+    await removeTargetFromRule(targetId, checkHmrcEventBus, endEventRuleName);
+    await removeTargetFromRule(
+      targetId,
+      checkHmrcEventBus,
+      txMaAuditEventRuleName
+    );
+
     await retry(async () => {
-      await Promise.all([
-        deleteQueue(vcIssuedEventTestQueue.QueueUrl),
-        deleteQueue(endEventTestQueue.QueueUrl),
-        deleteQueue(txMaAuditEventTestQueue.QueueUrl),
-      ]);
-      await pause(60);
+      await deleteQueue(vcIssuedEventTestQueue.QueueUrl);
     });
+
+    await retry(async () => {
+      await deleteQueue(endEventTestQueue.QueueUrl);
+    });
+
+    await retry(async () => {
+      await deleteQueue(txMaAuditEventTestQueue.QueueUrl);
+    });
+
+    await pause(30);
   });
 
   it("should publish END event to CheckHmrc EventBridge Bus successfully", async () => {

--- a/integration-tests/resources/queue-helper.ts
+++ b/integration-tests/resources/queue-helper.ts
@@ -119,9 +119,7 @@ export const getQueueMessages = async (
 
     return allMessages;
   } catch (error) {
-    return retry(() => {
-      return getQueueMessages(queueUrl, retryConfig);
-    }, retryConfig);
+    throw new Error("No messages received: " + error);
   }
 };
 export const setUpQueueAndAttachToRule = async (

--- a/integration-tests/resources/queue-helper.ts
+++ b/integration-tests/resources/queue-helper.ts
@@ -90,11 +90,7 @@ export const addQueuePolicy = async (
   });
 };
 export const getQueueMessages = async (
-  queueUrl: string,
-  retryConfig: RetryConfig = {
-    intervalInMs: 0,
-    maxRetries: 5,
-  }
+  queueUrl: string
 ): Promise<Message[]> => {
   try {
     let allMessages: Message[] = [];

--- a/integration-tests/resources/util.ts
+++ b/integration-tests/resources/util.ts
@@ -4,36 +4,41 @@ interface RetryConfig {
   swallowError?: boolean;
   quiet?: boolean;
 }
+
 export const pause = (seconds: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, seconds * 1000));
 
 const retry = async <T>(
   fn: () => Promise<T>,
-  config: RetryConfig = { intervalInMs: 1000, maxRetries: 10 },
+  config: RetryConfig = { intervalInMs: 1000, maxRetries: 3 }
 ): Promise<T> => {
-  const { intervalInMs = 1000, maxRetries = 10 } = config;
+  const { intervalInMs = 1000, maxRetries = 3, swallowError, quiet } = config;
+
   try {
     return await fn();
   } catch (err) {
-    if (!config.quiet) {
+    const interval = intervalInMs / 1000;
+
+    if (!quiet) {
       // eslint-disable-next-line no-console
       console.warn(
-        `Retrying after ${
-          intervalInMs / 1000
-        } seconds. ${maxRetries} retries left.`
+        `Retrying after ${interval} seconds. ${maxRetries} retries left.`
       );
       // eslint-disable-next-line no-console
       console.warn(err instanceof Error ? err.message : err);
     }
-    if (maxRetries === 0) {
-      config && config.swallowError
-        ? await Promise.resolve()
-        : Promise.reject(err);
-      throw err;
+
+    if (maxRetries <= 0) {
+      if (swallowError) {
+        return (await Promise.resolve()) as unknown as T;
+      } else {
+        throw err;
+      }
     }
-    await pause(intervalInMs);
+
+    await pause(interval);
     return retry(fn, { ...config, maxRetries: maxRetries - 1 });
   }
 };
 
-export { RetryConfig, retry, pause as wait };
+export { RetryConfig, retry };


### PR DESCRIPTION
The event bridge tests that were run pre-merge were intermittently failing. 
They had the following issues:
* Not cleaning up after themselves properly
* Taking too long (e.g. some cases they took 10-15 minutes each)
* Interfering with each other

The clean up code in itself wasn't wrong however the way the awaits, retries and promises were done, caused the scripts to be long running and timeout before they could properly clean up. 

This PR fixes the clean up issues after each test and lowers the time the tests wait and re-try on failure. Refactored the `@AfterEach` blocks to run in sequence and not parallel. 

The GHAs are now also running in sequence instead of parallel to avoid any conflicts between them. This is because if we ran an APIGW test, that test would be publishing audit events and in parallel the event bridge tests would pick up those events and get the wrong value. Similar was seen when for the event bridge tests between themselves.