### PR TITLE
OJ-2822: Concat FamilyName's before sending request to HMRC

### DIFF
--- a/infrastructure/samconfig.toml
+++ b/infrastructure/samconfig.toml
@@ -1,6 +1,6 @@
 version = 0.1
 [default.deploy.parameters]
-stack_name = "check-hmrc-cri-api"
+stack_name = "<your_name>-check-hmrc-cri-api"
 resolve_s3 = true
 s3_prefix = "check-hmrc-cri-api"
 region = "eu-west-2"

--- a/lambdas/matching/src/match-event.ts
+++ b/lambdas/matching/src/match-event.ts
@@ -1,9 +1,10 @@
+import { Names } from "./name-part";
+
 export interface MatchEvent {
   sessionId: string;
   nino: string;
   userDetails: {
-    firstName: string;
-    lastName: string;
+    names: Names;
     dob: string;
     nino: string;
   };

--- a/lambdas/matching/src/name-part.ts
+++ b/lambdas/matching/src/name-part.ts
@@ -1,0 +1,24 @@
+interface NamePart {
+  M: {
+    type: {
+      S: string;
+    };
+    value: {
+      S: string;
+    };
+  };
+}
+
+interface NameParts {
+  L: NamePart[];
+}
+
+interface Person {
+  M: {
+    nameParts: NameParts;
+  };
+}
+
+export interface Names {
+  L: Person[];
+}

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -223,8 +223,7 @@
           "sessionId.$": "$.sessionId",
           "nino.$": "$.nino",
           "userDetails": {
-            "firstName.$": "$.userInfo.Items[0].names.L[0].M.nameParts.L[0].M.value.S",
-            "lastName.$": "$.userInfo.Items[0].names.L[0].M.nameParts.L[1].M.value.S",
+            "names.$": "$.userInfo.Items[0].names",
             "dob.$": "$.userInfo.Items[0].birthDates.L[0].M.value.S"
           },
           "userAgent.$": "$.parameters.UserAgent",


### PR DESCRIPTION
## Proposed changes

### What and Why did it change

1. The `NinoCheckStateMachine` now provides the entire Name structure to the `MatchingHandler` Lambda instead of trying to parse the `GivenName` and `FamilyName`
2. The `MatchingHandler` concatenates all the `FamilyName`s and converts it into a single space-delimited string. Secondaly, the `MatchingHandler` will choose the first `GivenName`

This change was implemented because users can have multiple surnames so we send them all to HMRC. 

Example:
GivenName: John
FamilyName: [Bob, Alice, Eve]

The request sent to HMRC will be:

firstName: John
lastName: Bob Alice Eve

Secondly, we choose the first GivenName from the array to mitigate any risks of the RP providing us with data in an order we do not expect. 

### Issue tracking
- [OJ-2822](https://govukverify.atlassian.net/browse/OJ-2822)


[OJ-2822]: https://govukverify.atlassian.net/browse/OJ-2822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ