### PR TITLE
OJ-2779: Create alarm for when 80% of concurrent Lambda executions is used

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -417,6 +417,27 @@ Resources:
           MetricNamespace: !Sub "${AWS::StackName}/LogMessages"
           MetricName: "OTGFunction-Fatalerror"
 
+  CheckHmrcLambdaConcurrency80Alarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ${AWS::StackName}-CheckHmrcLambdaConcurrency80-alarm
+      AlarmDescription: !Sub Check HMRC ${Environment} lambdas alarm if over 80% of concurrent executions is used ${SupportManualURL}"
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      InsufficientDataActions: []
+      MetricName: ConcurrentExecutions
+      Namespace: AWS/Lambda
+      Statistic: Maximum
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 780
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
   CheckHmrcLambdaErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:


### PR DESCRIPTION
## Proposed changes

### What changed and why
Added a generic alarm `CheckHmrcLambdaConcurrency80Alarm` which fires when over 80% of concurrent executions is used. In this PR, there is 1 alarm to cover them all to follow the current alarm pattern we have defined.

**Screenshot**
![Screenshot 2024-10-10 at 15 47 56](https://github.com/user-attachments/assets/29cd32e6-9c08-4fc2-8cfe-3faf3d4cfc4e)

### Issue tracking
- [OJ-2779](https://govukverify.atlassian.net/browse/OJ-2779)

[OJ-2779]: https://govukverify.atlassian.net/browse/OJ-2779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ