### PR TITLE
OJ-2806: use text body and then try-parse to json

### DIFF
--- a/lambdas/matching/src/matching-handler.ts
+++ b/lambdas/matching/src/matching-handler.ts
@@ -42,13 +42,14 @@ export class MatchingHandler implements LambdaInterface {
       const contentType = response.headers.get("content-type");
 
       if (contentType?.includes("application/json")) {
-        let responseBody;
+        let responseBody = await response.text();
+
         try {
-          responseBody = await response.json();
+          responseBody = JSON.parse(responseBody);
         } catch (error) {
-          responseBody = {
-            message: await response.text(),
-          };
+          logger.info(
+            "Received a non-json body for the application/json content-type"
+          );
         }
 
         return {

--- a/lambdas/matching/tests/matching-handler.test.ts
+++ b/lambdas/matching/tests/matching-handler.test.ts
@@ -45,7 +45,7 @@ describe("matching-handler", () => {
           .mockReturnValueOnce("mock-txn")
           .mockReturnValueOnce("application/json"),
       },
-      json: jest.fn().mockResolvedValueOnce({
+      text: jest.fn().mockResolvedValueOnce({
         firstName: "Jim",
         lastName: "Ferguson",
         dateOfBirth: "1948-04-23",
@@ -75,9 +75,6 @@ describe("matching-handler", () => {
           .mockReturnValueOnce("content-type")
           .mockReturnValueOnce("application/json"),
       },
-      json: jest.fn().mockImplementation(() => {
-        throw new Error("Type error");
-      }),
       text: jest
         .fn()
         .mockResolvedValueOnce("Request to create account for a deceased user"),
@@ -88,9 +85,9 @@ describe("matching-handler", () => {
     const result = await matchingHandler.handler(testEvent, {} as Context);
 
     expect(result.status).toBe("422");
-    expect(result.body).toStrictEqual({
-      message: "Request to create account for a deceased user",
-    });
+    expect(result.body).toStrictEqual(
+      "Request to create account for a deceased user"
+    );
   });
 
   it("should return text when content type is not json", async () => {


### PR DESCRIPTION
## Proposed changes

### What changed and why
In TypeScript we cannot fall-back to text after trying to read the body as JSON. To mitigate this, we parse the body as text first and then try to parse as JSON.

### Issue tracking
- [OJ-2806](https://govukverify.atlassian.net/browse/OJ-2806)


[OJ-2806]: https://govukverify.atlassian.net/browse/OJ-2806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ