### PR TITLE
OJ-2806: return text body instead when content-type is application/json and body is invalid json

### DIFF
--- a/lambdas/matching/src/matching-handler.ts
+++ b/lambdas/matching/src/matching-handler.ts
@@ -40,10 +40,20 @@ export class MatchingHandler implements LambdaInterface {
       const txn = response.headers.get("x-amz-cf-id") ?? "";
       addLogEntry(event, txn, context);
       const contentType = response.headers.get("content-type");
+
       if (contentType?.includes("application/json")) {
+        let responseBody;
+        try {
+          responseBody = await response.json();
+        } catch (error) {
+          responseBody = {
+            message: await response.text(),
+          };
+        }
+
         return {
           status: response.status.toString(),
-          body: await response.json(),
+          body: responseBody,
           txn: txn,
         };
       } else {

--- a/lambdas/matching/tests/matching-handler.test.ts
+++ b/lambdas/matching/tests/matching-handler.test.ts
@@ -67,6 +67,32 @@ describe("matching-handler", () => {
     expect(result.txn).toStrictEqual("mock-txn");
   });
 
+  it("should return a valid response when the content-type is application/json and the body is not valid JSON", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValueOnce("content-type")
+          .mockReturnValueOnce("application/json"),
+      },
+      json: jest.fn().mockImplementation(() => {
+        throw new Error("Type error");
+      }),
+      text: jest
+        .fn()
+        .mockResolvedValueOnce("Request to create account for a deceased user"),
+      status: 422,
+    });
+
+    const matchingHandler = new MatchingHandler();
+    const result = await matchingHandler.handler(testEvent, {} as Context);
+
+    expect(result.status).toBe("422");
+    expect(result.body).toStrictEqual({
+      message: "Request to create account for a deceased user",
+    });
+  });
+
   it("should return text when content type is not json", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       headers: {


### PR DESCRIPTION
## Proposed changes

### What changed
The matching-handler will return the body as text instead of JSON if the content-type is application/json but the body is not valid JSON.

### Why did it change
HMRC send plain text for HTTP 422 and they also set the responses `Content-Type` as `application/json` so when our code sees this, we try to parse the response body as JSON. As the body isn't valid JSON our code throws an exception. To fix this, we instead read the body as text when the body is not valid JSON.

### Issue tracking
- [OJ-2806](https://govukverify.atlassian.net/browse/OJ-2806)

[OJ-2806]: https://govukverify.atlassian.net/browse/OJ-2806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ