### PR TITLE
OJ-2793: Removed the lamda alarms and metric fileters. Added general lambda alarm and updated the state machine alarms to be critical

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -195,37 +195,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref PIIRedactedEpochTimeFunctionLogGroup
 
-  EpochTimeFunctionEventErrorMetricFilter:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      LogGroupName: !Ref EpochTimeFunctionLogGroup
-      FilterPattern: "{($.eventName = ExecutionsFailed) || ($.eventName = ExecutionThrottled) || ($.eventName = ExecutionsAborted) || ($.eventName = ExecutionsTimedOut)}"
-      MetricTransformations:
-        - MetricValue: 1
-          MetricName: !Sub ${EpochTimeFunction}-Error
-          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
-
-  EpochTimeFunctionEventErrorAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-EpochTimeFunction-Errors-alarm"
-      AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${EpochTimeFunction} errors. ${SupportManualURL}"
-      ActionsEnabled: true
-      OKActions: [!ImportValue platform-alarm-warning-alert-topic]
-      AlarmActions: [!ImportValue platform-alarm-warning-alert-topic]
-      InsufficientDataActions: []
-      MetricName: !Sub ${EpochTimeFunction}-Error
-      Namespace: !Sub ${AWS::StackName}/LogMessages
-      Statistic: Sum
-      Dimensions: []
-      Period: 60
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
-      Threshold: 1
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
-
   CiMappingFunction:
     Type: AWS::Serverless::Function
     Metadata:
@@ -256,39 +225,6 @@ Resources:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref PIIRedactedCiMappingFunctionLogGroup
-
-  CiMappingFunctionEventErrorMetricFilter:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      LogGroupName: !Ref CiMappingFunctionLogGroup
-      FilterPattern: "{($.eventName = ExecutionsFailed) || ($.eventName = ExecutionThrottled) || ($.eventName = ExecutionsAborted) || ($.eventName = ExecutionsTimedOut)}"
-      MetricTransformations:
-        - MetricValue: 1
-          MetricName: !Sub ${CiMappingFunction}-Error
-          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
-
-  CiMappingFunctionEventErrorAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-CiMappingFunction-Errors-alarm"
-      AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${CiMappingFunction} errors. ${SupportManualURL}"
-      ActionsEnabled: true
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      InsufficientDataActions: []
-      MetricName: !Sub ${CiMappingFunction}-Error
-      Namespace: !Sub ${AWS::StackName}/LogMessages
-      Statistic: Sum
-      Dimensions: []
-      Period: 60
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
-      Threshold: 1
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
 
   CreateAuthCodeFunction:
     Type: AWS::Serverless::Function
@@ -321,39 +257,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref PIIRedactedCreateAuthCodeFunctionLogGroup
 
-  CreateAuthCodeFunctionEventErrorMetricFilter:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      LogGroupName: !Ref CreateAuthCodeFunctionLogGroup
-      FilterPattern: "{($.eventName = ExecutionsFailed) || ($.eventName = ExecutionThrottled) || ($.eventName = ExecutionsAborted) || ($.eventName = ExecutionsTimedOut)}"
-      MetricTransformations:
-        - MetricValue: 1
-          MetricName: !Sub ${CreateAuthCodeFunction}-Error
-          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
-
-  CreateAuthCodeFunctionEventErrorAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-CreateAuthCodeFunction-Errors-alarm"
-      AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${CreateAuthCodeFunction} errors. ${SupportManualURL}"
-      ActionsEnabled: true
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      InsufficientDataActions: []
-      MetricName: !Sub ${CreateAuthCodeFunction}-Error
-      Namespace: !Sub ${AWS::StackName}/LogMessages
-      Statistic: Sum
-      Dimensions: []
-      Period: 60
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
-      Threshold: 1
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
-
   CredentialSubjectFunction:
     Type: AWS::Serverless::Function
     Metadata:
@@ -385,39 +288,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref PIIRedactedCredentialSubjectFunctionLogGroup
 
-  CredentialSubjectFunctionEventErrorMetricFilter:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      LogGroupName: !Ref CredentialSubjectFunctionLogGroup
-      FilterPattern: "{($.eventName = ExecutionsFailed) || ($.eventName = ExecutionThrottled) || ($.eventName = ExecutionsAborted) || ($.eventName = ExecutionsTimedOut)}"
-      MetricTransformations:
-        - MetricValue: 1
-          MetricName: !Sub ${CredentialSubjectFunction}-Error
-          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
-
-  CredentialSubjectFunctionEventErrorAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-CredentialSubjectFunction-Errors-alarm"
-      AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${CredentialSubjectFunction} errors. ${SupportManualURL}"
-      ActionsEnabled: true
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      InsufficientDataActions: []
-      MetricName: !Sub ${CredentialSubjectFunction}-Error
-      Namespace: !Sub ${AWS::StackName}/LogMessages
-      Statistic: Sum
-      Dimensions: []
-      Period: 60
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
-      Threshold: 1
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
-
   CurrentTimeFunction:
     Type: AWS::Serverless::Function
     Metadata:
@@ -448,39 +318,6 @@ Resources:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref PIIRedactedCurrentTimeFunctionLogGroup
-
-  CurrentTimeFunctionEventErrorMetricFilter:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      LogGroupName: !Ref CurrentTimeFunctionLogGroup
-      FilterPattern: "{($.eventName = ExecutionsFailed) || ($.eventName = ExecutionThrottled) || ($.eventName = ExecutionsAborted) || ($.eventName = ExecutionsTimedOut)}"
-      MetricTransformations:
-        - MetricValue: 1
-          MetricName: !Sub ${CurrentTimeFunction}-Error
-          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
-
-  CurrentTimeFunctionEventErrorAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-CurrentTimeFunction-Errors-alarm"
-      AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${CurrentTimeFunction} errors. ${SupportManualURL}"
-      ActionsEnabled: true
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      InsufficientDataActions: []
-      MetricName: !Sub ${CurrentTimeFunction}-Error
-      Namespace: !Sub ${AWS::StackName}/LogMessages
-      Statistic: Sum
-      Dimensions: []
-      Period: 60
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
-      Threshold: 1
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
 
   JwtSignerFunction:
     Type: AWS::Serverless::Function
@@ -519,39 +356,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref PIIRedactedJwtSignerFunctionLogGroup
 
-  JwtSignerFunctionEventErrorMetricFilter:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      LogGroupName: !Ref JwtSignerFunctionLogGroup
-      FilterPattern: "{($.eventName = ExecutionsFailed) || ($.eventName = ExecutionThrottled) || ($.eventName = ExecutionsAborted) || ($.eventName = ExecutionsTimedOut)}"
-      MetricTransformations:
-        - MetricValue: 1
-          MetricName: !Sub ${JwtSignerFunction}-Error
-          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
-
-  JwtSignerFunctionEventErrorAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-JwtSignerFunction-Errors-alarm"
-      AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${JwtSignerFunction} errors. ${SupportManualURL}"
-      ActionsEnabled: true
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      InsufficientDataActions: []
-      MetricName: !Sub ${JwtSignerFunction}-Error
-      Namespace: !Sub ${AWS::StackName}/LogMessages
-      Statistic: Sum
-      Dimensions: []
-      Period: 60
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
-      Threshold: 1
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
-
   OTGFunction:
     Type: AWS::Serverless::Function
     Metadata:
@@ -583,39 +387,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref PIIRedactedOTGFunctionLogGroup
 
-  OTGFunctionEventErrorMetricFilter:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      LogGroupName: !Ref OTGFunctionLogGroup
-      FilterPattern: "{($.eventName = ExecutionsFailed) || ($.eventName = ExecutionThrottled) || ($.eventName = ExecutionsAborted) || ($.eventName = ExecutionsTimedOut)}"
-      MetricTransformations:
-        - MetricValue: 1
-          MetricName: !Sub ${MatchingFunction}-Error
-          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
-
-  OTGFunctionEventErrorAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-OTGFunction-Errors-alarm"
-      AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${OTGFunction} errors. ${SupportManualURL}"
-      ActionsEnabled: true
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      InsufficientDataActions: []
-      MetricName: !Sub ${OTGFunction}-Error
-      Namespace: !Sub ${AWS::StackName}/LogMessages
-      Statistic: Sum
-      Dimensions: []
-      Period: 60
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
-      Threshold: 1
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
-
   OTGFunctionFatalErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -626,57 +397,47 @@ Resources:
           MetricNamespace: !Sub "${AWS::StackName}/LogMessages"
           MetricName: "OTGFunction-Fatalerror"
 
-  OTGFunctionFatalErrorAlarm:
-    DependsOn:
-      - "OTGFunctionFatalErrorMetricFilter"
+  CheckHmrcLambdaErrors:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-OTGFunction-FatalError-alarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal ${OTGFunction} Error occurs. ${SupportManualURL}"
+      AlarmName: !Sub ${AWS::StackName}-CheckHmrcLambdaErrors-alarm
+      AlarmDescription: !Sub Check HMRC ${Environment} lambda errors"
       ActionsEnabled: true
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue core-infrastructure-AlarmTopic
+      OKActions:
+        - !ImportValue core-infrastructure-AlarmTopic
       InsufficientDataActions: []
-      MetricName: !Sub ${OTGFunction}-Fatalerror
-      Namespace: !Sub "${AWS::StackName}/LogMessages"
+      MetricName: Errors
+      Namespace: AWS/Lambda
       Statistic: Sum
-      Dimensions: []
-      Period: 60
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
+      Period: 300
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 3
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
-  OTGFunctionThrottleAlarm:
+  CheckHmrcLambdaThrottle:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
     Properties:
+      AlarmName: !Sub ${AWS::StackName}-CheckHmrcLambdaThrottle-alarm
+      AlarmDescription: !Sub Check HMRC ${Environment} lambda throttle"
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
-        - !ImportValue platform-alarm-critical-alert-topic
       OKActions:
         - !ImportValue core-infrastructure-AlarmTopic
-        - !ImportValue platform-alarm-critical-alert-topic
       InsufficientDataActions: []
-      AlarmDescription: !Sub "Trigger if the ${OTGFunction} lambda throttles. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-OTGFunction-Throttles-alarm"
       MetricName: Throttles
       Namespace: AWS/Lambda
       Statistic: Sum
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref OTGFunction
-      TreatMissingData: notBreaching
-      Period: 60 # This is the minimum value for the AWS Namespace
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
+      Period: 300
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 3
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
 
   MatchingFunction:
     Type: AWS::Serverless::Function
@@ -708,41 +469,6 @@ Resources:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref PIIRedactedMatchingFunctionLogGroup
-
-  MatchingFunctionEventErrorMetricFilter:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      LogGroupName: !Ref MatchingFunctionLogGroup
-      FilterPattern: "{($.eventName = ExecutionsFailed) || ($.eventName = ExecutionThrottled) || ($.eventName = ExecutionsAborted) || ($.eventName = ExecutionsTimedOut)}"
-      MetricTransformations:
-        - MetricValue: 1
-          MetricName: !Sub ${MatchingFunction}-Error
-          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
-
-  MatchingFunctionEventErrorAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-MatchingFunction-Errors-alarm"
-      AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${MatchingFunction} errors. ${SupportManualURL}"
-      ActionsEnabled: true
-      OKActions:
-        - !ImportValue core-infrastructure-AlarmTopic
-        - !ImportValue platform-alarm-critical-alert-topic
-      AlarmActions:
-        - !ImportValue core-infrastructure-AlarmTopic
-        - !ImportValue platform-alarm-critical-alert-topic
-      InsufficientDataActions: []
-      MetricName: !Sub ${MatchingFunction}-Error
-      Namespace: !Sub ${AWS::StackName}/LogMessages
-      Statistic: Sum
-      Dimensions: []
-      Period: 60
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
-      Threshold: 1
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
 
   SsmParametersFunction:
     Type: AWS::Serverless::Function
@@ -778,39 +504,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref PIIRedactedSsmParametersFunctionLogGroup
 
-  SsmParametersFunctionEventErrorMetricFilter:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      LogGroupName: !Ref SsmParametersFunctionLogGroup
-      FilterPattern: "{($.eventName = ExecutionsFailed) || ($.eventName = ExecutionThrottled) || ($.eventName = ExecutionsAborted) || ($.eventName = ExecutionsTimedOut)}"
-      MetricTransformations:
-        - MetricValue: 1
-          MetricName: !Sub ${SsmParametersFunction}-Error
-          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
-
-  SsmParametersFunctionEventErrorAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-SsmParametersFunction-Errors-alarm"
-      AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${SsmParametersFunction} errors. ${SupportManualURL}"
-      ActionsEnabled: true
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      InsufficientDataActions: []
-      MetricName: !Sub ${SsmParametersFunction}-Error
-      Namespace: !Sub ${AWS::StackName}/LogMessages
-      Statistic: Sum
-      Dimensions: []
-      Period: 60
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
-      Threshold: 1
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
-
   TimeFunction:
     Type: AWS::Serverless::Function
     Metadata:
@@ -841,39 +534,6 @@ Resources:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref PIIRedactedTimeFunctionLogGroup
-
-  TimeFunctionEventErrorMetricFilter:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      LogGroupName: !Ref TimeFunctionLogGroup
-      FilterPattern: "{($.eventName = ExecutionsFailed) || ($.eventName = ExecutionThrottled) || ($.eventName = ExecutionsAborted) || ($.eventName = ExecutionsTimedOut)}"
-      MetricTransformations:
-        - MetricValue: 1
-          MetricName: !Sub ${TimeFunction}-Error
-          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
-
-  TimeFunctionEventErrorAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-TimeFunction-Errors-alarm"
-      AlarmDescription: !Sub "Triggers CloudWatch Alarm when the ${TimeFunction} errors. ${SupportManualURL}"
-      ActionsEnabled: true
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      InsufficientDataActions: []
-      MetricName: !Sub ${TimeFunction}-Error
-      Namespace: !Sub ${AWS::StackName}/LogMessages
-      Statistic: Sum
-      Dimensions: []
-      Period: 60
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
-      Threshold: 1
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
 
   UserAgent:
     Type: AWS::SSM::Parameter
@@ -953,7 +613,7 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref PIIRedactedPublicNinoCheckApiAccessLogGroup
 
-  PublicNinoCheckApiFatalErorMetricFilter:
+  PublicNinoCheckApiFatalErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref PublicNinoCheckApiAccessLogGroup
@@ -965,7 +625,7 @@ Resources:
 
   PublicNinoCheckApiFatalErrorAlarm:
     DependsOn:
-      - "PublicNinoCheckApiFatalErorMetricFilter"
+      - "PublicNinoCheckApiFatalErrorMetricFilter"
     Type: AWS::CloudWatch::Alarm
     Condition: "DeployAlarms"
     Properties:
@@ -1056,7 +716,7 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref PIIRedactedPrivateNinoCheckApiAccessLogGroup
 
-  PrivateNinoCheckApiFatalErorMetricFilter:
+  PrivateNinoCheckApiFatalErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref PrivateNinoCheckApiAccessLogGroup
@@ -1068,7 +728,7 @@ Resources:
 
   PrivateNinoCheckApiFatalErrorAlarm:
     DependsOn:
-      - "PrivateNinoCheckApiFatalErorMetricFilter"
+      - "PrivateNinoCheckApiFatalErrorMetricFilter"
     Type: AWS::CloudWatch::Alarm
     Condition: "DeployAlarms"
     Properties:
@@ -1196,9 +856,11 @@ Resources:
     Condition: "DeployAlarms"
     Properties:
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
       AlarmDescription: !Sub "${CheckSessionStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
       AlarmName: !Sub "${AWS::StackName}-${Environment}-CheckSessionStateMachine-alarm"
       ComparisonOperator: GreaterThanThreshold
@@ -1325,9 +987,11 @@ Resources:
     Condition: "DeployAlarms"
     Properties:
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
       AlarmDescription: !Sub "${NinoCheckStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
       AlarmName: !Sub "${AWS::StackName}-${Environment}-NinoCheckStateMachine-ExecutionsFailed-alarm"
       ComparisonOperator: GreaterThanThreshold
@@ -1540,9 +1204,11 @@ Resources:
     Condition: "DeployAlarms"
     Properties:
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
       AlarmDescription: !Sub "${NinoIssueCredentialStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
       AlarmName: !Sub "${AWS::StackName}-${Environment}-NinoIssueCredentialStateMachine-ExecutionsFailed-alarm"
       ComparisonOperator: GreaterThanThreshold


### PR DESCRIPTION
## Proposed changes

### What changed
- Existing lambda alarms were removed
- Added the `CheckHmrcLambdaErrors` alarm to capture all lambda errors (and follow the same standard as Address and KBV)
- Added the `CheckHmrcLambdaThrottle` alarm to capture all lambda throttle
- Updated the state machine alarms to use `core-infrastructure-AlarmTopic` and `platform-alarm-critical-alert-topic` to increase the level to critical and link it to PagerDuty
- Removed incorrect metric filters

![Screenshot 2024-09-30 at 16 55 20](https://github.com/user-attachments/assets/83d9e0ee-b802-445d-a671-1e84ae64bb50)
![Screenshot 2024-09-30 at 16 55 33](https://github.com/user-attachments/assets/974f2332-fa57-4491-9b8e-cee0125c27dd)
![Screenshot 2024-09-30 at 16 59 07](https://github.com/user-attachments/assets/a649cb0d-b8f5-404f-818a-21b4fb9702ae)


### Why did it change

The lambda alarms in NINo were using metrics with `FilterPattern` that are related to step functions rather than the lambdas making them impossible to hit and test. So the alarm were updated to follow the same standard as in Address and KBV. Also the existing state machine alarms are elevated to critical and linked to the PagerDuty. 

### Issue tracking

- [OJ-2793](https://govukverify.atlassian.net/browse/OJ-2793)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2793]: https://govukverify.atlassian.net/browse/OJ-2793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ