### PR TITLE
OJ-2629: Remove session-id exclusion in VTL

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -150,7 +150,7 @@ paths:
                 #end
               #end
               {
-                "input":"{\"nino\":\"$nino\",\"sessionId\":\"$input.params('session-id').trim()\",#set($headerKeys = $headers.keySet())#set($headerCount = $headerKeys.size())#foreach($headerKey in $headerKeys)#if($headerKey != 'session-id')\"$headerKey\": \"$headers.get($headerKey)\"#if($foreach.hasNext && $foreach.index != $headerCount - 1),#end#end#end}",
+                "input":"{\"nino\":\"$nino\",\"sessionId\":\"$input.params('session-id').trim()\",#set($headerKeys = $headers.keySet())#set($headerCount = $headerKeys.size())#foreach($headerKey in $headerKeys)\"$headerKey\": \"$headers.get($headerKey)\"#if($foreach.hasNext && $foreach.index != $headerCount - 1),#end#end}",
                 "stateMachineArn": "${NinoCheckStateMachine.Arn}"
               }
         responses:

--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -150,7 +150,7 @@ paths:
                 #end
               #end
               {
-                "input":"{\"nino\":\"$nino\",\"sessionId\":\"$input.params('session-id').trim()\",#set($headerKeys = $headers.keySet())#set($headerCount = $headerKeys.size())#foreach($headerKey in $headerKeys)\"$headerKey\": \"$headers.get($headerKey)\"#if($foreach.hasNext && $foreach.index != $headerCount - 1),#end#end}",
+                "input":"{\"nino\":\"$nino\",\"sessionId\":\"$input.params('session-id').trim()\",#set($headerKeys = $headers.keySet())#set($headerCount = $headerKeys.size())#foreach($headerKey in $headerKeys)\"$headerKey\": \"$headers.get($headerKey)\"#if($foreach.hasNext),#end#end}",
                 "stateMachineArn": "${NinoCheckStateMachine.Arn}"
               }
         responses:


### PR DESCRIPTION
## Proposed changes

### What changed
VTL for /check to not try to exclude the "session-id" header

### Why did it change
The parsing logic was causing invalid JSON to be produces so to avoid adding extra complexity to the VTL, I have removed that logic. The reason it was added was because we provide a "sessionId" already so now we will also get a "session-id" which does not cause any functional issues. 

### Issue tracking
- [OJ-2629](https://govukverify.atlassian.net/browse/OJ-2629)


[OJ-2629]: https://govukverify.atlassian.net/browse/OJ-2629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ