### PR TITLE
OJ-2798: Fix delete state machine

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -195,7 +195,7 @@ Resources:
       DefinitionUri: ../step-functions/delete-person-identity-records.asl.json
       DefinitionSubstitutions:
         TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
-        StateMachineArn: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-PersonDeleteRecordsStateMachineLog
+        StateMachineArn: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-PersonDeleteRecordsStateMachine
         SleepFunction: !Ref SleepFunction
       Logging:
         Destinations:
@@ -213,7 +213,7 @@ Resources:
             Action:
               - states:StartExecution
               - states:StartSyncExecution
-            Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-PersonDeleteRecordsStateMachineLog
+            Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-PersonDeleteRecordsStateMachine
         - Statement:
             Effect: Allow
             Action: logs:*
@@ -225,7 +225,7 @@ Resources:
   PersonDeleteRecordsStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-PersonDeleteRecordsStateMachineLog
+      LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-PersonDeleteRecordsStateMachine
       RetentionInDays: 30
 
   AttemptTblDelRecordsStateMachine:
@@ -233,7 +233,7 @@ Resources:
     Properties:
       Name: !Sub ${AWS::StackName}-AttemptTblDelRecordsStateMachine
       Type: EXPRESS
-      DefinitionUri: ../step-functions/delete-records.asl.json
+      DefinitionUri: ../step-functions/delete-attempts-records.asl.json
       DefinitionSubstitutions:
         TableName: !Ref UserAttemptsTable
         StateMachineArn: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-AttemptTblDelRecordsStateMachine

--- a/step-functions/delete-attempts-records.asl.json
+++ b/step-functions/delete-attempts-records.asl.json
@@ -76,6 +76,9 @@
               "Key": {
                 "sessionId": {
                   "S.$": "$.sessionId.S"
+                },
+                "timestamp": {
+                  "S.$": "$.timestamp.S"
                 }
               }
             },


### PR DESCRIPTION
## Proposed changes

### Why did it change
The test data being used did not accurately reflect what was in the higher accounts. When doing a DynamoDB delete, we do not have to worry about using a LastEvalutedBy 

### Issue tracking
- [OJ-2798](https://govukverify.atlassian.net/browse/OJ-2798)


[OJ-2798]: https://govukverify.atlassian.net/browse/OJ-2798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ