### PR TITLE
Ips 1101 step function and lambda canaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,18 @@ Steps:
 1. `make run` to create the Docker container
 2. `make create` to create the mocked state machine in the Docker container
 3. `make <test>` e.g. `make happy1stTry`
+
+## Canaries
+When deploying using sam deploy, canary deployment strategy will be used which is set in LambdaDeploymentPreference and StepFunctionsDeploymentPreference in template.yaml file.
+
+When deploying using the pipeline, canary deployment strategy set in the pipeline will be used and override the default set in template.yaml.
+
+Canary deployments will cause a rollback if any canary alarms associated with a lambda or step-functions are triggered and a slack notification will be sent to #di-orange-warnings-non-prod or #di-orange-warning-alerts-prod.
+
+To skip canaries such as when releasing urgent changes to production, set the last commit message to contain either of these phrases: [skip canary], [canary skip], or [no canary] as specified in the [Canary Escape Hatch guide](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3836051600/Rollback+Recovery+Guidance#Escape-Hatch%3A-how-to-skip-canary-deployments-when-needed).
+`git commit -m "some message [skip canary]"`
+
+Note: To update LambdaDeploymentPreference or StepFunctionsDeploymentPreference, update the LambdaCanaryDeployment or StepFunctionsDeploymentPreference pipeline parameter in the [identity-common-infra repository](https://github.com/govuk-one-login/identity-common-infra/tree/main/terraform/orange/hmrc-check). To update the LambdaDeploymentPreference or StepFunctionsDeploymentPreference for a stack in dev using sam deploy, parameter override needs to be set in the [deploy script](./deploy.sh):
+
+`--parameter-overrides LambdaDeploymentPreference=<define-strategy> \`
+`--parameter-overrides StepFunctionsDeploymentPreference=<define-strategy> \`

--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -151,7 +151,7 @@ paths:
               #end
               {
                 "input":"{\"nino\":\"$nino\",\"sessionId\":\"$util.escapeJavaScript($input.params('session-id').trim())\",#set($headerKeys = $headers.keySet())#set($headerCount = $headerKeys.size())#foreach($headerKey in $headerKeys)\"$headerKey\": \"$util.escapeJavaScript($headers.get($headerKey))\"#if($foreach.hasNext),#end#end}",
-                "stateMachineArn": "${NinoCheckStateMachine.Arn}"
+                "stateMachineArn": "${NinoCheckStateMachine.Arn}:live"
               }
         responses:
           default:
@@ -199,7 +199,7 @@ paths:
             Fn::Sub: |-
               {
                 "input": "{\"sessionId\": \"$util.escapeJavaScript($input.params('session-id').trim())\"}",
-                "stateMachineArn": "${AbandonStateMachine.Arn}"
+                "stateMachineArn": "${AbandonStateMachine.Arn}:live"
               }
         responses:
           default:

--- a/infrastructure/public-api.yaml
+++ b/infrastructure/public-api.yaml
@@ -156,7 +156,7 @@ paths:
             Fn::Sub: |-
               {
                 "input": "{\"bearerToken\": \"$util.escapeJavaScript($input.params('Authorization').trim())\"}",
-                "stateMachineArn": "${NinoIssueCredentialStateMachine.Arn}"
+                "stateMachineArn": "${NinoIssueCredentialStateMachine.Arn}:live"
               }
         responses:
           default:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -54,13 +54,13 @@ Parameters:
       - Canary10Percent10Minutes
       - Canary10Percent15Minutes
       - Canary10Percent30Minutes
-  # StepFunctionsDeploymentPreference:
-  #   Description: "Specifies the configuration to enable gradual StepFunction deployments. It can be used to set deployment type and also allows skipping canary deployment by setting to 'ALL_AT_ONCE'"
-  #   Type: String
-  #   Default: "CANARY"
-  #   AllowedValues:
-  #     - ALL_AT_ONCE
-  #     - CANARY
+  StepFunctionsDeploymentPreference:
+    Description: "Specifies the configuration to enable gradual StepFunction deployments. It can be used to set deployment type and also allows skipping canary deployment by setting to 'ALL_AT_ONCE'"
+    Type: String
+    Default: "CANARY"
+    AllowedValues:
+      - ALL_AT_ONCE
+      - CANARY
 
 Conditions:
   EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]
@@ -180,10 +180,6 @@ Globals:
           - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}"
           - SecretArn: !FindInMap [Dynatrace, SecretArn, !Ref Environment]
     AutoPublishAlias: live
-    DeploymentPreference:
-      Enabled: true
-      Type: !Ref LambdaDeploymentPreference
-      Role: !GetAtt CodeDeployServiceRole.Arn
 
 Resources:
   EpochTimeFunction:
@@ -1178,6 +1174,12 @@ Resources:
   CheckSessionStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: !Ref StepFunctionsDeploymentPreference
+        Alarms:
+          - !Ref CurrentTimeFunctionCanaryErrors
+          - !Ref CheckSessionStateMachineFailedCanary
       Type: EXPRESS
       DefinitionUri: ../step-functions/check_session.asl.json
       DefinitionSubstitutions:
@@ -1239,6 +1241,15 @@ Resources:
   NinoCheckStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: !Ref StepFunctionsDeploymentPreference
+        Alarms:
+          - !Ref OTGFunctionCanaryErrors
+          - !Ref CreateAuthCodeFunctionCanaryErrors
+          - !Ref MatchingFunctionCanaryErrors
+          - !Ref SsmParametersFunctionCanaryErrors
+          - !Ref NinoCheckStateMachineFailedCanary
       Type: EXPRESS
       DefinitionUri: ../step-functions/nino_check.asl.json
       DefinitionSubstitutions:
@@ -1368,6 +1379,12 @@ Resources:
   AbandonStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: !Ref StepFunctionsDeploymentPreference
+        Alarms:
+          - !Ref SsmParametersFunctionCanaryErrors
+          - !Ref AbandonStateMachineFailedCanary
       Type: EXPRESS
       DefinitionUri: ../step-functions/abandon.asl.json
       DefinitionSubstitutions:
@@ -1460,6 +1477,16 @@ Resources:
   NinoIssueCredentialStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: !Ref StepFunctionsDeploymentPreference
+        Alarms:
+          - !Ref CiMappingFunctionCanaryErrors
+          - !Ref TimeFunctionCanaryErrors
+          - !Ref CredentialSubjectFunctionCanaryErrors
+          - !Ref JwtSignerFunctionCanaryErrors
+          - !Ref SsmParametersFunctionCanaryErrors
+          - !Ref NinoIssueCredentialStateMachineFailedCanary
       Type: EXPRESS
       DefinitionUri: ../step-functions/nino_issue_credential.asl.json
       DefinitionSubstitutions:
@@ -2329,6 +2356,13 @@ Resources:
   AuditEventStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: !Ref StepFunctionsDeploymentPreference
+        Alarms:
+          - !Ref CredentialSubjectFunctionCanaryErrors
+          - !Ref EpochTimeFunctionCanaryErrors
+          - !Ref AuditEventStateMachineFailedCanary
       Type: EXPRESS
       DefinitionUri: ../step-functions/audit_event.asl.json
       DefinitionSubstitutions:
@@ -2607,6 +2641,11 @@ Resources:
       BuildProperties:
         Sourcemap: true
     Properties:
+      DeploymentPreference:
+        Type: !Ref LambdaDeploymentPreference
+        Alarms:
+          - !Ref PIIRedactFunctionCanaryErrors
+        Role: !GetAtt CodeDeployServiceRole.Arn
       Handler: lambdas/pii-redact/src/pii-redact-handler.lambdaHandler
       LoggingConfig:
         LogGroup: !Sub /aws/lambda/${AWS::StackName}/PIIRedactFunction

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -72,13 +72,12 @@ Conditions:
     !Or [!Condition IsLocalDevEnvironment, !Condition IsDevEnvironment]
   IsNotDevLikeEnvironment: !Not
     - !Condition IsDevLikeEnvironment
-  IsProdEnvironment: !Equals [!Ref Environment, production]
+  UseCanaryDeploymentAlarms: !Or
+    - !Not [ !Equals [ !Ref StepFunctionsDeploymentPreference, ALL_AT_ONCE ]]
+    - !Not [ !Equals [ !Ref LambdaDeploymentPreference, AllAtOnce ]]
   DeployAlarms: !Or
     - !Condition IsNotDevLikeEnvironment
     - !Equals [!Ref DeployAlarmsInDevEnvironment, "true"]
-  UseDeploymentAlarms: !Or
-    - !Not [ !Equals [ !Ref StepFunctionsDeploymentPreference, ALL_AT_ONCE ]]
-    - !Not [ !Equals [ !Ref LambdaDeploymentPreference, AllAtOnce ]]
 Mappings:
   # Only numeric values should be assigned here
   MaxJwtTtl:
@@ -1183,7 +1182,7 @@ Resources:
         Interval: 15
         Percentage: 10
         Alarms: !If
-          - UseDeploymentAlarms
+          - UseCanaryDeploymentAlarms
           - - !Ref CurrentTimeFunctionCanaryErrors
             - !Ref CheckSessionStateMachineFailedCanary
           - !Ref AWS::NoValue
@@ -1255,7 +1254,7 @@ Resources:
         Interval: 15
         Percentage: 10
         Alarms: !If
-          - UseDeploymentAlarms
+          - UseCanaryDeploymentAlarms
           - - !Ref OTGFunctionCanaryErrors
             - !Ref CreateAuthCodeFunctionCanaryErrors
             - !Ref MatchingFunctionCanaryErrors
@@ -1398,7 +1397,7 @@ Resources:
         Interval: 15
         Percentage: 10
         Alarms: !If
-          - UseDeploymentAlarms
+          - UseCanaryDeploymentAlarms
           - - !Ref SsmParametersFunctionCanaryErrors
             - !Ref AbandonStateMachineFailedCanary
           - !Ref AWS::NoValue
@@ -1501,7 +1500,7 @@ Resources:
         Interval: 15
         Percentage: 10
         Alarms: !If
-          - UseDeploymentAlarms
+          - UseCanaryDeploymentAlarms
           - - !Ref CiMappingFunctionCanaryErrors
             - !Ref TimeFunctionCanaryErrors
             - !Ref CredentialSubjectFunctionCanaryErrors
@@ -1968,12 +1967,13 @@ Resources:
 
   CheckSessionStateMachineFailedCanary:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue] #Only alert to Slack if deployed to Prod, this is the only env in which canaries are enabled
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the CheckSessionStateMachine"
       MetricName: ExecutionsFailed
       Dimensions:
@@ -1992,12 +1992,13 @@ Resources:
 
   AbandonStateMachineFailedCanary:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the AbandonStateMachine"
       MetricName: ExecutionsFailed
       Dimensions:
@@ -2016,12 +2017,13 @@ Resources:
 
   NinoCheckStateMachineFailedCanary:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the NinoCheckStateMachine"
       MetricName: ExecutionsFailed
       Dimensions:
@@ -2040,12 +2042,13 @@ Resources:
 
   NinoIssueCredentialStateMachineFailedCanary:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the NinoIssueCredentialStateMachine"
       MetricName: ExecutionsFailed
       Dimensions:
@@ -2064,12 +2067,13 @@ Resources:
 
   AuditEventStateMachineFailedCanary:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the AuditEventStateMachine"
       MetricName: ExecutionsFailed
       Dimensions:
@@ -2089,12 +2093,13 @@ Resources:
   #Lambda alarms
   CurrentTimeFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the CurrentTimeFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2115,12 +2120,13 @@ Resources:
 
   OTGFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the OTGFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2141,12 +2147,13 @@ Resources:
 
   CreateAuthCodeFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the CreateAuthCodeFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2168,12 +2175,13 @@ Resources:
 
   MatchingFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the MatchingFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2194,12 +2202,13 @@ Resources:
 
   SsmParametersFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the SsmParametersFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2220,12 +2229,13 @@ Resources:
 
   CiMappingFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the CiMappingFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2246,12 +2256,13 @@ Resources:
 
   TimeFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the TimeFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2272,12 +2283,13 @@ Resources:
 
   CredentialSubjectFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the CredentialSubjectFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2298,12 +2310,13 @@ Resources:
 
   JwtSignerFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the JwtSignerFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2324,12 +2337,13 @@ Resources:
 
   EpochTimeFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the EpochTimeFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2350,12 +2364,13 @@ Resources:
 
   PIIRedactFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Errors returned from the PIIRedactFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2385,7 +2400,7 @@ Resources:
         Interval: 15
         Percentage: 10
         Alarms: !If
-          - UseDeploymentAlarms
+          - UseCanaryDeploymentAlarms
           - - !Ref CredentialSubjectFunctionCanaryErrors
             - !Ref EpochTimeFunctionCanaryErrors
             - !Ref AuditEventStateMachineFailedCanary
@@ -2672,7 +2687,7 @@ Resources:
       DeploymentPreference:
         Type: !Ref LambdaDeploymentPreference
         Alarms: !If
-          - UseDeploymentAlarms
+          - UseCanaryDeploymentAlarms
           - [!Ref PIIRedactFunctionCanaryErrors]
           - [!Ref AWS::NoValue]
         Role: !GetAtt CodeDeployServiceRole.Arn

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -76,7 +76,9 @@ Conditions:
   DeployAlarms: !Or
     - !Condition IsNotDevLikeEnvironment
     - !Equals [!Ref DeployAlarmsInDevEnvironment, "true"]
-
+  UseDeploymentAlarms: !Or
+    - !Not [ !Equals [ !Ref StepFunctionsDeploymentPreference, ALL_AT_ONCE ]]
+    - !Not [ !Equals [ !Ref LambdaDeploymentPreference, AllAtOnce ]]
 Mappings:
   # Only numeric values should be assigned here
   MaxJwtTtl:
@@ -1180,9 +1182,11 @@ Resources:
         Type: !Ref StepFunctionsDeploymentPreference
         Interval: 1
         Percentage: 20
-        Alarms:
-          - !Ref CurrentTimeFunctionCanaryErrors
-          - !Ref CheckSessionStateMachineFailedCanary
+        Alarms: !If
+          - UseDeploymentAlarms
+          - - !Ref CurrentTimeFunctionCanaryErrors
+            - !Ref CheckSessionStateMachineFailedCanary
+          - !Ref AWS::NoValue
         StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${CheckSessionStateMachine}:live"
       Type: EXPRESS
       DefinitionUri: ../step-functions/check_session.asl.json
@@ -1250,12 +1254,14 @@ Resources:
         Type: !Ref StepFunctionsDeploymentPreference
         Interval: 1
         Percentage: 20
-        Alarms:
-          - !Ref OTGFunctionCanaryErrors
-          - !Ref CreateAuthCodeFunctionCanaryErrors
-          - !Ref MatchingFunctionCanaryErrors
-          - !Ref SsmParametersFunctionCanaryErrors
-          - !Ref NinoCheckStateMachineFailedCanary
+        Alarms: !If
+          - UseDeploymentAlarms
+          - - !Ref OTGFunctionCanaryErrors
+            - !Ref CreateAuthCodeFunctionCanaryErrors
+            - !Ref MatchingFunctionCanaryErrors
+            - !Ref SsmParametersFunctionCanaryErrors
+            - !Ref NinoCheckStateMachineFailedCanary
+          - !Ref AWS::NoValue
         StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${NinoCheckStateMachine}:live"
       Type: EXPRESS
       DefinitionUri: ../step-functions/nino_check.asl.json
@@ -1391,9 +1397,11 @@ Resources:
         Type: !Ref StepFunctionsDeploymentPreference
         Interval: 1
         Percentage: 20
-        Alarms:
-          - !Ref SsmParametersFunctionCanaryErrors
-          - !Ref AbandonStateMachineFailedCanary
+        Alarms: !If
+          - UseDeploymentAlarms
+          - - !Ref SsmParametersFunctionCanaryErrors
+            - !Ref AbandonStateMachineFailedCanary
+          - !Ref AWS::NoValue
         StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AbandonStateMachine}:live"
       Type: EXPRESS
       DefinitionUri: ../step-functions/abandon.asl.json
@@ -1492,13 +1500,15 @@ Resources:
         Type: !Ref StepFunctionsDeploymentPreference
         Interval: 1
         Percentage: 20
-        Alarms:
-          - !Ref CiMappingFunctionCanaryErrors
-          - !Ref TimeFunctionCanaryErrors
-          - !Ref CredentialSubjectFunctionCanaryErrors
-          - !Ref JwtSignerFunctionCanaryErrors
-          - !Ref SsmParametersFunctionCanaryErrors
-          - !Ref NinoIssueCredentialStateMachineFailedCanary
+        Alarms: !If
+          - UseDeploymentAlarms
+          - - !Ref CiMappingFunctionCanaryErrors
+            - !Ref TimeFunctionCanaryErrors
+            - !Ref CredentialSubjectFunctionCanaryErrors
+            - !Ref JwtSignerFunctionCanaryErrors
+            - !Ref SsmParametersFunctionCanaryErrors
+            - !Ref NinoIssueCredentialStateMachineFailedCanary
+          - !Ref AWS::NoValue
         StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${NinoIssueCredentialStateMachine}:live"
       Type: EXPRESS
       DefinitionUri: ../step-functions/nino_issue_credential.asl.json
@@ -2002,7 +2012,7 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
+      TreatMissingData: breaching
 
   NinoCheckStateMachineFailedCanary:
     Type: AWS::CloudWatch::Alarm
@@ -2374,10 +2384,12 @@ Resources:
         Type: !Ref StepFunctionsDeploymentPreference
         Interval: 1
         Percentage: 20
-        Alarms:
-          - !Ref CredentialSubjectFunctionCanaryErrors
-          - !Ref EpochTimeFunctionCanaryErrors
-          - !Ref AuditEventStateMachineFailedCanary
+        Alarms: !If
+          - UseDeploymentAlarms
+          - - !Ref CredentialSubjectFunctionCanaryErrors
+            - !Ref EpochTimeFunctionCanaryErrors
+            - !Ref AuditEventStateMachineFailedCanary
+          - !Ref AWS::NoValue
         StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AuditEventStateMachine}:live"
       Type: EXPRESS
       DefinitionUri: ../step-functions/audit_event.asl.json
@@ -2659,8 +2671,10 @@ Resources:
     Properties:
       DeploymentPreference:
         Type: !Ref LambdaDeploymentPreference
-        Alarms:
-          - !Ref PIIRedactFunctionCanaryErrors
+        Alarms: !If
+          - UseDeploymentAlarms
+          - [!Ref PIIRedactFunctionCanaryErrors]
+          - [!Ref AWS::NoValue]
         Role: !GetAtt CodeDeployServiceRole.Arn
       Handler: lambdas/pii-redact/src/pii-redact-handler.lambdaHandler
       LoggingConfig:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1191,7 +1191,7 @@ Resources:
       Type: EXPRESS
       DefinitionUri: ../step-functions/check_session.asl.json
       DefinitionSubstitutions:
-        CurrentTimeFunctionArn: !GetAtt CurrentTimeFunction.Arn
+        CurrentTimeFunctionArn: !Ref CurrentTimeFunction.Version
         CommonStackName: !Ref CommonStackName
       Logging:
         Destinations:
@@ -1268,15 +1268,15 @@ Resources:
       DefinitionSubstitutions:
         AuditEventPrefix: !Ref AuditEventNamePrefix
         CheckSessionStateMachineArn: !Sub ${CheckSessionStateMachine}:live
-        CreateAuthCodeFunctionArn: !GetAtt CreateAuthCodeFunction.Arn
-        MatchingFunctionArn: !GetAtt MatchingFunction.Arn
+        CreateAuthCodeFunctionArn: !Ref CreateAuthCodeFunction.Version
+        MatchingFunctionArn: !Ref MatchingFunction.Version
         UserAttemptsTable: !Ref UserAttemptsTable
         NinoUsersTable: !Ref NinoUsersTable
         UserAgent: !Ref UserAgent
         BearerTokenName: !Ref BearerTokenName
         CommonStackName: !Ref CommonStackName
-        SsmParametersFunction: !Ref SsmParametersFunction
-        OTGFunction: !Ref OTGFunction
+        SsmParametersFunction: !Ref SsmParametersFunction.Version
+        OTGFunction: !Ref OTGFunction.Version
         CheckHmrcEventBus: !Ref CheckHmrcEventBus
         CheckHmrcEventBusSource: !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
         AuditEventNameResponseReceived:
@@ -1409,7 +1409,7 @@ Resources:
         AuditEventPrefix: !Ref AuditEventNamePrefix
         CheckSessionStateMachineArn: !Sub ${CheckSessionStateMachine}:live
         CommonStackName: !Ref CommonStackName
-        SsmParametersFunction: !Ref SsmParametersFunction
+        SsmParametersFunction: !Ref SsmParametersFunction.Version
         CheckHmrcEventBus: !Ref CheckHmrcEventBus
         CheckHmrcEventBusSource: !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
         AuditEventNameAbandoned: !FindInMap [Audit, EventName, Abandoned]
@@ -1514,16 +1514,16 @@ Resources:
       DefinitionUri: ../step-functions/nino_issue_credential.asl.json
       DefinitionSubstitutions:
         AuditEventPrefix: !Ref AuditEventNamePrefix
-        CiMappingFunctionArn: !GetAtt CiMappingFunction.Arn
-        TimeFunctionArn: !GetAtt TimeFunction.Arn
-        CredentialSubjectFunctionArn: !GetAtt CredentialSubjectFunction.Arn
+        CiMappingFunctionArn: !Ref CiMappingFunction.Version
+        TimeFunctionArn: !Ref TimeFunction.Version
+        CredentialSubjectFunctionArn: !Ref CredentialSubjectFunction.Version
         UserAttemptsTable: !Ref UserAttemptsTable
         MaxJwtTtlParameter: !Ref MaxJwtTtlParameter
         JwtTtlUnitParameter: !Ref JwtTtlUnitParameter
         CommonStackName: !Ref CommonStackName
         NinoUsersTable: !Ref NinoUsersTable
-        JwtSignerFunction: !GetAtt JwtSignerFunction.Arn
-        SsmParametersFunction: !Ref SsmParametersFunction
+        JwtSignerFunction: !Ref JwtSignerFunction.Version
+        SsmParametersFunction: !Ref SsmParametersFunction.Version
         CheckHmrcEventBus: !Ref CheckHmrcEventBus
         CheckHmrcEventBusSource: !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
         AuditEventNameVcIssued: !FindInMap [Audit, EventName, VcIssued]
@@ -2394,8 +2394,8 @@ Resources:
       Type: EXPRESS
       DefinitionUri: ../step-functions/audit_event.asl.json
       DefinitionSubstitutions:
-        CredentialSubjectFunctionArn: !GetAtt CredentialSubjectFunction.Arn
-        EpochTimeArn: !GetAtt EpochTimeFunction.Arn
+        CredentialSubjectFunctionArn: !Ref CredentialSubjectFunction.Version
+        EpochTimeArn: !Ref EpochTimeFunction.Version
         CheckHmrcEventBus: !Ref CheckHmrcEventBus
         CheckHmrcEventBusSource: !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
       Logging:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -44,6 +44,23 @@ Parameters:
     Type: String
     Default: "https://team-manual.account.gov.uk/teams/CRI-Orange-team/supporting-cri-orange/hmrc-nino-runbook/#backend-api-alarms"
     Description: The support manual URL to be provided in alarm messages.
+  LambdaDeploymentPreference:
+    Description: "Specifies the configuration to enable gradual Lambda deployments. It can be used to set deployment type and also allows skipping canary deployment by setting to 'AllAtOnce'"
+    Type: String
+    Default: "Canary10Percent10Minutes"
+    AllowedValues:
+      - AllAtOnce
+      - Canary10Percent5Minutes
+      - Canary10Percent10Minutes
+      - Canary10Percent15Minutes
+      - Canary10Percent30Minutes
+  StepFunctionsDeploymentPreference:
+    Description: "Specifies the configuration to enable gradual StepFunction deployments. It can be used to set deployment type and also allows skipping canary deployment by setting to 'ALL_AT_ONCE'"
+    Type: String
+    Default: "CANARY"
+    AllowedValues:
+      - ALL_AT_ONCE
+      - CANARY
 
 Conditions:
   EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -54,13 +54,13 @@ Parameters:
       - Canary10Percent10Minutes
       - Canary10Percent15Minutes
       - Canary10Percent30Minutes
-  StepFunctionsDeploymentPreference:
-    Description: "Specifies the configuration to enable gradual StepFunction deployments. It can be used to set deployment type and also allows skipping canary deployment by setting to 'ALL_AT_ONCE'"
-    Type: String
-    Default: "CANARY"
-    AllowedValues:
-      - ALL_AT_ONCE
-      - CANARY
+  # StepFunctionsDeploymentPreference:
+  #   Description: "Specifies the configuration to enable gradual StepFunction deployments. It can be used to set deployment type and also allows skipping canary deployment by setting to 'ALL_AT_ONCE'"
+  #   Type: String
+  #   Default: "CANARY"
+  #   AllowedValues:
+  #     - ALL_AT_ONCE
+  #     - CANARY
 
 Conditions:
   EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]
@@ -179,6 +179,11 @@ Globals:
         DT_TENANT: !Sub
           - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}"
           - SecretArn: !FindInMap [Dynatrace, SecretArn, !Ref Environment]
+    AutoPublishAlias: live
+    DeploymentPreference:
+      Enabled: true
+      Type: !Ref LambdaDeploymentPreference
+      Role: !GetAtt CodeDeployServiceRole.Arn
 
 Resources:
   EpochTimeFunction:
@@ -1904,6 +1909,299 @@ Resources:
       Threshold: 3
       TreatMissingData: notBreaching
 
+  ##################################################################
+  #                                                                  #
+  # Canary Alarms                                                    #
+  #                                                                  #
+  ####################################################################
+
+  CurrentTimeFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the CurrentTimeFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-CurrentTimeLookupFunction:live"
+        - Name: FunctionName
+          Value: !Ref CurrentTimeFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt CurrentTimeFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  OTGFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the OTGFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-OTGLookupFunction:live"
+        - Name: FunctionName
+          Value: !Ref OTGFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt OTGFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  CreateAuthCodeFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the CreateAuthCodeFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-CreateAuthCodeLookupFunction:live"
+        - Name: FunctionName
+          Value: !Ref CreateAuthCodeFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt CreateAuthCodeFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+
+  MatchingFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the MatchingFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-MatchingLookupFunction:live"
+        - Name: FunctionName
+          Value: !Ref MatchingFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt MatchingFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  SsmParametersFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the SsmParametersFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-SsmParametersLookupFunction:live"
+        - Name: FunctionName
+          Value: !Ref SsmParametersFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt SsmParametersFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  CiMappingFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the CiMappingFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-CiMappingLookupFunction:live"
+        - Name: FunctionName
+          Value: !Ref CiMappingFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt CiMappingFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  TimeFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the TimeFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-TimeLookupFunction:live"
+        - Name: FunctionName
+          Value: !Ref TimeFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt TimeFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  CredentialSubjectFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the CredentialSubjectFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-CredentialSubjectLookupFunction:live"
+        - Name: FunctionName
+          Value: !Ref CredentialSubjectFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt CredentialSubjectFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  JwtSignerFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the JwtSignerFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-JwtSignerLookupFunction:live"
+        - Name: FunctionName
+          Value: !Ref JwtSignerFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt JwtSignerFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  EpochTimeFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the EpochTimeFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-EpochTimeLookupFunction:live"
+        - Name: FunctionName
+          Value: !Ref EpochTimeFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt EpochTimeFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  PIIRedactFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the PIIRedactFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-PIIRedactLookupFunction:live"
+        - Name: FunctionName
+          Value: !Ref PIIRedactFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt PIIRedactFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
   ###############################################################################
 
   AuditEventStateMachine:
@@ -2371,6 +2669,28 @@ Resources:
       DestinationArn: !GetAtt PIIRedactFunction.Arn
       FilterPattern: ""
       LogGroupName: !Ref AuditEventStateMachineLogGroup
+
+  ####################################################################
+  #                                                                  #
+  # Code Deploy Service Role                                       #
+  #                                                                  #
+  ####################################################################
+
+  CodeDeployServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - codedeploy.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda
+      PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
 
 ##################################################################
 #                                                                  #

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -61,6 +61,7 @@ Parameters:
     AllowedValues:
       - ALL_AT_ONCE
       - CANARY
+      - LINEAR
 
 Conditions:
   EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]
@@ -1180,6 +1181,7 @@ Resources:
         Alarms:
           - !Ref CurrentTimeFunctionCanaryErrors
           - !Ref CheckSessionStateMachineFailedCanary
+        StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${CheckSessionStateMachine}:live"
       Type: EXPRESS
       DefinitionUri: ../step-functions/check_session.asl.json
       DefinitionSubstitutions:
@@ -1250,6 +1252,7 @@ Resources:
           - !Ref MatchingFunctionCanaryErrors
           - !Ref SsmParametersFunctionCanaryErrors
           - !Ref NinoCheckStateMachineFailedCanary
+        StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${NinoCheckStateMachine}:live"
       Type: EXPRESS
       DefinitionUri: ../step-functions/nino_check.asl.json
       DefinitionSubstitutions:
@@ -1385,6 +1388,7 @@ Resources:
         Alarms:
           - !Ref SsmParametersFunctionCanaryErrors
           - !Ref AbandonStateMachineFailedCanary
+        StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AbandonStateMachine}:live"
       Type: EXPRESS
       DefinitionUri: ../step-functions/abandon.asl.json
       DefinitionSubstitutions:
@@ -1487,6 +1491,7 @@ Resources:
           - !Ref JwtSignerFunctionCanaryErrors
           - !Ref SsmParametersFunctionCanaryErrors
           - !Ref NinoIssueCredentialStateMachineFailedCanary
+        StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${NinoIssueCredentialStateMachine}:live"
       Type: EXPRESS
       DefinitionUri: ../step-functions/nino_issue_credential.asl.json
       DefinitionSubstitutions:
@@ -2363,6 +2368,7 @@ Resources:
           - !Ref CredentialSubjectFunctionCanaryErrors
           - !Ref EpochTimeFunctionCanaryErrors
           - !Ref AuditEventStateMachineFailedCanary
+        StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AuditEventStateMachine}:live"
       Type: EXPRESS
       DefinitionUri: ../step-functions/audit_event.asl.json
       DefinitionSubstitutions:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1178,6 +1178,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
+        Interval: 1
+        Percentage: 20
         Alarms:
           - !Ref CurrentTimeFunctionCanaryErrors
           - !Ref CheckSessionStateMachineFailedCanary
@@ -1246,6 +1248,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
+        Interval: 1
+        Percentage: 20
         Alarms:
           - !Ref OTGFunctionCanaryErrors
           - !Ref CreateAuthCodeFunctionCanaryErrors
@@ -1385,6 +1389,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
+        Interval: 1
+        Percentage: 20
         Alarms:
           - !Ref SsmParametersFunctionCanaryErrors
           - !Ref AbandonStateMachineFailedCanary
@@ -1484,6 +1490,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
+        Interval: 1
+        Percentage: 20
         Alarms:
           - !Ref CiMappingFunctionCanaryErrors
           - !Ref TimeFunctionCanaryErrors
@@ -2364,6 +2372,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
+        Interval: 1
+        Percentage: 20
         Alarms:
           - !Ref CredentialSubjectFunctionCanaryErrors
           - !Ref EpochTimeFunctionCanaryErrors

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1267,7 +1267,7 @@ Resources:
       DefinitionUri: ../step-functions/nino_check.asl.json
       DefinitionSubstitutions:
         AuditEventPrefix: !Ref AuditEventNamePrefix
-        CheckSessionStateMachineArn: !Ref CheckSessionStateMachine
+        CheckSessionStateMachineArn: !Sub ${CheckSessionStateMachine}:live
         CreateAuthCodeFunctionArn: !GetAtt CreateAuthCodeFunction.Arn
         MatchingFunctionArn: !GetAtt MatchingFunction.Arn
         UserAttemptsTable: !Ref UserAttemptsTable
@@ -1407,7 +1407,7 @@ Resources:
       DefinitionUri: ../step-functions/abandon.asl.json
       DefinitionSubstitutions:
         AuditEventPrefix: !Ref AuditEventNamePrefix
-        CheckSessionStateMachineArn: !Ref CheckSessionStateMachine
+        CheckSessionStateMachineArn: !Sub ${CheckSessionStateMachine}:live
         CommonStackName: !Ref CommonStackName
         SsmParametersFunction: !Ref SsmParametersFunction
         CheckHmrcEventBus: !Ref CheckHmrcEventBus
@@ -1671,7 +1671,7 @@ Resources:
         detail-type:
           - !FindInMap [Audit, EventName, ResponseReceived]
       Targets:
-        - Arn: !Ref AuditEventStateMachine
+        - Arn: !Sub ${AuditEventStateMachine}:live
           Id: AuditEventStateMachineResponseReceivedTarget
           RoleArn: !GetAtt EventBridgeStateMachineExecutionRole.Arn
   AuditEventRequestSentRule:
@@ -1686,7 +1686,7 @@ Resources:
         detail-type:
           - !FindInMap [Audit, EventName, RequestSent]
       Targets:
-        - Arn: !Ref AuditEventStateMachine
+        - Arn: !Sub ${AuditEventStateMachine}:live
           Id: AuditEventStateMachineRequestSentTarget
           RoleArn: !GetAtt EventBridgeStateMachineExecutionRole.Arn
   AuditEventVcIssuedRule:
@@ -1701,7 +1701,7 @@ Resources:
         detail-type:
           - !FindInMap [Audit, EventName, VcIssued]
       Targets:
-        - Arn: !Ref AuditEventStateMachine
+        - Arn: !Sub ${AuditEventStateMachine}:live
           Id: AuditEventStateMachineVcIssuedTarget
           RoleArn: !GetAtt EventBridgeStateMachineExecutionRole.Arn
   AuditEventEndRule:
@@ -1716,7 +1716,7 @@ Resources:
         detail-type:
           - !FindInMap [Audit, EventName, End]
       Targets:
-        - Arn: !Ref AuditEventStateMachine
+        - Arn: !Sub ${AuditEventStateMachine}:live
           Id: AuditEventStateMachineEndTarget
           RoleArn: !GetAtt EventBridgeStateMachineExecutionRole.Arn
   AuditEventAbandonedRule:
@@ -1731,7 +1731,7 @@ Resources:
         detail-type:
           - !FindInMap [Audit, EventName, Abandoned]
       Targets:
-        - Arn: !Ref AuditEventStateMachine
+        - Arn: !Sub ${AuditEventStateMachine}:live
           Id: AuditEventStateMachineAbandonedTarget
           RoleArn: !GetAtt EventBridgeStateMachineExecutionRole.Arn
 

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1914,7 +1914,129 @@ Resources:
   # Canary Alarms                                                    #
   #                                                                  #
   ####################################################################
+  #Step function alarms
 
+  CheckSessionStateMachineFailedCanary:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the CheckSessionStateMachine"
+      MetricName: ExecutionsFailed
+      Dimensions:
+        - Name: StateMachineArn
+          Value: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${CheckSessionStateMachine}"
+        - Name: Alias
+          Value: 'live'
+      Namespace: AWS/States
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  AbandonStateMachineFailedCanary:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the AbandonStateMachine"
+      MetricName: ExecutionsFailed
+      Dimensions:
+        - Name: StateMachineArn
+          Value: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AbandonStateMachine}"
+        - Name: Alias
+          Value: 'live'
+      Namespace: AWS/States
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  NinoCheckStateMachineFailedCanary:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the NinoCheckStateMachine"
+      MetricName: ExecutionsFailed
+      Dimensions:
+        - Name: StateMachineArn
+          Value: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${NinoCheckStateMachine}"
+        - Name: Alias
+          Value: 'live'
+      Namespace: AWS/States
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  NinoIssueCredentialStateMachineFailedCanary:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the NinoIssueCredentialStateMachine"
+      MetricName: ExecutionsFailed
+      Dimensions:
+        - Name: StateMachineArn
+          Value: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${NinoIssueCredentialStateMachine"
+        - Name: Alias
+          Value: 'live'
+      Namespace: AWS/States
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  AuditEventStateMachineFailedCanary:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the AuditEventStateMachine"
+      MetricName: ExecutionsFailed
+      Dimensions:
+        - Name: StateMachineArn
+          Value: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AuditEventStateMachine}"
+        - Name: Alias
+          Value: 'live'
+      Namespace: AWS/States
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  #Lambda alarms
   CurrentTimeFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -72,7 +72,7 @@ Conditions:
     !Or [!Condition IsLocalDevEnvironment, !Condition IsDevEnvironment]
   IsNotDevLikeEnvironment: !Not
     - !Condition IsDevLikeEnvironment
-  IsProdEnvironment: !Equals [!Ref Environment, prod]
+  IsProdEnvironment: !Equals [!Ref Environment, production]
   DeployAlarms: !Or
     - !Condition IsNotDevLikeEnvironment
     - !Equals [!Ref DeployAlarmsInDevEnvironment, "true"]
@@ -1180,8 +1180,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
-        Interval: 1
-        Percentage: 20
+        Interval: 15
+        Percentage: 10
         Alarms: !If
           - UseDeploymentAlarms
           - - !Ref CurrentTimeFunctionCanaryErrors
@@ -1252,8 +1252,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
-        Interval: 1
-        Percentage: 20
+        Interval: 15
+        Percentage: 10
         Alarms: !If
           - UseDeploymentAlarms
           - - !Ref OTGFunctionCanaryErrors
@@ -1395,8 +1395,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
-        Interval: 1
-        Percentage: 20
+        Interval: 15
+        Percentage: 10
         Alarms: !If
           - UseDeploymentAlarms
           - - !Ref SsmParametersFunctionCanaryErrors
@@ -1498,8 +1498,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
-        Interval: 1
-        Percentage: 20
+        Interval: 15
+        Percentage: 10
         Alarms: !If
           - UseDeploymentAlarms
           - - !Ref CiMappingFunctionCanaryErrors
@@ -1969,7 +1969,7 @@ Resources:
   CheckSessionStateMachineFailedCanary:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue] #Only alert to Slack if deployed to Prod, this is the only env in which canaries are enabled
       OKActions:
@@ -1993,7 +1993,7 @@ Resources:
   AbandonStateMachineFailedCanary:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2012,12 +2012,12 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: breaching
+      TreatMissingData: notBreaching
 
   NinoCheckStateMachineFailedCanary:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2041,7 +2041,7 @@ Resources:
   NinoIssueCredentialStateMachineFailedCanary:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2065,7 +2065,7 @@ Resources:
   AuditEventStateMachineFailedCanary:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2090,7 +2090,7 @@ Resources:
   CurrentTimeFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2116,7 +2116,7 @@ Resources:
   OTGFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2142,7 +2142,7 @@ Resources:
   CreateAuthCodeFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2169,7 +2169,7 @@ Resources:
   MatchingFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2195,7 +2195,7 @@ Resources:
   SsmParametersFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2221,7 +2221,7 @@ Resources:
   CiMappingFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2247,7 +2247,7 @@ Resources:
   TimeFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2273,7 +2273,7 @@ Resources:
   CredentialSubjectFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2299,7 +2299,7 @@ Resources:
   JwtSignerFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2325,7 +2325,7 @@ Resources:
   EpochTimeFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2351,7 +2351,7 @@ Resources:
   PIIRedactFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
@@ -2382,8 +2382,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
-        Interval: 1
-        Percentage: 20
+        Interval: 15
+        Percentage: 10
         Alarms: !If
           - UseDeploymentAlarms
           - - !Ref CredentialSubjectFunctionCanaryErrors

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -47,7 +47,7 @@ Parameters:
   LambdaDeploymentPreference:
     Description: "Specifies the configuration to enable gradual Lambda deployments. It can be used to set deployment type and also allows skipping canary deployment by setting to 'AllAtOnce'"
     Type: String
-    Default: "Canary10Percent10Minutes"
+    Default: "AllAtOnce"
     AllowedValues:
       - AllAtOnce
       - Canary10Percent5Minutes
@@ -57,7 +57,7 @@ Parameters:
   StepFunctionsDeploymentPreference:
     Description: "Specifies the configuration to enable gradual StepFunction deployments. It can be used to set deployment type and also allows skipping canary deployment by setting to 'ALL_AT_ONCE'"
     Type: String
-    Default: "CANARY"
+    Default: "ALL_AT_ONCE"
     AllowedValues:
       - ALL_AT_ONCE
       - CANARY
@@ -72,7 +72,7 @@ Conditions:
     !Or [!Condition IsLocalDevEnvironment, !Condition IsDevEnvironment]
   IsNotDevLikeEnvironment: !Not
     - !Condition IsDevLikeEnvironment
-
+  IsProdEnvironment: !Equals [!Ref Environment, prod]
   DeployAlarms: !Or
     - !Condition IsNotDevLikeEnvironment
     - !Equals [!Ref DeployAlarmsInDevEnvironment, "true"]
@@ -1971,9 +1971,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue] #Only alert to Slack if deployed to Prod, this is the only env in which canaries are enabled
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the CheckSessionStateMachine"
       MetricName: ExecutionsFailed
       Dimensions:
@@ -1995,9 +1995,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the AbandonStateMachine"
       MetricName: ExecutionsFailed
       Dimensions:
@@ -2019,9 +2019,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the NinoCheckStateMachine"
       MetricName: ExecutionsFailed
       Dimensions:
@@ -2043,9 +2043,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the NinoIssueCredentialStateMachine"
       MetricName: ExecutionsFailed
       Dimensions:
@@ -2067,9 +2067,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the AuditEventStateMachine"
       MetricName: ExecutionsFailed
       Dimensions:
@@ -2092,9 +2092,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the CurrentTimeFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2118,9 +2118,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the OTGFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2144,9 +2144,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the CreateAuthCodeFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2171,9 +2171,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the MatchingFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2197,9 +2197,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the SsmParametersFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2223,9 +2223,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the CiMappingFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2249,9 +2249,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the TimeFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2275,9 +2275,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the CredentialSubjectFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2301,9 +2301,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the JwtSignerFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2327,9 +2327,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the EpochTimeFunction Lambda."
       MetricName: Errors
       Dimensions:
@@ -2353,9 +2353,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Errors returned from the PIIRedactFunction Lambda."
       MetricName: Errors
       Dimensions:


### PR DESCRIPTION
## Proposed changes

### What changed

Lambda and step function canary deployment configured

- Set deployment preference for lambda and step function, by default set to AllAtOnce
- Enabled versioning for lambda using autopublishalias live in globals
- Enabled versioning for step functions using autopublishalias live in individual step function
- Added code deploy role for lambda canary deployment
- Created alarms Execution failed alarm and lambda error alarms
- For state machines, I associated both the step function and relevant lambda alarms in the state machine configuration
- For one lambda that is not called using a step function PII Redact, I set the configuration in that lambda
- from api gateway and eventbus, pointed the state machine to the live version e.g. "stateMachineArn": "${XXXXXStateMachine.Arn}:live" to make sure even if there is a rollback, the live version is used and not the latest which may be faulty
- Step function deployment set to 10% over 15 minutes as agreed with Orange tech lead, defined in interval and percentage parameter of each step function

- IsCanaryEnabledAlarm condition added to make sure alarms are only deployed if canary deployment strategy is not all at once. Therefore, canary alarms in this case will only deploy in prod. This prevents unnecessary alarms triggering and notifying to slack. 

### Why did it change

These changes are required to enable canaries
Alarms when triggered will cause a rollback

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1120](https://govukverify.atlassian.net/browse/IPS-1120)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks

Canary testing of lambda canary deployment:
![image](https://github.com/user-attachments/assets/61c3b336-3737-4bd7-b293-06f23353e263)

and completed:
![image](https://github.com/user-attachments/assets/ca860a1f-df17-414f-a9e3-53177f214075)

Canary testing of lambda rollback:
![image](https://github.com/user-attachments/assets/05c4172c-7621-4166-9631-1fd48f537432)

![image](https://github.com/user-attachments/assets/22d55a8b-707b-4ccc-9876-01023b8d84d7)

![image](https://github.com/user-attachments/assets/bda9e1fa-86b0-46a8-990b-30ac6c2e48b3)


Canary testing in step functions:
![image](https://github.com/user-attachments/assets/6ec29614-942c-462f-b1b1-d3bf1802ca2c)

Testing rollback when alarm is triggered in abandon state machine:
![image](https://github.com/user-attachments/assets/ce712b8f-b779-4b83-88f5-3f345bb241b7)

Rolled back to previous version (version 3)
![image](https://github.com/user-attachments/assets/2504d739-2537-46d8-bcd8-827a0682f367)

Slack notified of alarm:
<img width="756" alt="image" src="https://github.com/user-attachments/assets/5955e87e-5a66-44b7-9366-825739e2ad4a">



[IPS-1120]: https://govukverify.atlassian.net/browse/IPS-1101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

When executing a state machine, the live version is invoked with the correct version:
![image](https://github.com/user-attachments/assets/e1d44e69-277f-4c82-b014-9d29ae30145f)


[IPS-1101]: https://govukverify.atlassian.net/browse/IPS-1101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ