### PR TITLE
OJ 2721 kid

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,7 +127,8 @@
         "A84nU-ZLSFNs8VI6VXkunvWwRx-T3gAXvw2JPRrP78c",
         "HMRCBearerToken",
         "goodToken",
-        "badToken"
+        "badToken",
+        "02ba5dbd2a3664670bf5c4689a9f8e014fe2c019209c9e5db7641a2b2a4bc7a8"
       ]
     }
   ],

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -96,13 +96,6 @@ Mappings:
       VcIssued: VC_ISSUED
       End: END
       Abandoned: ABANDONED
-    Source:
-      dev: review-hc.dev.account.gov.uk
-      localdev: review-hc.localdev.account.gov.uk
-      build: review-hc.build.account.gov.uk
-      staging: review-hc.staging.account.gov.uk
-      integration: review-hc.integration.account.gov.uk
-      production: review-hc.production.account.gov.uk
 
   PlatformConfiguration:
     dev:
@@ -115,6 +108,20 @@ Mappings:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
     production:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+
+  EnvironmentConfiguration:
+    localdev:
+      DOMAINNAME: review-hc.localdev.account.gov.uk
+    dev: 
+      DOMAINNAME: review-hc.dev.account.gov.uk
+    build:
+      DOMAINNAME: review-hc.build.account.gov.uk
+    staging:
+      DOMAINNAME: review-hc.staging.account.gov.uk
+    integration:
+      DOMAINNAME: review-hc.integration.account.gov.uk
+    production:
+      DOMAINNAME: review-hc.production.account.gov.uk
 
 Globals:
   Function:
@@ -495,8 +502,7 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-JwtSigner"
-          # TODO
-          DNS_SUFFIX: !FindInMap [Audit, Source, !Ref Environment]
+          DOMAIN_NAME: !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME] 
 
   JwtSignerFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1212,7 +1218,7 @@ Resources:
         SsmParametersFunction: !Ref SsmParametersFunction
         OTGFunction: !Ref OTGFunction
         CheckHmrcEventBus: !Ref CheckHmrcEventBus
-        CheckHmrcEventBusSource: !FindInMap [Audit, Source, !Ref Environment]
+        CheckHmrcEventBusSource: !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
         AuditEventNameResponseReceived:
           !FindInMap [Audit, EventName, ResponseReceived]
         AuditEventNameRequestSent: !FindInMap [Audit, EventName, RequestSent]
@@ -1334,7 +1340,7 @@ Resources:
         CommonStackName: !Ref CommonStackName
         SsmParametersFunction: !Ref SsmParametersFunction
         CheckHmrcEventBus: !Ref CheckHmrcEventBus
-        CheckHmrcEventBusSource: !FindInMap [Audit, Source, !Ref Environment]
+        CheckHmrcEventBusSource: !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
         AuditEventNameAbandoned: !FindInMap [Audit, EventName, Abandoned]
       Logging:
         Destinations:
@@ -1433,7 +1439,7 @@ Resources:
         JwtSignerFunction: !GetAtt JwtSignerFunction.Arn
         SsmParametersFunction: !Ref SsmParametersFunction
         CheckHmrcEventBus: !Ref CheckHmrcEventBus
-        CheckHmrcEventBusSource: !FindInMap [Audit, Source, !Ref Environment]
+        CheckHmrcEventBusSource: !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
         AuditEventNameVcIssued: !FindInMap [Audit, EventName, VcIssued]
         AuditEventNameEnd: !FindInMap [Audit, EventName, End]
       Logging:
@@ -1575,7 +1581,7 @@ Resources:
       State: ENABLED
       EventPattern:
         source:
-          - !FindInMap [Audit, Source, !Ref Environment]
+          - !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
         detail-type:
           - !FindInMap [Audit, EventName, ResponseReceived]
       Targets:
@@ -1590,7 +1596,7 @@ Resources:
       State: ENABLED
       EventPattern:
         source:
-          - !FindInMap [Audit, Source, !Ref Environment]
+          - !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
         detail-type:
           - !FindInMap [Audit, EventName, RequestSent]
       Targets:
@@ -1605,7 +1611,7 @@ Resources:
       State: ENABLED
       EventPattern:
         source:
-          - !FindInMap [Audit, Source, !Ref Environment]
+          - !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
         detail-type:
           - !FindInMap [Audit, EventName, VcIssued]
       Targets:
@@ -1620,7 +1626,7 @@ Resources:
       State: ENABLED
       EventPattern:
         source:
-          - !FindInMap [Audit, Source, !Ref Environment]
+          - !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
         detail-type:
           - !FindInMap [Audit, EventName, End]
       Targets:
@@ -1635,7 +1641,7 @@ Resources:
       State: ENABLED
       EventPattern:
         source:
-          - !FindInMap [Audit, Source, !Ref Environment]
+          - !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
         detail-type:
           - !FindInMap [Audit, EventName, Abandoned]
       Targets:
@@ -1651,7 +1657,7 @@ Resources:
       State: ENABLED
       EventPattern:
         source:
-          - !FindInMap [Audit, Source, !Ref Environment]
+          - !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
         detail:
           timestamp: [{ "exists": true }]
           event_timestamp_ms: [{ "exists": true }]
@@ -1878,7 +1884,7 @@ Resources:
         CredentialSubjectFunctionArn: !GetAtt CredentialSubjectFunction.Arn
         EpochTimeArn: !GetAtt EpochTimeFunction.Arn
         CheckHmrcEventBus: !Ref CheckHmrcEventBus
-        CheckHmrcEventBusSource: !FindInMap [Audit, Source, !Ref Environment]
+        CheckHmrcEventBusSource: !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
       Logging:
         Destinations:
           - CloudWatchLogsLogGroup:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -112,7 +112,7 @@ Mappings:
   EnvironmentConfiguration:
     localdev:
       DOMAINNAME: review-hc.localdev.account.gov.uk
-    dev: 
+    dev:
       DOMAINNAME: review-hc.dev.account.gov.uk
     build:
       DOMAINNAME: review-hc.build.account.gov.uk
@@ -502,7 +502,7 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-JwtSigner"
-          DOMAIN_NAME: !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME] 
+          DOMAIN_NAME: !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
 
   JwtSignerFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -495,6 +495,8 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-JwtSigner"
+          # TODO
+          DNS_SUFFIX: !FindInMap [Audit, Source, !Ref Environment]
 
   JwtSignerFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
+++ b/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
@@ -275,9 +275,7 @@ describe("Nino Check Hmrc Issue Credential", () => {
         expect(header).toEqual({
           typ: "JWT",
           alg: "ES256",
-          kid: expect.stringContaining(
-            "did:web:review-hc.localdev.account.gov.uk#"
-          ),
+          kid: `did:web:review-hc.${environment}.account.gov.uk#${hash}`,
         });
 
         const result = await aVcWithFailedCheckDetailsRecordCheck();

--- a/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
+++ b/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
@@ -104,10 +104,6 @@ describe("Nino Check Hmrc Issue Credential", () => {
         "Bearer identity-check passed"
       );
 
-      const currentCredentialKmsSigningKeyId = await getSSMParameter(
-        `/${output.CommonStackName}/verifiableCredentialKmsSigningKeyId`
-      );
-
       const token = JSON.parse(startExecutionResult.output as string);
 
       const [headerEncoded, payloadEncoded, _] = token.jwt.split(".");
@@ -117,7 +113,10 @@ describe("Nino Check Hmrc Issue Credential", () => {
       expect(header).toEqual({
         typ: "JWT",
         alg: "ES256",
-        kid: currentCredentialKmsSigningKeyId,
+        // TODO these run in other envs
+        kid: expect.stringContaining(
+          "did:web:review-hc.localdev.account.gov.uk#"
+        ),
       });
 
       const result = await aVcWithCheckDetails();
@@ -177,10 +176,6 @@ describe("Nino Check Hmrc Issue Credential", () => {
         "Bearer identity-check failed"
       );
 
-      const currentCredentialKmsSigningKeyId = await getSSMParameter(
-        `/${output.CommonStackName}/verifiableCredentialKmsSigningKeyId`
-      );
-
       const token = JSON.parse(startExecutionResult.output as string);
 
       const [headerEncoded, payloadEncoded, _] = token.jwt.split(".");
@@ -190,7 +185,9 @@ describe("Nino Check Hmrc Issue Credential", () => {
       expect(header).toEqual({
         typ: "JWT",
         alg: "ES256",
-        kid: currentCredentialKmsSigningKeyId,
+        kid: expect.stringContaining(
+          "did:web:review-hc.localdev.account.gov.uk#"
+        ),
       });
 
       const result = await aVcWithFailedCheckDetailsAndCi();
@@ -220,10 +217,6 @@ describe("Nino Check Hmrc Issue Credential", () => {
         "Bearer record-check passed"
       );
 
-      const currentCredentialKmsSigningKeyId = await getSSMParameter(
-        `/${output.CommonStackName}/verifiableCredentialKmsSigningKeyId`
-      );
-
       const token = JSON.parse(startExecutionResult.output as string);
 
       const [headerEncoded, payloadEncoded, _] = token.jwt.split(".");
@@ -233,7 +226,9 @@ describe("Nino Check Hmrc Issue Credential", () => {
       expect(header).toEqual({
         typ: "JWT",
         alg: "ES256",
-        kid: currentCredentialKmsSigningKeyId,
+        kid: expect.stringContaining(
+          "did:web:review-hc.localdev.account.gov.uk#"
+        ),
       });
 
       const result = await aVcWithCheckDetailsDataCheck();
@@ -264,10 +259,6 @@ describe("Nino Check Hmrc Issue Credential", () => {
           "Bearer record-check failed"
         );
 
-        const currentCredentialKmsSigningKeyId = await getSSMParameter(
-          `/${output.CommonStackName}/verifiableCredentialKmsSigningKeyId`
-        );
-
         const token = JSON.parse(startExecutionResult.output as string);
 
         const [headerEncoded, payloadEncoded, _] = token.jwt.split(".");
@@ -277,7 +268,9 @@ describe("Nino Check Hmrc Issue Credential", () => {
         expect(header).toEqual({
           typ: "JWT",
           alg: "ES256",
-          kid: currentCredentialKmsSigningKeyId,
+          kid: expect.stringContaining(
+            "did:web:review-hc.localdev.account.gov.uk#"
+          ),
         });
 
         const result = await aVcWithFailedCheckDetailsRecordCheck();
@@ -452,7 +445,7 @@ describe("Nino Check Hmrc Issue Credential", () => {
     clientSessionId: "252561a2-c6ef-47e7-87ab-93891a2a6a41",
     persistentSessionId: "156714ef-f9df-48c2-ada8-540e7bce44f7",
     evidenceRequest,
-    txn: "mock-txn"
+    txn: "mock-txn",
   });
 
   const ninoCheckPassedData = async (

--- a/lambdas/jwt-signer/src/jwt-signer-handler.ts
+++ b/lambdas/jwt-signer/src/jwt-signer-handler.ts
@@ -27,9 +27,9 @@ export class JwtSignerHandler implements LambdaInterface {
 
     const parsedHeader = JSON.parse(event.header) as SignerHeader;
 
-    if (event.kid) {
+    if (parsedHeader.kid) {
       parsedHeader.kid = `did:web:${process.env.DNS_SUFFIX}#${this.getHashedKid(
-        event.kid
+        parsedHeader.kid
       )}`;
     }
 
@@ -56,7 +56,7 @@ export class JwtSignerHandler implements LambdaInterface {
   ): Promise<Uint8Array> {
     const payload = Buffer.from(`${jwtHeader}.${jwtPayload}`);
 
-    const signage: SignageType = this.checkSize(payload)
+    const signage: SignageType = this.isLargeSize(payload)
       ? { message: this.hashInput(payload), type: MessageType.DIGEST }
       : { message: payload, type: MessageType.RAW };
 
@@ -96,7 +96,7 @@ export class JwtSignerHandler implements LambdaInterface {
     return Buffer.from(hash).toString("hex");
   };
 
-  private checkSize = (message: Buffer): boolean => message.length >= 4096;
+  private isLargeSize = (message: Buffer): boolean => message.length >= 4096;
 }
 
 const handlerClass = new JwtSignerHandler(

--- a/lambdas/jwt-signer/src/jwt-signer-handler.ts
+++ b/lambdas/jwt-signer/src/jwt-signer-handler.ts
@@ -28,9 +28,9 @@ export class JwtSignerHandler implements LambdaInterface {
     const parsedHeader = JSON.parse(event.header) as SignerHeader;
 
     if (parsedHeader.kid) {
-      parsedHeader.kid = `did:web:${process.env.DNS_SUFFIX}#${this.getHashedKid(
-        parsedHeader.kid
-      )}`;
+      parsedHeader.kid = `did:web:${
+        process.env.DOMAIN_NAME
+      }#${this.getHashedKid(parsedHeader.kid)}`;
     }
 
     const header = base64url.encode(JSON.stringify(parsedHeader));

--- a/lambdas/jwt-signer/src/jwt-signer-handler.ts
+++ b/lambdas/jwt-signer/src/jwt-signer-handler.ts
@@ -2,7 +2,7 @@ import { LambdaInterface } from "@aws-lambda-powertools/commons";
 import { createHash } from "crypto";
 import sigFormatter from "ecdsa-sig-formatter";
 import { fromEnv } from "@aws-sdk/credential-providers";
-import { SignerPayLoad } from "./signer-payload";
+import { SignerPayLoad, SignerHeader } from "./signer-payload";
 import { SignageType } from "./signage-type";
 import { base64url } from "jose";
 import {
@@ -24,7 +24,16 @@ export class JwtSignerHandler implements LambdaInterface {
     context: Context
   ): Promise<string> {
     logHelper.logEntry(context.functionName, event.govJourneyId);
-    const header = base64url.encode(event.header);
+
+    const parsedHeader = JSON.parse(event.header) as SignerHeader;
+
+    if (event.kid) {
+      parsedHeader.kid = `did:web:${process.env.DNS_SUFFIX}#${this.getHashedKid(
+        event.kid
+      )}`;
+    }
+
+    const header = base64url.encode(JSON.stringify(parsedHeader));
     const payload = base64url.encode(event.claimsSet);
 
     const response = await this.signWithKms(
@@ -80,6 +89,12 @@ export class JwtSignerHandler implements LambdaInterface {
 
   private hashInput = (input: Buffer): Uint8Array =>
     createHash("sha256").update(input).digest();
+
+  private getHashedKid = (keyId: string): string => {
+    const kidBytes = Buffer.from(keyId, "utf8");
+    const hash = createHash("sha256").update(kidBytes).digest();
+    return Buffer.from(hash).toString("hex");
+  };
 
   private checkSize = (message: Buffer): boolean => message.length >= 4096;
 }

--- a/lambdas/jwt-signer/src/signer-payload.ts
+++ b/lambdas/jwt-signer/src/signer-payload.ts
@@ -4,3 +4,9 @@ export type SignerPayLoad = {
   claimsSet: string;
   govJourneyId: string;
 };
+
+export type SignerHeader = {
+  kid: string;
+  typ: string;
+  alg: string;
+};

--- a/lambdas/jwt-signer/src/signer-payload.ts
+++ b/lambdas/jwt-signer/src/signer-payload.ts
@@ -6,7 +6,7 @@ export type SignerPayLoad = {
 };
 
 export type SignerHeader = {
-  kid: string;
-  typ: string;
+  kid?: string;
+  type: string;
   alg: string;
 };

--- a/lambdas/jwt-signer/tests/test-data.ts
+++ b/lambdas/jwt-signer/tests/test-data.ts
@@ -7,10 +7,21 @@ interface Address {
   validFrom: string;
 }
 
+const dnsSuffix = process.env.DNS_SUFFIX!;
+
 export const kid = "0976c11e-8ef3-4659-b7f2-ee0b842b85bd";
+
+const hashedKid =
+  "02ba5dbd2a3664670bf5c4689a9f8e014fe2c019209c9e5db7641a2b2a4bc7a8";
 
 export const header = {
   kid,
+  type: "JWT",
+  alg: "ES256",
+};
+
+export const jwtHeader = {
+  kid: `did:web:${dnsSuffix}#${hashedKid}`,
   type: "JWT",
   alg: "ES256",
 };
@@ -56,7 +67,7 @@ export const claimsSet = {
   iat: 1697516406,
 };
 
-const generateFixedString = (length: number = 10) =>
+const generateFixedString = (length: number = 30) =>
   "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".substring(
     0,
     length

--- a/lambdas/jwt-signer/tests/test-data.ts
+++ b/lambdas/jwt-signer/tests/test-data.ts
@@ -7,7 +7,7 @@ interface Address {
   validFrom: string;
 }
 
-const dnsSuffix = process.env.DNS_SUFFIX!;
+const dnsSuffix = process.env.DOMAIN_NAME!;
 
 export const kid = "0976c11e-8ef3-4659-b7f2-ee0b842b85bd";
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added the Hashed kid in the JWT header

### Why did it change

Due to the [RFC 71](https://github.com/govuk-one-login/architecture/blob/c3e867fbd746237ec8715760e3995782e319231f/rfc/0071-opque-kid-claims.md#kms-key-aliases:~:text=When%20producing%20a%20hash%2C%20we%20need%20to%20ensure%20we%20are%20using%20the%20underlying%20KMS%20Key%20ID%20and%20not%20the%20alias) points out that this should not be a hash of the KMS Key ID

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2721](https://govukverify.atlassian.net/browse/OJ-2721)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2721]: https://govukverify.atlassian.net/browse/OJ-2721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ