### PR TITLE
OJ-2610: Escape JavaScript in VTL

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -144,13 +144,13 @@ paths:
               #set($headers = {})
               #foreach($header in $input.params().header.keySet())
                 #set($headerName = $util.escapeJavaScript($header))
-                #set($headerValue = $input.params().header.get($header))
+                #set($headerValue = $util.escapeJavaScript($input.params().header.get($header)))
                 #if($headerName.trim() && $headerValue.trim())
                   $util.qr($headers.put($headerName, $headerValue))
                 #end
               #end
               {
-                "input":"{\"nino\":\"$nino\",\"sessionId\":\"$input.params('session-id').trim()\",#set($headerKeys = $headers.keySet())#set($headerCount = $headerKeys.size())#foreach($headerKey in $headerKeys)\"$headerKey\": \"$headers.get($headerKey)\"#if($foreach.hasNext),#end#end}",
+                "input":"{\"nino\":\"$nino\",\"sessionId\":\"$util.escapeJavaScript($input.params('session-id').trim())\",#set($headerKeys = $headers.keySet())#set($headerCount = $headerKeys.size())#foreach($headerKey in $headerKeys)\"$headerKey\": \"$util.escapeJavaScript($headers.get($headerKey))\"#if($foreach.hasNext),#end#end}",
                 "stateMachineArn": "${NinoCheckStateMachine.Arn}"
               }
         responses:
@@ -198,7 +198,7 @@ paths:
           application/json:
             Fn::Sub: |-
               {
-                "input": "{\"sessionId\": \"$input.params('session-id').trim()\"}",
+                "input": "{\"sessionId\": \"$util.escapeJavaScript($input.params('session-id').trim())\"}",
                 "stateMachineArn": "${AbandonStateMachine.Arn}"
               }
         responses:

--- a/infrastructure/public-api.yaml
+++ b/infrastructure/public-api.yaml
@@ -155,7 +155,7 @@ paths:
           application/json:
             Fn::Sub: |-
               {
-                "input": "{\"bearerToken\": \"$input.params('Authorization').trim()\"}",
+                "input": "{\"bearerToken\": \"$util.escapeJavaScript($input.params('Authorization').trim())\"}",
                 "stateMachineArn": "${NinoIssueCredentialStateMachine.Arn}"
               }
         responses:

--- a/integration-tests/api-gateway/check/check-happy.test.ts
+++ b/integration-tests/api-gateway/check/check-happy.test.ts
@@ -60,4 +60,30 @@ describe("Given the session and NINO is valid", () => {
     const checkData = check.status;
     expect(checkData).toEqual(200);
   });
+
+  it("should 500 when provided with JS in the session header", async () => {
+    const maliciousSessionId = `<script>alert('Attack!');</script>`;
+    const check = await checkEndpoint(
+      {
+        "session-id": maliciousSessionId,
+        "txma-audit-encoded": "test encoded header",
+      },
+      NINO
+    );
+    expect(check.status).toEqual(500);
+  });
+
+  it("should 500 when provided with JS as a nino", async () => {
+    const session = await createSession();
+    const sessionData = await session.json();
+    const maliciousNino = `<script>alert('Attack!');</script>`;
+    const check = await checkEndpoint(
+      {
+        "session-id": sessionData.session_id,
+        "txma-audit-encoded": "test encoded header",
+      },
+      maliciousNino
+    );
+    expect(check.status).toEqual(500);
+  });
 });


### PR DESCRIPTION
## Proposed changes

### What changed and why
Added `$util.escapeJavaScript` to all the bits that in OpenAPI spec that come from user input.

https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html

### Issue tracking
- [OJ-2610](https://govukverify.atlassian.net/browse/OJ-2610)

[OJ-2610]: https://govukverify.atlassian.net/browse/OJ-2610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ