### PR TITLE
OJ-2618: Audit event rule DLQ

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,7 @@ set -eu
 
 stack_name="${1:-}"
 common_stack_name="${2:-}"
-common_infra_stack_name="${3:-}"
+txma_stack_name="${3:-}"
 
 if ! [[ "$stack_name" ]]; then
   [[ $(aws sts get-caller-identity --query Arn --output text) =~ \/([^\/\.]+)\. ]] && user="${BASH_REMATCH[1]}" || exit
@@ -31,5 +31,5 @@ sam deploy --stack-name "$stack_name" \
   cri:deployment-source=manual \
   --parameter-overrides \
   ${common_stack_name:+CommonStackName=$common_stack_name} \
-  ${common_infra_stack_name:+CommonInfrastructureStackName=$common_infra_stack_name} \
+  ${txma_stack_name:+TxmaStackName=$txma_stack_name} \
   Environment=localdev

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,6 +4,7 @@ set -eu
 
 stack_name="${1:-}"
 common_stack_name="${2:-}"
+common_infra_stack_name="${3:-}"
 
 if ! [[ "$stack_name" ]]; then
   [[ $(aws sts get-caller-identity --query Arn --output text) =~ \/([^\/\.]+)\. ]] && user="${BASH_REMATCH[1]}" || exit
@@ -29,5 +30,5 @@ sam deploy --stack-name "$stack_name" \
   cri:application=Orange \
   cri:deployment-source=manual \
   --parameter-overrides \
-  ${common_stack_name:+CommonStackName=$common_stack_name} \
+  ${common_infra_stack_name:+CommonInfrastructureStackName=$common_infra_stack_name} \
   Environment=localdev

--- a/deploy.sh
+++ b/deploy.sh
@@ -30,5 +30,6 @@ sam deploy --stack-name "$stack_name" \
   cri:application=Orange \
   cri:deployment-source=manual \
   --parameter-overrides \
+  ${common_stack_name:+CommonStackName=$common_stack_name} \
   ${common_infra_stack_name:+CommonInfrastructureStackName=$common_infra_stack_name} \
   Environment=localdev

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1628,11 +1628,11 @@ Resources:
             - auditEventQueueName: !ImportValue "AuditEventQueueName"
           Id: AuditEventQueue
           InputPath: "$.detail"
-          DeadLetterConfig:
-            Arn: !If
+          DeadLetterConfig: !If
               - IsDevLikeEnvironment
               - !Ref AWS::NoValue
-              - Fn::ImportValue: !Sub "${CommonInfrastructureStackName}-AuditEventDLQArn"
+              - Arn: !ImportValue
+                  Fn::Sub: "${CommonInfrastructureStackName}-AuditEventDLQArn"
 
   EventBridgeStateMachineExecutionRole:
     Type: AWS::IAM::Role

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -22,10 +22,10 @@ Parameters:
     Type: String
     Default: common-cri-api
     Description: The name of the stack containing the common CRI lambdas/infra
-  CommonInfrastructureStackName:
+  TxmaStackName:
     Type: String
     Default: txma-infrastructure
-    Description: The name of the stack containing the common CRI infrastructure
+    Description: The name of the stack containing the common TxMA infrastructure
   CodeSigningConfigArn:
     Type: String
     Default: ""
@@ -1527,7 +1527,7 @@ Resources:
       KmsKeyIdentifier: !If
         - IsDevLikeEnvironment
         - !Ref AWS::NoValue
-        - Fn::ImportValue: !Sub "${CommonInfrastructureStackName}-AuditEventQueueEncryptionKeyArn"
+        - Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueEncryptionKeyArn
 
   ##################################################################
   #                                                                  #
@@ -1631,8 +1631,8 @@ Resources:
           DeadLetterConfig: !If
               - IsDevLikeEnvironment
               - !Ref AWS::NoValue
-              - Arn: !ImportValue
-                  Fn::Sub: "${CommonInfrastructureStackName}-AuditEventDLQArn"
+              - Arn:
+                  Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventDLQArn
 
   EventBridgeStateMachineExecutionRole:
     Type: AWS::IAM::Role

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -22,6 +22,10 @@ Parameters:
     Type: String
     Default: common-cri-api
     Description: The name of the stack containing the common CRI lambdas/infra
+  CommonInfrastructureStackName:
+    Type: String
+    Default: txma-infrastructure
+    Description: The name of the stack containing the common CRI infrastructure
   CodeSigningConfigArn:
     Type: String
     Default: ""
@@ -1521,9 +1525,9 @@ Resources:
     Properties:
       Name: !Sub ${AWS::StackName}-CheckHmrcEventBus
       KmsKeyIdentifier: !If
-          - IsDevLikeEnvironment
-          - !Ref AWS::NoValue
-          - !ImportValue txma-infrastructure-AuditEventQueueEncryptionKeyArn
+        - IsDevLikeEnvironment
+        - !Ref AWS::NoValue
+        - Fn::ImportValue: !Sub "${CommonInfrastructureStackName}-AuditEventQueueEncryptionKeyArn"
 
   ##################################################################
   #                                                                  #
@@ -1624,6 +1628,11 @@ Resources:
             - auditEventQueueName: !ImportValue "AuditEventQueueName"
           Id: AuditEventQueue
           InputPath: "$.detail"
+          DeadLetterConfig:
+            Arn: !If
+              - IsDevLikeEnvironment
+              - !Ref AWS::NoValue
+              - Fn::ImportValue: !Sub "${CommonInfrastructureStackName}-AuditEventDLQArn"
 
   EventBridgeStateMachineExecutionRole:
     Type: AWS::IAM::Role

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1625,7 +1625,8 @@ Resources:
       Targets:
         - Arn: !Sub
             - "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${auditEventQueueName}"
-            - auditEventQueueName: !ImportValue "AuditEventQueueName"
+            - auditEventQueueName:
+                Fn::ImportValue: !Sub  "${TxmaStackName}-AuditEventQueueName"
           Id: AuditEventQueue
           InputPath: "$.detail"
           DeadLetterConfig: !If


### PR DESCRIPTION
## Proposed changes

### What changed
- Added `DeadLetterConfig` for `TxMaAuditEventRule`
- Set `CommonInfrastructureStackName` as a parameter so we can easily point to custom stacks

### Why did it change

So that messages that fail to reach the Audit event queue reach the audit event dead letter queue

### Screenshots
<img width="1691" alt="Screenshot 2024-06-14 at 9 28 52 AM" src="https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/assets/40401118/2dd22cdf-2d22-465a-afe5-20751c55b44f">

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2618](https://govukverify.atlassian.net/browse/OJ-2618)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed



[OJ-2618]: https://govukverify.atlassian.net/browse/OJ-2618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ