### PR TITLE
OJ-2632: Adds custom metrics for response latency

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -139,6 +139,7 @@ Globals:
         NODE_OPTIONS: --enable-source-maps
         AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: true
+        POWERTOOLS_METRICS_NAMESPACE: !Ref CriIdentifier
         DT_CONNECTION_AUTH_TOKEN: !Sub
           - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}"
           - SecretArn: !FindInMap [Dynatrace, SecretArn, !Ref Environment]
@@ -1294,7 +1295,7 @@ Resources:
       FilterPattern: '{$.type = "ExecutionFailed"}'
       MetricTransformations:
         - MetricValue: "1"
-          MetricName: "NinoCheckStateMachine}-Error"
+          MetricName: "NinoCheckStateMachine-Error"
           MetricNamespace: !Sub "${AWS::StackName}/LogMessages"
 
   NinoCheckStateMachineAlarm:

--- a/lambdas/matching/src/matching-handler.ts
+++ b/lambdas/matching/src/matching-handler.ts
@@ -1,16 +1,20 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
-import { MatchEvent } from "./match-event";
-import { Context } from "aws-lambda";
 import { Logger } from "@aws-lambda-powertools/logger";
+import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
+import { Context } from "aws-lambda";
+import { MatchEvent } from "./match-event";
+import { MetricDimensions, MetricNames } from "./metric-types";
 
-const logger = new Logger();
+export const logger = new Logger();
+const metrics = new Metrics();
 
 export class MatchingHandler implements LambdaInterface {
   public async handler(
     event: MatchEvent,
     context: Context
-  ): Promise<{ status: string; body: string;  txn: string }> {
+  ): Promise<{ status: string; body: string; txn: string }> {
     try {
+      const requestStartTime = Date.now();
       const response = await fetch(event.apiURL, {
         method: "POST",
         headers: {
@@ -25,6 +29,13 @@ export class MatchingHandler implements LambdaInterface {
           nino: event.nino,
         }),
       });
+      const latency = captureResponseLatency(requestStartTime);
+      logger.info({
+        message: "API response received",
+        status: response.status,
+        "latency (ms)": latency,
+      });
+
       const txn = response.headers.get("x-amz-cf-id") ?? "";
       addLogEntry(event, txn, context);
       const contentType = response.headers.get("content-type");
@@ -58,9 +69,23 @@ export const lambdaHandler = handlerClass.handler.bind(handlerClass);
 function addLogEntry(event: MatchEvent, txn: string | null, context: Context) {
   logger.appendKeys({
     govuk_signin_journey_id: event.user.govuk_signin_journey_id,
-    txn: txn
+    txn: txn,
   });
   logger.info(
     `${context.functionName} invoked with government journey id: ${event.user.govuk_signin_journey_id}`
   );
+}
+
+function captureResponseLatency(start: number): number {
+  const latency = Date.now() - start;
+
+  const singleMetric = metrics.singleMetric();
+  singleMetric.addDimension(MetricDimensions.HTTP, "MatchingHandler");
+  singleMetric.addMetric(
+    MetricNames.ResponseLatency,
+    MetricUnits.Milliseconds,
+    latency
+  );
+
+  return latency;
 }

--- a/lambdas/matching/src/matching-handler.ts
+++ b/lambdas/matching/src/matching-handler.ts
@@ -32,6 +32,7 @@ export class MatchingHandler implements LambdaInterface {
       const latency = captureResponseLatency(requestStartTime);
       logger.info({
         message: "API response received",
+        url: event.apiURL,
         status: response.status,
         "latency (ms)": latency,
       });

--- a/lambdas/matching/src/matching-handler.ts
+++ b/lambdas/matching/src/matching-handler.ts
@@ -14,7 +14,7 @@ export class MatchingHandler implements LambdaInterface {
     context: Context
   ): Promise<{ status: string; body: string; txn: string }> {
     try {
-      const requestStartTime = Date.now();
+      const requestStartTime = Math.floor(performance.now());
       const response = await fetch(event.apiURL, {
         method: "POST",
         headers: {
@@ -34,7 +34,7 @@ export class MatchingHandler implements LambdaInterface {
         message: "API response received",
         url: event.apiURL,
         status: response.status,
-        "latency (ms)": latency,
+        latencyInMs: latency,
       });
 
       const txn = response.headers.get("x-amz-cf-id") ?? "";
@@ -78,7 +78,7 @@ function addLogEntry(event: MatchEvent, txn: string | null, context: Context) {
 }
 
 function captureResponseLatency(start: number): number {
-  const latency = Date.now() - start;
+  const latency = Math.floor(performance.now()) - start;
 
   const singleMetric = metrics.singleMetric();
   singleMetric.addDimension(MetricDimensions.HTTP, "MatchingHandler");

--- a/lambdas/matching/src/metric-types.ts
+++ b/lambdas/matching/src/metric-types.ts
@@ -1,0 +1,7 @@
+export const MetricDimensions = {
+  HTTP: "HTTP",
+};
+
+export const MetricNames = {
+  ResponseLatency: "ResponseLatency",
+};

--- a/lambdas/matching/tests/matching-handler.test.ts
+++ b/lambdas/matching/tests/matching-handler.test.ts
@@ -1,18 +1,47 @@
-import { MatchingHandler } from "../src/matching-handler";
+import { MatchingHandler, logger } from "../src/matching-handler";
 import { MatchEvent } from "../src/match-event";
 import { Context } from "aws-lambda";
 
+jest.mock("@aws-lambda-powertools/logger", () => ({
+  Logger: jest.fn().mockImplementation(() => ({
+    info: jest.fn(),
+    error: jest.fn(),
+    appendKeys: jest.fn(),
+  })),
+}));
+
 describe("matching-handler", () => {
+  let testEvent: MatchEvent;
+
   beforeEach(() => {
+    global.fetch = jest.fn();
+    testEvent = {
+      sessionId: "12346",
+      nino: "AA000003D",
+      userDetails: {
+        firstName: "Jim",
+        lastName: "Ferguson",
+        dob: "1948-04-23",
+        nino: "AA000003D",
+      },
+      userAgent: "govuk-one-login",
+      apiURL:
+        "https://test-api.service.hmrc.gov.uk/individuals/authentication/authenticator/match",
+      oAuthToken: "123",
+      user: { govuk_signin_journey_id: "test-government-journey-id" },
+    } as MatchEvent;
+  });
+
+  afterEach(() => {
     jest.clearAllMocks();
     jest.resetAllMocks();
   });
 
   it("should return a matching response for a given nino and user", async () => {
-    global.fetch = jest.fn();
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       headers: {
-        get: jest.fn()
+        get: jest
+          .fn()
           .mockReturnValueOnce("mock-txn")
           .mockReturnValueOnce("application/json"),
       },
@@ -24,23 +53,10 @@ describe("matching-handler", () => {
       }),
       status: 200,
     });
+
     const matchingHandler = new MatchingHandler();
-    const event = {
-      sessionId: "12346",
-      nino: "AA000003D",
-      userDetails: {
-        firstName: "Jim",
-        lastName: "Ferguson",
-        dob: "1948-04-23",
-        nino: "AA000003D",
-      },
-      userAgent: "govuk-one-login",
-      apiURL:
-        "https://test-api.service.hmrc.gov.uk/individuals/authentication/authenticator/match",
-      oAuthToken: "123",
-      user: { govuk_signin_journey_id: "test-government-journey-id" },
-    } as MatchEvent;
-    const result = await matchingHandler.handler(event, {} as Context);
+    const result = await matchingHandler.handler(testEvent, {} as Context);
+
     expect(result.status).toBe("200");
     expect(result.body).toStrictEqual({
       firstName: "Jim",
@@ -48,70 +64,57 @@ describe("matching-handler", () => {
       dateOfBirth: "1948-04-23",
       nino: "AA000003D",
     });
-    expect(result.txn).toStrictEqual("mock-txn")
+    expect(result.txn).toStrictEqual("mock-txn");
   });
+
   it("should return text when content type is not json", async () => {
-    global.fetch = jest.fn();
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       headers: {
-        get: jest.fn()
-          .mockReturnValueOnce("mock-txn")
-          .mockReturnValueOnce(""),
+        get: jest.fn().mockReturnValueOnce("mock-txn").mockReturnValueOnce(""),
       },
       text: jest.fn().mockResolvedValueOnce("Test Text"),
       status: 200,
     });
+
     const matchingHandler = new MatchingHandler();
-    const event = {
-      sessionId: "12346",
-      nino: "AA000003D",
-      userDetails: {
-        firstName: "Jim",
-        lastName: "Ferguson",
-        dob: "1948-04-23",
-        nino: "AA000003D",
-      },
-      userAgent: "govuk-one-login",
-      apiURL:
-        "https://test-api.service.hmrc.gov.uk/individuals/authentication/authenticator/match",
-      oAuthToken: "123",
-      user: { govuk_signin_journey_id: "test-government-journey-id" },
-    } as MatchEvent;
-    const result = await matchingHandler.handler(event, {} as Context);
+    const result = await matchingHandler.handler(testEvent, {} as Context);
+
     expect(result.status).toBe("200");
     expect(result.body).toStrictEqual("Test Text");
-    expect(result.txn).toStrictEqual("mock-txn")
+    expect(result.txn).toStrictEqual("mock-txn");
   });
 
   it("should return an error message when has no content-type and has no body", async () => {
-    global.fetch = jest.fn();
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       headers: {
-        get: jest.fn()
-          .mockReturnValueOnce("mock-txn")
-          .mockReturnValueOnce(""),
+        get: jest.fn().mockReturnValueOnce("mock-txn").mockReturnValueOnce(""),
       },
       status: 200,
     });
     const matchingHandler = new MatchingHandler();
-    const event = {
-      sessionId: "12346",
-      nino: "AA000003D",
-      userDetails: {
-        firstName: "Jim",
-        lastName: "Ferguson",
-        dob: "1948-04-23",
-        nino: "AA000003D",
-      },
-      userAgent: "govuk-one-login",
-      apiURL:
-        "https://test-api.service.hmrc.gov.uk/individuals/authentication/authenticator/match",
-      oAuthToken: "123",
-      user: { govuk_signin_journey_id: "test-government-journey-id" },
-    } as MatchEvent;
-
     await expect(
-      matchingHandler.handler(event, {} as Context)
+      matchingHandler.handler(testEvent, {} as Context)
     ).rejects.toThrow();
+  });
+
+  it("should log API latency", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      headers: {
+        get: jest.fn().mockReturnValueOnce("mock-txn").mockReturnValueOnce(""),
+      },
+      text: jest.fn().mockResolvedValueOnce("Test Text"),
+      status: 200,
+    });
+
+    const matchingHandler = new MatchingHandler();
+    await matchingHandler.handler(testEvent, {} as Context);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "API response received",
+        status: 200,
+        "latency (ms)": expect.anything(),
+      })
+    );
   });
 });

--- a/lambdas/matching/tests/matching-handler.test.ts
+++ b/lambdas/matching/tests/matching-handler.test.ts
@@ -114,7 +114,7 @@ describe("matching-handler", () => {
         message: "API response received",
         url: testEvent.apiURL,
         status: 200,
-        "latency (ms)": expect.anything(),
+        latencyInMs: expect.anything(),
       })
     );
   });

--- a/lambdas/matching/tests/matching-handler.test.ts
+++ b/lambdas/matching/tests/matching-handler.test.ts
@@ -112,6 +112,7 @@ describe("matching-handler", () => {
     expect(logger.info).toHaveBeenCalledWith(
       expect.objectContaining({
         message: "API response received",
+        url: testEvent.apiURL,
         status: 200,
         "latency (ms)": expect.anything(),
       })


### PR DESCRIPTION
## Proposed changes

### What changed

Added custom metrics and info log for response latency in the matching lambda.

### Why did it change

This allows us to separate the response times of third parties (or stubs) from the overall response times. 

DT board to follow once the metric has been merged.

### Screenshots

![image](https://github.com/user-attachments/assets/bc55cb9b-e843-45c2-9335-f210a4ed5891)
![image](https://github.com/user-attachments/assets/7e83d96e-0c8a-472c-a907-9c57e92143ac)

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2632](https://govukverify.atlassian.net/browse/OJ-2632)

## Checklists

### Environment variables or secrets

- [ ] Documented in the [README](./blob/main/README.md)
- [x] Added to deployment repository
- [ ] Added to local startup repository


[OJ-2632]: https://govukverify.atlassian.net/browse/OJ-2632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ