### PR TITLE
OJ-2609: Removing PutEvent alarm (Will be reverted)

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1844,27 +1844,6 @@ Resources:
         - Name: EventBusName
           Value: !Ref CheckHmrcEventBus
 
-  CheckHmrcPutEventAlarm:
-    Condition: "DeployAlarms"
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      InsufficientDataActions: []
-      AlarmDescription: !Sub "${AWS::StackName}-${Environment} PutEvents (PutEvents Failed) 4 or more requests in the last hour. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-CheckHmrcEventBus-PutEventsApproximateFailedCount-alarm"
-      MetricName: PutEventsApproximateFailedCount
-      ComparisonOperator: GreaterThanThreshold
-      Namespace: "AWS/Events"
-      Statistic: Sum
-      DatapointsToAlarm: 1
-      EvaluationPeriods: 1
-      Period: 3600
-      Threshold: 3
-      TreatMissingData: notBreaching
-
   ###############################################################################
 
   AuditEventStateMachine:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Removing PutEvent alarm to delete it in all the stacks, will then revert this to deploy the alarm with the new resource name

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
I have renamed the PutEvents Alarm resource, this is causing an issue in CF as it is not deleting the previous alarm .. 'already exists'.
Removing it in this PR and once it's deployed and removed the alarm, will revert this change to redeploy it. 

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2609](https://govukverify.atlassian.net/browse/OJ-2609)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
