### PR TITLE
OJ-2773: Add TTL to `user-attempts` and `nino-users` table

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1126,6 +1126,9 @@ Resources:
           KeyType: HASH
         - AttributeName: timestamp
           KeyType: RANGE
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
 
   NinoUsersTable:
     Type: AWS::DynamoDB::Table
@@ -1138,6 +1141,9 @@ Resources:
       KeySchema:
         - AttributeName: sessionId
           KeyType: HASH
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
 
   CheckSessionStateMachine:
     Type: AWS::Serverless::StateMachine

--- a/integration-tests/step-functions/mocked/check-session/check-session.test.ts
+++ b/integration-tests/step-functions/mocked/check-session/check-session.test.ts
@@ -30,7 +30,7 @@ describe("check-session", () => {
         responseStepFunction
       );
       expect(results[0].stateExitedEventDetails?.output).toBe(
-        '{"status":"SESSION_OK","txmaAuditHeader":"{}","clientId":"exampleClientId","userAuditInfo":{"govuk_signin_journey_id":"252561a2-c6ef-47e7-87ab-93891a2a6a41","user_id":"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2","persistent_session_id":"156714ef-f9df-48c2-ada8-540e7bce44f7","session_id":"12345","ip_address":"51.149.8.29"}}'
+        '{"status":"SESSION_OK","txmaAuditHeader":"{}","sessionExpiry":"2695828259","clientId":"exampleClientId","userAuditInfo":{"govuk_signin_journey_id":"252561a2-c6ef-47e7-87ab-93891a2a6a41","user_id":"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2","persistent_session_id":"156714ef-f9df-48c2-ada8-540e7bce44f7","session_id":"12345","ip_address":"51.149.8.29"}}'
       );
     });
     it("it should pass when a valid session exists and persistent_session_id is absent", async () => {
@@ -49,7 +49,7 @@ describe("check-session", () => {
         responseStepFunction
       );
       expect(results[0].stateExitedEventDetails?.output).toBe(
-        '{"status":"SESSION_OK","txmaAuditHeader":"{}","clientId":"exampleClientId","userAuditInfo":{"govuk_signin_journey_id":"252561a2-c6ef-47e7-87ab-93891a2a6a41","user_id":"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2","session_id":"12345","ip_address":"51.149.8.29"}}'
+        '{"status":"SESSION_OK","txmaAuditHeader":"{}","sessionExpiry":"2695828259","clientId":"exampleClientId","userAuditInfo":{"govuk_signin_journey_id":"252561a2-c6ef-47e7-87ab-93891a2a6a41","user_id":"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2","session_id":"12345","ip_address":"51.149.8.29"}}'
       );
     });
   });

--- a/integration-tests/step-functions/mocked/nino-check/MockConfigFile.json
+++ b/integration-tests/step-functions/mocked/nino-check/MockConfigFile.json
@@ -217,7 +217,7 @@
     "CheckSessionSuccess": {
       "0": {
         "Return": {
-          "Output": "{\"status\":\"SESSION_OK\",\"userAuditInfo\":{\"govuk_signin_journey_id\":\"252561a2-c6ef-47e7-87ab-93891a2a6a41\",\"user_id\":\"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2\",\"persistent_session_id\":\"156714ef-f9df-48c2-ada8-540e7bce44f7\",\"session_id\":\"12345\",\"ip_address\":\"51.149.8.29\"},\"clientId\":\"exampleClientId\", \"txmaAuditHeader\": \"test encoded header\"}"
+          "Output": "{\"status\":\"SESSION_OK\",\"userAuditInfo\":{\"govuk_signin_journey_id\":\"252561a2-c6ef-47e7-87ab-93891a2a6a41\",\"user_id\":\"urn:fdc:gov.uk:2022:da580c9d-cdf9-4961-afde-233249db04d2\",\"persistent_session_id\":\"156714ef-f9df-48c2-ada8-540e7bce44f7\",\"session_id\":\"12345\",\"ip_address\":\"51.149.8.29\"},\"clientId\":\"exampleClientId\", \"txmaAuditHeader\": \"test encoded header\", \"sessionExpiry\": \"2695828259\"}"
         }
       }
     },

--- a/step-functions/check_session.asl.json
+++ b/step-functions/check_session.asl.json
@@ -165,7 +165,8 @@
 				"status": "SESSION_OK",
 				"clientId.$": "$[0].sessionQuery.items[0].clientId.S",
 				"userAuditInfo.$": "$[0].UserSessionInfo",
-				"txmaAuditHeader.$": "$[1].TxmaAuditHeader.value"
+				"txmaAuditHeader.$": "$[1].TxmaAuditHeader.value",
+        "sessionExpiry.$": "$[0].sessionQuery.items[0].expiryDate.N"
 			}
 		},
 		"Err: No sessionId provided": {

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -333,6 +333,9 @@
           },
           "attempt": {
             "S": "PASS"
+          },
+          "ttl": {
+            "N.$": "$.sessionCheck.sessionExpiry"
           }
         }
       },
@@ -388,6 +391,9 @@
           },
           "attempt": {
             "S": "FAIL"
+          },
+          "ttl": {
+            "N.$": "$.sessionCheck.sessionExpiry"
           }
         }
       },
@@ -459,6 +465,9 @@
           },
           "nino": {
             "S.$": "$$.Execution.Input.nino"
+          },
+          "ttl": {
+            "N.$": "$.sessionCheck.sessionExpiry"
           }
         }
       },
@@ -501,6 +510,9 @@
           },
           "attempt": {
             "S": "FAIL"
+          },
+          "ttl": {
+            "N.$": "$.sessionCheck.sessionExpiry"
           }
         }
       },


### PR DESCRIPTION
## Proposed changes

### What changed
Added a TTL to the `user-attempts` and `nino-users` table. The TTL set is 2 hours.

### Why did it change
This was added because once sessions had expired, we did not remove the data from the database. This meant our DB will retain the records and continue to grow, taking up resources. The information stored in those tables are only required when the user is performing a NINO check, once they get a VC, the information is no longer needed. 

**Screenshot**
![image](https://github.com/user-attachments/assets/8563e133-6687-4c7a-9a9e-20441742563c)

### Issue tracking
- [OJ-2773](https://govukverify.atlassian.net/browse/OJ-2773)


[OJ-2773]: https://govukverify.atlassian.net/browse/OJ-2773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ