### PR TITLE
OJ-2798: Delete records with no TTL

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -184,6 +184,34 @@ Globals:
     AutoPublishAlias: live
 
 Resources:
+  #################
+  # START OJ-2798 #
+  #################
+  SleepFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Sourcemap: true
+    Properties:
+      Handler: lambdas/sleep-function/src/sleep-function.lambdaHandler
+      LoggingConfig:
+        LogGroup: !Sub /aws/lambda/${AWS::StackName}/SleepFunction
+      CodeSigningConfigArn:
+        !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: !Sub ${CriIdentifier}-SleepFunction
+
+  SleepFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/SleepFunction
+      RetentionInDays: 30
+  ###############
+  # END OJ-2798 #
+  ###############
+
   EpochTimeFunction:
     Type: AWS::Serverless::Function
     Metadata:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -187,6 +187,129 @@ Resources:
   #################
   # START OJ-2798 #
   #################
+  PersonDeleteRecordsStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: !Sub ${AWS::StackName}-PersonDeleteRecordsStateMachine
+      Type: EXPRESS
+      DefinitionUri: ../step-functions/delete-person-identity-records.asl.json
+      DefinitionSubstitutions:
+        TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
+        StateMachineArn: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-PersonDeleteRecordsStateMachineLog
+        SleepFunction: !Ref SleepFunction
+      Logging:
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt PersonDeleteRecordsStateMachineLogGroup.Arn
+        IncludeExecutionData: True
+        Level: ALL
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref SleepFunction
+        - DynamoDBCrudPolicy:
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
+        - Statement:
+            Effect: Allow
+            Action:
+              - states:StartExecution
+              - states:StartSyncExecution
+            Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-PersonDeleteRecordsStateMachineLog
+        - Statement:
+            Effect: Allow
+            Action: logs:*
+            Resource: "*"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+  PersonDeleteRecordsStateMachineLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-PersonDeleteRecordsStateMachineLog
+      RetentionInDays: 30
+
+  AttemptTblDelRecordsStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: !Sub ${AWS::StackName}-AttemptTblDelRecordsStateMachine
+      Type: EXPRESS
+      DefinitionUri: ../step-functions/delete-records.asl.json
+      DefinitionSubstitutions:
+        TableName: !Ref UserAttemptsTable
+        StateMachineArn: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-AttemptTblDelRecordsStateMachine
+        SleepFunction: !Ref SleepFunction
+      Logging:
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt AttemptTblDelRecordsStateMachineLogGroup.Arn
+        IncludeExecutionData: True
+        Level: ALL
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref SleepFunction
+        - DynamoDBCrudPolicy:
+            TableName: !Ref UserAttemptsTable
+        - Statement:
+            Effect: Allow
+            Action:
+              - states:StartExecution
+              - states:StartSyncExecution
+            Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-AttemptTblDelRecordsStateMachine
+        - Statement:
+            Effect: Allow
+            Action: logs:*
+            Resource: "*"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+  AttemptTblDelRecordsStateMachineLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-AttemptTblDelRecordsStateMachine
+      RetentionInDays: 30
+
+  UserTblDelRecordsStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: !Sub ${AWS::StackName}-UserTblDelRecordsStateMachine
+      Type: EXPRESS
+      DefinitionUri: ../step-functions/delete-records.asl.json
+      DefinitionSubstitutions:
+        TableName: !Ref NinoUsersTable
+        StateMachineArn: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-UserTableDeleteRecordsStateMachine
+        SleepFunction: !Ref SleepFunction
+      Logging:
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt UserTblDelRecordsStateMachineLogGroup.Arn
+        IncludeExecutionData: True
+        Level: ALL
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref SleepFunction
+        - DynamoDBCrudPolicy:
+            TableName: !Ref NinoUsersTable
+        - Statement:
+            Effect: Allow
+            Action:
+              - states:StartExecution
+              - states:StartSyncExecution
+            Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-UserTblDelRecordsStateMachine
+        - Statement:
+            Effect: Allow
+            Action: logs:*
+            Resource: "*"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+  UserTblDelRecordsStateMachineLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-UserTblDelRecordsStateMachine
+      RetentionInDays: 30
+
   SleepFunction:
     Type: AWS::Serverless::Function
     Metadata:

--- a/lambdas/sleep-function/jest.config.ts
+++ b/lambdas/sleep-function/jest.config.ts
@@ -1,0 +1,7 @@
+import type { Config } from "jest";
+import baseConfig from "../../jest.config.base";
+
+export default {
+  ...baseConfig,
+  displayName: "lambdas/sleep-function",
+} satisfies Config;

--- a/lambdas/sleep-function/package.json
+++ b/lambdas/sleep-function/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sleep-function",
+  "description": "",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "unit": "jest --silent",
+    "test": "npm run unit --",
+    "test:coverage": "npm run unit -- --coverage",
+    "deploy": "../../deploy.sh",
+    "compile": "tsc"
+  },
+  "dependencies": {}
+}

--- a/lambdas/sleep-function/src/sleep-function.ts
+++ b/lambdas/sleep-function/src/sleep-function.ts
@@ -1,0 +1,10 @@
+import { LambdaInterface } from "@aws-lambda-powertools/commons";
+
+export class SleepFunction implements LambdaInterface {
+  public async handler(event: { ms: number }, _context: unknown) {
+    await new Promise((resolve) => setTimeout(resolve, event.ms));
+  }
+}
+
+const handlerClass = new SleepFunction();
+export const lambdaHandler = handlerClass.handler.bind(handlerClass);

--- a/lambdas/sleep-function/tests/sleep-function.test.ts
+++ b/lambdas/sleep-function/tests/sleep-function.test.ts
@@ -1,0 +1,11 @@
+import { SleepFunction } from "../src/sleep-function";
+
+describe("SleepFunction", () => {
+  it("should wait for the specified milliseconds", async () => {
+    const ms = 1000;
+    const sleepFunction = new SleepFunction();
+    const start = Date.now();
+    await sleepFunction.handler({ ms: ms }, {});
+    expect(Date.now() - start).toBeGreaterThanOrEqual(ms);
+  });
+});

--- a/lambdas/sleep-function/tsconfig.json
+++ b/lambdas/sleep-function/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "target": "es2022",
+    "strict": true,
+    "preserveConstEnums": true,
+    "sourceMap": true,
+    "module": "es2022",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["jest", "node", "aws-lambda"],
+    "outDir": "./build/",
+    "noImplicitAny": true
+  },
+  "exclude": ["node_modules", "build", "coverage"],
+  "include": ["src", "tests"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -575,6 +575,7 @@
     "lambdas/matching": {},
     "lambdas/otg-api": {},
     "lambdas/pii-redact": {},
+    "lambdas/sleep-function": {},
     "lambdas/ssm-parameters": {},
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -19740,6 +19741,10 @@
         "node": ">=8"
       }
     },
+    "node_modules/sleep-function": {
+      "resolved": "lambdas/sleep-function",
+      "link": true
+    },
     "node_modules/sonic-boom": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
@@ -35990,6 +35995,9 @@
     "slash": {
       "version": "3.0.0",
       "dev": true
+    },
+    "sleep-function": {
+      "version": "file:lambdas/sleep-function"
     },
     "sonic-boom": {
       "version": "3.8.1",

--- a/step-functions/delete-person-identity-records.asl.json
+++ b/step-functions/delete-person-identity-records.asl.json
@@ -1,0 +1,167 @@
+{
+  "Comment": "Fix session items that have an invalid TTL",
+  "StartAt": "Does input contain LastEvaluatedKey?",
+  "States": {
+    "Does input contain LastEvaluatedKey?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.LastEvaluatedKey",
+          "IsPresent": false,
+          "Next": "Scan for expiryDate of 7200 without LastEvaluatedKey"
+        }
+      ],
+      "Default": "Scan for expiryDate of 7200 with LastEvaluatedKey"
+    },
+    "Scan for expiryDate of 7200 without LastEvaluatedKey": {
+      "Type": "Task",
+      "Parameters": {
+        "TableName": "${TableName}",
+        "FilterExpression": "expiryDate = :expiryDate",
+        "ExpressionAttributeValues": {
+          ":expiryDate": {
+            "N": "7200"
+          }
+        },
+        "Limit": 100
+      },
+      "Resource": "arn:aws:states:::aws-sdk:dynamodb:scan",
+      "Next": "Create counter to track updates",
+      "ResultPath": "$.scan"
+    },
+    "Create counter to track updates": {
+      "Type": "Pass",
+      "Next": "Are there any records?",
+      "Parameters": {
+        "value": 0
+      },
+      "ResultPath": "$.counter"
+    },
+    "Scan for expiryDate of 7200 with LastEvaluatedKey": {
+      "Type": "Task",
+      "Parameters": {
+        "TableName": "${TableName}",
+        "FilterExpression": "expiryDate = :expiryDate",
+        "ExpressionAttributeValues": {
+          ":expiryDate": {
+            "N": "7200"
+          }
+        },
+        "ExclusiveStartKey": {
+          "sessionId": {
+            "S.$": "$.LastEvaluatedKey"
+          }
+        },
+        "Limit": 200
+      },
+      "Resource": "arn:aws:states:::aws-sdk:dynamodb:scan",
+      "ResultPath": "$.scan",
+      "Next": "Create counter to track updates (1)"
+    },
+    "Create counter to track updates (1)": {
+      "Type": "Pass",
+      "Next": "Are there any records?",
+      "Parameters": {
+        "value.$": "$.Processed_Records"
+      },
+      "ResultPath": "$.counter"
+    },
+    "Are there any records?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.scan.Count",
+          "NumericGreaterThan": 0,
+          "Next": "Loop over each item"
+        }
+      ],
+      "Default": "Total records processed"
+    },
+    "Loop over each item": {
+      "Type": "Map",
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
+        "StartAt": "DynamoDB DeleteItem",
+        "States": {
+          "DynamoDB DeleteItem": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::dynamodb:deleteItem",
+            "Parameters": {
+              "TableName": "${TableName}",
+              "Key": {
+                "sessionId": {
+                  "S.$": "$.sessionId.S"
+                }
+              }
+            },
+            "End": true,
+            "ResultPath": null
+          }
+        }
+      },
+      "ItemsPath": "$.scan.Items",
+      "ResultPath": null,
+      "Next": "Is the LastEvaluatedKey present?"
+    },
+    "Is the LastEvaluatedKey present?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.scan.LastEvaluatedKey.sessionId.S",
+          "IsPresent": true,
+          "Next": "Pause for 1 second"
+        }
+      ],
+      "Default": "Total records processed"
+    },
+    "Total records processed": {
+      "Type": "Pass",
+      "Next": "Success",
+      "Parameters": {
+        "Total Records Updated.$": "States.MathAdd($.counter.value, $.scan.Count)"
+      }
+    },
+    "Pause for 1 second": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${SleepFunction}",
+        "Payload": {
+          "ms": "1000"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Re-run this state machine",
+      "ResultPath": null
+    },
+    "Re-run this state machine": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::states:startExecution",
+      "Parameters": {
+        "StateMachineArn": "${StateMachineArn}",
+        "Input": {
+          "LastEvaluatedKey.$": "$.scan.LastEvaluatedKey.sessionId.S",
+          "Processed_Records.$": "States.MathAdd($.counter.value, $.scan.Count)"
+        }
+      },
+      "End": true
+    },
+    "Success": {
+      "Type": "Succeed"
+    }
+  }
+}

--- a/step-functions/delete-records.asl.json
+++ b/step-functions/delete-records.asl.json
@@ -1,0 +1,155 @@
+{
+  "Comment": "Fix session items that have an invalid TTL",
+  "StartAt": "Does input contain LastEvaluatedKey?",
+  "States": {
+    "Does input contain LastEvaluatedKey?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.LastEvaluatedKey",
+          "IsPresent": false,
+          "Next": "Scan without LastEvaluatedKey"
+        }
+      ],
+      "Default": "Scan with LastEvaluatedKey"
+    },
+    "Scan without LastEvaluatedKey": {
+      "Type": "Task",
+      "Parameters": {
+        "TableName": "${TableName}",
+        "Limit": 100
+      },
+      "Resource": "arn:aws:states:::aws-sdk:dynamodb:scan",
+      "Next": "Create counter to track updates",
+      "ResultPath": "$.scan"
+    },
+    "Create counter to track updates": {
+      "Type": "Pass",
+      "Next": "Are there any records?",
+      "Parameters": {
+        "value": 0
+      },
+      "ResultPath": "$.counter"
+    },
+    "Scan with LastEvaluatedKey": {
+      "Type": "Task",
+      "Parameters": {
+        "TableName": "${TableName}",
+        "ExclusiveStartKey": {
+          "sessionId": {
+            "S.$": "$.LastEvaluatedKey"
+          }
+        },
+        "Limit": 200
+      },
+      "Resource": "arn:aws:states:::aws-sdk:dynamodb:scan",
+      "ResultPath": "$.scan",
+      "Next": "Create counter to track updates (1)"
+    },
+    "Create counter to track updates (1)": {
+      "Type": "Pass",
+      "Next": "Are there any records?",
+      "Parameters": {
+        "value.$": "$.Processed_Records"
+      },
+      "ResultPath": "$.counter"
+    },
+    "Are there any records?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.scan.Count",
+          "NumericGreaterThan": 0,
+          "Next": "Loop over each item"
+        }
+      ],
+      "Default": "Total records processed"
+    },
+    "Loop over each item": {
+      "Type": "Map",
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
+        "StartAt": "DynamoDB DeleteItem",
+        "States": {
+          "DynamoDB DeleteItem": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::dynamodb:deleteItem",
+            "Parameters": {
+              "TableName": "${TableName}",
+              "Key": {
+                "sessionId": {
+                  "S.$": "$.sessionId.S"
+                }
+              }
+            },
+            "End": true,
+            "ResultPath": null
+          }
+        }
+      },
+      "ItemsPath": "$.scan.Items",
+      "ResultPath": null,
+      "Next": "Is the LastEvaluatedKey present?"
+    },
+    "Is the LastEvaluatedKey present?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.scan.LastEvaluatedKey.sessionId.S",
+          "IsPresent": true,
+          "Next": "Pause for 1 second"
+        }
+      ],
+      "Default": "Total records processed"
+    },
+    "Total records processed": {
+      "Type": "Pass",
+      "Next": "Success",
+      "Parameters": {
+        "Total Records Updated.$": "States.MathAdd($.counter.value, $.scan.Count)"
+      }
+    },
+    "Pause for 1 second": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${SleepFunction}",
+        "Payload": {
+          "ms": "1000"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Re-run this state machine",
+      "ResultPath": null
+    },
+    "Re-run this state machine": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::states:startExecution",
+      "Parameters": {
+        "StateMachineArn": "${StateMachineArn}",
+        "Input": {
+          "LastEvaluatedKey.$": "$.scan.LastEvaluatedKey.sessionId.S",
+          "Processed_Records.$": "States.MathAdd($.counter.value, $.scan.Count)"
+        }
+      },
+      "End": true
+    },
+    "Success": {
+      "Type": "Succeed"
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes

### What changed
Create a new state machine to delete all records in the person identity table

### Why did it change
We have a load of records that do not have valid TTLs. TTLs have been added to the table however the old records were not cleaned up. This PR deletes those records as Check HMRC is not live in production so we can benefit from just deleting all the records.

**Screenshot**
![Screenshot 2024-10-28 at 10 40 30](https://github.com/user-attachments/assets/52d806d1-c773-443c-94af-085e430a2a1a)

**Before**
![Screenshot 2024-10-28 at 12 17 05](https://github.com/user-attachments/assets/82319c17-1103-429f-8fcc-0e899c6a5501)

**After**
![Screenshot 2024-10-28 at 13 23 12](https://github.com/user-attachments/assets/a6271d77-e09c-4ada-be19-1ce3fbddfcfb)


### Issue tracking
- [OJ-2798](https://govukverify.atlassian.net/browse/OJ-2798)



[OJ-2798]: https://govukverify.atlassian.net/browse/OJ-2798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ