### PR TITLE
Add groups to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,15 @@ updates:
         versions: ["17.x", "18.x"]
     commit-message:
       prefix: BAU
+    groups:
+      aws:
+        patterns:
+          - "@aws-*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Proposed changes

### What changed

Add groups to dependabot following pattern from [core](https://github.com/govuk-one-login/ipv-core-back/blob/main/.github/dependabot.yml).

I have trialed this in address and seems to work well

### Why did it change

Some groups of dependencies (`@aws-sdk` and `eslint`) should be kept in alignment to prevent compatibility issues between them. This PR ensures that dependabot keeps the alignment
