### PR TITLE
OJ-2552: Use Query instead of Scan for "Query Session Item" in NinoIssueCredentialStateMachine

### DIFF
--- a/integration-tests/step-functions/mocked/nino-issue-credential/MockConfigFile.json
+++ b/integration-tests/step-functions/mocked/nino-issue-credential/MockConfigFile.json
@@ -3,6 +3,7 @@
     "nino_issue_credential": {
       "TestCases": {
         "HappyPath": {
+          "Fetch Session ID for AccessToken": "QuerySessionItem",
           "Query Session Item": "QuerySessionItem",
           "Fetch SSM Parameters": "FetchSSMParamsSuccess",
           "Fetch details from person identity": "FetchDetailsFromPersonIdentity",
@@ -14,6 +15,7 @@
           "Audit Event VC Issued Sent": "PublishAuditEventVcIssued"
         },
         "HappyPathWithoutPersistentSessionId": {
+          "Fetch Session ID for AccessToken": "QuerySessionItem",
           "Query Session Item": "QuerySessionItemWithoutPersistentSessionId",
           "Fetch SSM Parameters": "FetchSSMParamsSuccess",
           "Fetch details from person identity": "FetchDetailsFromPersonIdentity",
@@ -25,6 +27,7 @@
           "Audit Event VC Issued Sent": "PublishAuditEventVcIssued"
         },
         "UnHappyPath": {
+          "Fetch Session ID for AccessToken": "QuerySessionItem",
           "Query Session Item": "QuerySessionItem",
           "Fetch SSM Parameters": "FetchSSMParamsSuccess",
           "Fetch details from person identity": "FetchDetailsFromPersonIdentity",
@@ -37,9 +40,10 @@
           "Audit Event VC Issued Sent": "PublishAuditEventVcIssued"
         },
         "UnHappyPathBearerTokenInvalid": {
+          "Fetch Session ID for AccessToken": "QuerySessionItem",
           "Query Session Item": "QuerySessionItemHasNoItem",
           "Fetch SSM Parameters": "FetchSSMParamsSuccess",
-          "Err: Invalid Bearer Token": "InvalidBearerToken"
+          "Err: Invalid AccessToken": "InvalidBearerToken"
         }
       }
     }
@@ -413,7 +417,7 @@
     "InvalidBearerToken": {
       "0": {
         "Return": {
-          "error": "Invalid Bearer Token",
+          "error": "Invalid AccessToken",
           "httpStatus": 400
         }
       }

--- a/integration-tests/step-functions/mocked/nino-issue-credential/nino-issue-credential-unhappy.test.ts
+++ b/integration-tests/step-functions/mocked/nino-issue-credential/nino-issue-credential-unhappy.test.ts
@@ -55,7 +55,7 @@ describe("nino-issue-credential-unhappy", () => {
     expect(sfnContainer.getContainer()).toBeDefined();
   });
 
-  it("should return 400 when Bearer token is Invalid", async () => {
+  it("should return 400 when Access token is Invalid", async () => {
     const input = JSON.stringify({
       bearerToken: "Bearer",
     });
@@ -67,12 +67,12 @@ describe("nino-issue-credential-unhappy", () => {
     const results = await sfnContainer.waitFor(
       (event: HistoryEvent) =>
         event?.type === "PassStateExited" &&
-        event?.stateExitedEventDetails?.name === "Err: Invalid Bearer Token",
+        event?.stateExitedEventDetails?.name === "Err: Invalid AccessToken",
       responseStepFunction
     );
 
     expect(results[0].stateExitedEventDetails?.output).toBe(
-      '{"error":"Invalid Bearer Token","httpStatus":400}'
+      '{"error":"Invalid AccessToken","httpStatus":400}'
     );
   });
 

--- a/step-functions/nino_issue_credential.asl.json
+++ b/step-functions/nino_issue_credential.asl.json
@@ -1,32 +1,63 @@
 {
   "Comment": "A description of my state machine",
-  "StartAt": "Query Session Item",
+  "StartAt": "Fetch Session ID for AccessToken",
   "States": {
-    "Query Session Item": {
+    "Fetch Session ID for AccessToken": {
       "Type": "Task",
       "Parameters": {
         "TableName": "session-${CommonStackName}",
-        "FilterExpression": "accessToken = :value",
+        "IndexName": "access-token-index",
+        "KeyConditionExpression": "accessToken = :value",
         "ExpressionAttributeValues": {
           ":value": {
             "S.$": "$.bearerToken"
           }
         }
       },
-      "Resource": "arn:aws:states:::aws-sdk:dynamodb:scan",
-      "ResultPath": "$.querySessionResult",
-      "Next": "Bearer Token Valid?"
+      "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
+      "Next": "Found a session for AccessToken?",
+      "ResultPath": "$.sessionCheckQuery"
     },
-    "Bearer Token Valid?": {
+    "Found a session for AccessToken?": {
       "Type": "Choice",
       "Choices": [
         {
-          "Variable": "$.querySessionResult.Count",
-          "NumericGreaterThan": 0,
-          "Next": "Is Persistent Id Present?"
+          "Not": {
+            "Variable": "$.sessionCheckQuery.Count",
+            "NumericGreaterThan": 0
+          },
+          "Next": "Err: Invalid AccessToken"
         }
       ],
-      "Default": "Err: Invalid Bearer Token"
+      "Default": "Query Session Item"
+    },
+    "Query Session Item": {
+      "Type": "Task",
+      "Parameters": {
+        "TableName": "session-${CommonStackName}",
+        "KeyConditionExpression": "sessionId = :value",
+        "ExpressionAttributeValues": {
+          ":value": {
+            "S.$": "$.sessionCheckQuery.Items[0].sessionId.S"
+          }
+        }
+      },
+      "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
+      "Next": "Is session ID valid?",
+      "ResultPath": "$.querySessionResult"
+    },
+    "Is session ID valid?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Not": {
+            "Variable": "$.querySessionResult.Count",
+            "NumericGreaterThan": 0
+          },
+          "Next": "Err: Invalid AccessToken"
+        }
+      ],
+      "Default": "Is Persistent Id Present?"
     },
     "Is Persistent Id Present?": {
       "Type": "Choice",
@@ -107,11 +138,11 @@
         "userAuditInfo.$": "$.userAuditInfo"
       }
     },
-    "Err: Invalid Bearer Token": {
+    "Err: Invalid AccessToken": {
       "Type": "Pass",
       "End": true,
       "Parameters": {
-        "error": "Invalid Bearer Token",
+        "error": "Invalid AccessToken",
         "httpStatus": 400
       }
     },


### PR DESCRIPTION
## Proposed changes

### What changed
NinoIssueCredential state machine, the state "Query Session Item" now uses a DynamoDB query instead of a Scan

### Why did it change
When using a Scan we sometimes get a `LastEvaluatedKey` in the task response. This means that the Scan operation has not completed. We do not continue the Scan so the state machine falls over as it cannot find the session associated with a given `accessToken`. The fix implemented here is:

1. Query the the `sessionId` from the `accessToken` using the `"access-token-index` index.
2. Query the session record from the resolved `sessionId` from the 1st DynamoDB query

This fix is what is done in cri-lib and also by Lime Team in their state machines.

Note: We understand the issues of using the GSI however this fix is to reduce the error rate. GSI is being investigated by the programme. 

### Issue tracking
- [OJ-2552](https://govukverify.atlassian.net/browse/OJ-2552)


[OJ-2552]: https://govukverify.atlassian.net/browse/OJ-2552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ