### PR TITLE
OJ-2788: Ignore case when searching for CI mappings

### DIFF
--- a/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
+++ b/integration-tests/step-functions/aws/nino_issue_credential/nino_issue_credential.test.ts
@@ -567,7 +567,7 @@ describe("Nino Check Hmrc Issue Credential", () => {
           timestamp: Date.now().toString(),
           attempt: "FAIL",
           status: 200,
-          text: "DOB does not match CID, First Name does not match CID",
+          text: "Nino does not match CID",
         },
       }
     );

--- a/lambdas/ci-mapping/src/ci-mapping-event-validator.ts
+++ b/lambdas/ci-mapping/src/ci-mapping-event-validator.ts
@@ -28,8 +28,18 @@ export const validateInputs = (event: CiMappingEvent) => {
     event.contraIndicatorReasonsMapping
   );
 
+  console.log("contraIndicationMapping", contraIndicationMapping);
+
+  console.log(
+    "allMappedHmrcErrors(contraIndicationMapping)",
+    allMappedHmrcErrors(contraIndicationMapping)
+  );
+
   const hmrcErrorIsNotMapped = (hmrcError: string) =>
-    !allMappedHmrcErrors(contraIndicationMapping).includes(hmrcError);
+    // Strict comparison
+    !allMappedHmrcErrors(contraIndicationMapping)
+      .map((mapping) => mapping.toUpperCase())
+      .includes(hmrcError.toUpperCase());
 
   const allHmrcErrorsUnMatched = hmrcErrors.every(hmrcErrorIsNotMapped);
   const someHmrcErrorsUnMatched = hmrcErrors.some(hmrcErrorIsNotMapped);
@@ -65,13 +75,13 @@ export const getContraIndicatorWithReason = (
 };
 
 const areCIsEqual = (reasonCi?: string, contraCi?: string): boolean =>
-  reasonCi?.trim() === contraCi?.trim();
+  reasonCi?.trim().toUpperCase() === contraCi?.trim().toUpperCase();
 
 const getContraIndicationMappingMapping = (
   contraIndicationMapping: string[]
 ): string[] => {
   if (contraIndicationMapping?.length) {
-    return contraIndicationMapping.map((ciString) => ciString.toUpperCase());
+    return contraIndicationMapping;
   }
   throw new Error(CONTRAINDICATION_MAPPINGS_ABSENT_ERROR);
 };
@@ -90,7 +100,7 @@ const getInputHmrcErrors = (hmrcErrors: string[] = []) => {
     throw new Error(HMRC_ERRORS_ABSENT);
   }
   return hmrcErrors.reduce((result, hmrcError) => {
-    return result.concat(convertInputToArray(hmrcError.toUpperCase()));
+    return result.concat(convertInputToArray(hmrcError));
   }, [] as string[]);
 };
 
@@ -104,11 +114,17 @@ const throwUnMatchedCIsAreDetectedError = (
   );
 
   const unMatchedCIsFromReasons = [...reasonsMap].filter(
-    (ci) => !contraMap.has(ci)
+    (reason) =>
+      ![...contraMap].some((ci) => ci.toUpperCase() === reason.toUpperCase())
   );
+
   const unMatchedCIsFromContraIndications = [...contraMap].filter(
-    (ci) => !reasonsMap.has(ci)
+    (ci) =>
+      ![...reasonsMap].some(
+        (reason) => reason.toUpperCase() === ci.toUpperCase()
+      )
   );
+
   const unMatchedCIs = [
     ...unMatchedCIsFromReasons,
     ...unMatchedCIsFromContraIndications,

--- a/lambdas/ci-mapping/src/ci-mapping-event-validator.ts
+++ b/lambdas/ci-mapping/src/ci-mapping-event-validator.ts
@@ -28,17 +28,9 @@ export const validateInputs = (event: CiMappingEvent) => {
     event.contraIndicatorReasonsMapping
   );
 
-  console.log("contraIndicationMapping", contraIndicationMapping);
-
-  console.log(
-    "allMappedHmrcErrors(contraIndicationMapping)",
-    allMappedHmrcErrors(contraIndicationMapping)
-  );
-
   const hmrcErrorIsNotMapped = (hmrcError: string) =>
-    // Strict comparison
     !allMappedHmrcErrors(contraIndicationMapping)
-      .map((mapping) => mapping.toUpperCase())
+      .toUpperCase()
       .includes(hmrcError.toUpperCase());
 
   const allHmrcErrorsUnMatched = hmrcErrors.every(hmrcErrorIsNotMapped);

--- a/lambdas/ci-mapping/src/ci-mapping-event-validator.ts
+++ b/lambdas/ci-mapping/src/ci-mapping-event-validator.ts
@@ -71,7 +71,7 @@ const getContraIndicationMappingMapping = (
   contraIndicationMapping: string[]
 ): string[] => {
   if (contraIndicationMapping?.length) {
-    return contraIndicationMapping;
+    return contraIndicationMapping.map((ciString) => ciString.toUpperCase());
   }
   throw new Error(CONTRAINDICATION_MAPPINGS_ABSENT_ERROR);
 };
@@ -90,7 +90,7 @@ const getInputHmrcErrors = (hmrcErrors: string[] = []) => {
     throw new Error(HMRC_ERRORS_ABSENT);
   }
   return hmrcErrors.reduce((result, hmrcError) => {
-    return result.concat(convertInputToArray(hmrcError));
+    return result.concat(convertInputToArray(hmrcError.toUpperCase()));
   }, [] as string[]);
 };
 

--- a/lambdas/ci-mapping/src/ci-mapping-handler.ts
+++ b/lambdas/ci-mapping/src/ci-mapping-handler.ts
@@ -38,15 +38,19 @@ const getCIsForHmrcErrors = (event: CiMappingEvent): Array<ContraIndicator> => {
   const contraIndicators = contraIndicationMapping?.flatMap((ci) => {
     const { mappedHmrcErrors, ciValue } = getHmrcErrsCiRecord(ci);
 
+    const normalizedMappedHmrcErrors = mappedHmrcErrors
+      .split(",")
+      .map((value) => value.trim().toUpperCase());
+
     return hmrcErrors
       .flatMap((hmrcError) => hmrcError)
       .filter((hmrcError) =>
-        mappedHmrcErrors
-          .split(",")
-          .map((value) => value.trim())
-          .includes(hmrcError)
+        normalizedMappedHmrcErrors.includes(hmrcError.trim().toUpperCase())
       )
-      .map((hmrcError) => ({ ci: ciValue.trim(), reason: hmrcError.trim() }));
+      .map((hmrcError) => ({
+        ci: ciValue.trim(),
+        reason: hmrcError.trim(),
+      }));
   });
 
   return getContraIndicatorWithReason(

--- a/lambdas/ci-mapping/tests/ci-mapping-handler.test.ts
+++ b/lambdas/ci-mapping/tests/ci-mapping-handler.test.ts
@@ -87,6 +87,7 @@ describe("ci-mapping-handler", () => {
       expect(result).toEqual([{ ci: "ci_2", reason: "ci_2 reason" }]);
     }
   );
+
   it.each(testCases)(
     "should return all ContraIndicator code and reason pairs for hmrc errors input [%j]",
     async (testCase: TestCase) => {
@@ -166,7 +167,25 @@ describe("ci-mapping-handler", () => {
     expect(result).toEqual([]);
   });
 
-  it("throws error, no matching hmrc_error for any ContraIndicationMapping", async () => {
+  it.only("throws error, no matching hmrc_error for any ContraIndicationMapping", async () => {
+    const contraIndicationMapping = ["error, aaaa:ci_4"];
+    const contraIndicatorReasonsMapping = [
+      { ci: "ci_4", reason: "ci_4 reason" },
+    ];
+
+    const event = {
+      contraIndicationMapping,
+      hmrcErrors: ["ERROR"],
+      contraIndicatorReasonsMapping,
+    } as CiMappingEvent;
+    const ciMappingHandler = new CiMappingHandler();
+
+    const result = await ciMappingHandler.handler(event, {} as Context);
+
+    expect(result).toEqual([{ ci: "ci_4", reason: "ci_4 reason" }]);
+  });
+
+  it.only("should not throw error, where hmrc_error is different case to ContraIndicationMapping", async () => {
     const event = {
       contraIndicationMapping,
       hmrcErrors: ["not-a-mapped-error"],

--- a/lambdas/ci-mapping/tests/ci-mapping-handler.test.ts
+++ b/lambdas/ci-mapping/tests/ci-mapping-handler.test.ts
@@ -167,7 +167,7 @@ describe("ci-mapping-handler", () => {
     expect(result).toEqual([]);
   });
 
-  it.only("throws error, no matching hmrc_error for any ContraIndicationMapping", async () => {
+  it("throws error, no matching hmrc_error for any ContraIndicationMapping", async () => {
     const contraIndicationMapping = ["error, aaaa:ci_4"];
     const contraIndicatorReasonsMapping = [
       { ci: "ci_4", reason: "ci_4 reason" },
@@ -185,7 +185,7 @@ describe("ci-mapping-handler", () => {
     expect(result).toEqual([{ ci: "ci_4", reason: "ci_4 reason" }]);
   });
 
-  it.only("should not throw error, where hmrc_error is different case to ContraIndicationMapping", async () => {
+  it("should not throw error, where hmrc_error is different case to ContraIndicationMapping", async () => {
     const event = {
       contraIndicationMapping,
       hmrcErrors: ["not-a-mapped-error"],


### PR DESCRIPTION

## Proposed changes

### What changed

Ignore case when searching for CI mappings

### Why did it change

To make the system more resilient - we have conflicting information about the cases and this was the safest way to ensure success in prod

### Screenshots
Mappings stay as is
<img width="768" alt="Screenshot 2024-09-06 at 10 21 07 AM" src="https://github.com/user-attachments/assets/6e2a69b2-9e55-4030-b624-185fc087f119">

Error string case doesn't match mapping
<img width="778" alt="Screenshot 2024-09-06 at 10 21 53 AM" src="https://github.com/user-attachments/assets/e88a7922-eb10-4285-a308-1193aff8820f">

Correct CI is still generated
<img width="777" alt="Screenshot 2024-09-06 at 10 21 36 AM" src="https://github.com/user-attachments/assets/0e777a17-b868-4b3c-b812-567f8e8f2425">

Step function still passes
<img width="578" alt="Screenshot 2024-09-06 at 10 22 25 AM" src="https://github.com/user-attachments/assets/062b6228-7639-45c7-9e49-920484275684">

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2788](https://govukverify.atlassian.net/browse/OJ-2788)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

[OJ-2788]: https://govukverify.atlassian.net/browse/OJ-2788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ