### PR TITLE
OJ-2897: Track LogStream creations in DynamoDB and only create if not previously created

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -184,6 +184,21 @@ Globals:
     AutoPublishAlias: live
 
 Resources:
+  RedactionLogStreamTrackingTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${AWS::StackName}-redaction-logstream-tracking
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: logStreamName
+          AttributeType: S
+      KeySchema:
+        - AttributeName: logStreamName
+          KeyType: HASH
+      TimeToLiveSpecification:
+        AttributeName: expiryDate
+        Enabled: true
+
   CiMappingFunction:
     Type: AWS::Serverless::Function
     Metadata:
@@ -2137,6 +2152,8 @@ Resources:
       CodeSigningConfigArn:
         !If [ EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref RedactionLogStreamTrackingTable
         - Statement:
             Effect: Allow
             Action: logs:*
@@ -2148,6 +2165,7 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-PIIRedact"
+          RedactionLogStreamTrackingTable: !Ref RedactionLogStreamTrackingTable
 
   PIIRedactFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/lambdas/pii-redact/src/pii-redact-handler.ts
+++ b/lambdas/pii-redact/src/pii-redact-handler.ts
@@ -10,11 +10,24 @@ import {
   CreateLogStreamCommand,
 } from "@aws-sdk/client-cloudwatch-logs";
 import { redactPII } from "./pii-redactor";
+import {
+  DynamoDBClient,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
 
 const logger = new Logger();
 const cloudwatch = new CloudWatchLogsClient();
 
+const logStreamTrackingTable = process.env.RedactionLogStreamTrackingTable;
+
 export class PiiRedactHandler implements LambdaInterface {
+  private readonly dynamodb: DynamoDBClient;
+
+  constructor(dynamodb = new DynamoDBClient()) {
+    this.dynamodb = dynamodb;
+  }
+
   public async handler(
     event: CloudWatchLogsEvent,
     _context: unknown
@@ -29,53 +42,101 @@ export class PiiRedactHandler implements LambdaInterface {
       const piiRedactLogGroup = logEvents.logGroup + "-pii-redacted";
       const logStream = logEvents.logStream;
 
-      try {
-        await cloudwatch.send(
-          new CreateLogStreamCommand({
-            logGroupName: piiRedactLogGroup,
-            logStreamName: logStream,
-          })
-        );
-      } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (!message.includes("The specified log stream already exists")) {
-          throw error;
-        }
-        logger.info(logStream + " already exists");
-      }
+      await this.createLogStream(logStream, piiRedactLogGroup);
 
       for (const logEvent of logEvents.logEvents) {
         logEvent.message = redactPII(logEvent.message);
       }
 
-      logger.info("Putting redacted logs into " + piiRedactLogGroup);
-
-      try {
-        const response: PutLogEventsCommandOutput = await cloudwatch.send(
-          new PutLogEventsCommand({
-            logGroupName: piiRedactLogGroup,
-            logStreamName: logStream,
-            logEvents: logEvents.logEvents.map((event) => ({
-              id: event.id,
-              message: JSON.stringify(JSON.parse(event.message), null, 2),
-              timestamp: event.timestamp,
-              extractedFields: event.extractedFields,
-            })),
-          })
-        );
-        logger.info(JSON.stringify(response));
-      } catch (error) {
-        logger.error(
-          `Error putting log events into ${piiRedactLogGroup}: ${error}`
-        );
-        throw error;
-      }
+      await this.saveRedactedLog(piiRedactLogGroup, logStream, logEvents);
 
       return {};
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       logger.error(`Error in PiiRedactHandler: ${message}`);
       throw error;
+    }
+  }
+
+  private async saveRedactedLog(
+    redactLogGroup: string,
+    logStream: string,
+    logEvents: CloudWatchLogsDecodedData
+  ) {
+    logger.info("Putting redacted logs into " + redactLogGroup);
+
+    try {
+      const response: PutLogEventsCommandOutput = await cloudwatch.send(
+        new PutLogEventsCommand({
+          logGroupName: redactLogGroup,
+          logStreamName: logStream,
+          logEvents: logEvents.logEvents.map((event) => ({
+            id: event.id,
+            message: this.formatMessage(event.message),
+            timestamp: event.timestamp,
+            extractedFields: event.extractedFields,
+          })),
+        })
+      );
+      logger.info(JSON.stringify(response));
+    } catch (error) {
+      logger.error(`Error putting log events into ${redactLogGroup}: ${error}`);
+      throw error;
+    }
+  }
+
+  private async createLogStream(logStreamName: string, logGroupName: string) {
+    if (!(await this.logStreamExists(logStreamName))) {
+      logger.info("Creating log stream " + logStreamName);
+
+      await cloudwatch.send(
+        new CreateLogStreamCommand({
+          logGroupName: logGroupName,
+          logStreamName: logStreamName,
+        })
+      );
+
+      await this.saveLogStreamRecordInDB(logStreamName);
+      logger.info("Added " + logStreamName + " to " + logStreamTrackingTable);
+    }
+  }
+
+  private saveLogStreamRecordInDB(logStream: string) {
+    return this.dynamodb.send(
+      new PutItemCommand({
+        TableName: logStreamTrackingTable,
+        Item: {
+          logStreamName: {
+            S: logStream,
+          },
+          expiryDate: {
+            N: (Math.floor(Date.now() / 1000) + 120 * 60).toString(),
+          },
+        },
+      })
+    );
+  }
+
+  private async logStreamExists(logStream: string) {
+    const query = await this.dynamodb.send(
+      new QueryCommand({
+        TableName: logStreamTrackingTable,
+        KeyConditionExpression: "logStreamName = :logStream",
+        ExpressionAttributeValues: {
+          ":logStream": {
+            S: logStream,
+          },
+        },
+      })
+    );
+    return query.Count !== 0;
+  }
+
+  private formatMessage(message: string) {
+    try {
+      return JSON.stringify(JSON.parse(message), null, 2);
+    } catch (error) {
+      return message;
     }
   }
 }

--- a/lambdas/pii-redact/tests/pii-redact-handler.test.ts
+++ b/lambdas/pii-redact/tests/pii-redact-handler.test.ts
@@ -1,5 +1,7 @@
 import { PiiRedactHandler } from "../src/pii-redact-handler";
 import * as zlib from "node:zlib";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import mocked = jest.mocked;
 
 let shouldMockThrowError = false;
 
@@ -43,6 +45,11 @@ describe("pii-redact-handler", () => {
   }
 
   it("should not fail when running the handler", async () => {
+    const mockDynamoDbClient = mocked(DynamoDBClient);
+    mockDynamoDbClient.prototype.send = jest.fn().mockReturnValue({
+      Count: 0,
+    });
+
     const piiData = {
       owner: undefined,
       logGroup: "dummy-log-group",
@@ -64,12 +71,16 @@ describe("pii-redact-handler", () => {
         data: compressedData,
       },
     };
-    const handler = new PiiRedactHandler();
+    const handler = new PiiRedactHandler(mockDynamoDbClient.prototype);
     const result = await handler.handler(event, {});
     expect(result).toStrictEqual({});
   });
 
   it("should throw when an error occurs creating a log stream", async () => {
+    const mockDynamoDbClient = mocked(DynamoDBClient);
+    mockDynamoDbClient.prototype.send = jest.fn().mockReturnValue({
+      Count: 0,
+    });
     shouldMockThrowError = true;
     const piiData = {
       owner: undefined,
@@ -92,11 +103,77 @@ describe("pii-redact-handler", () => {
         data: compressedData,
       },
     };
-    const handler = new PiiRedactHandler();
+    const handler = new PiiRedactHandler(mockDynamoDbClient.prototype);
 
     await expect(handler.handler(event, {})).rejects.toThrow(
       new Error("Error creating log stream")
     );
     shouldMockThrowError = false;
+  });
+
+  it("should create log stream when does not exist", async () => {
+    const mockDynamoDbClient = mocked(DynamoDBClient);
+    mockDynamoDbClient.prototype.send = jest.fn().mockReturnValue({
+      Count: 0,
+    });
+
+    const piiData = {
+      owner: undefined,
+      logGroup: "dummy-log-group",
+      logStream: "dummy-log-stream",
+      subscriptionFilters: undefined,
+      messageType: undefined,
+      logEvents: [
+        {
+          id: undefined,
+          timestamp: undefined,
+          message: "{}",
+          extractedFields: undefined,
+        },
+      ],
+    };
+    const compressedData = await encode(JSON.stringify(piiData));
+    const event = {
+      awslogs: {
+        data: compressedData,
+      },
+    };
+    const handler = new PiiRedactHandler(mockDynamoDbClient.prototype);
+    const result = await handler.handler(event, {});
+
+    expect(result).toStrictEqual({});
+  });
+
+  it("should try not create log stream when it already exists", async () => {
+    const mockDynamoDbClient = mocked(DynamoDBClient);
+    mockDynamoDbClient.prototype.send = jest.fn().mockReturnValue({
+      Count: 1,
+    });
+
+    const piiData = {
+      owner: undefined,
+      logGroup: "dummy-log-group",
+      logStream: "dummy-log-stream",
+      subscriptionFilters: undefined,
+      messageType: undefined,
+      logEvents: [
+        {
+          id: undefined,
+          timestamp: undefined,
+          message: "{}",
+          extractedFields: undefined,
+        },
+      ],
+    };
+    const compressedData = await encode(JSON.stringify(piiData));
+    const event = {
+      awslogs: {
+        data: compressedData,
+      },
+    };
+    const handler = new PiiRedactHandler(mockDynamoDbClient.prototype);
+    const result = await handler.handler(event, {});
+
+    expect(result).toStrictEqual({});
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@aws-lambda-powertools/parameters": "1.17.0",
         "@aws-lambda-powertools/tracer": "1.14.2",
         "@aws-sdk/client-cloudwatch-logs": "3.574.0",
+        "@aws-sdk/client-dynamodb": "^3.682.0",
         "@aws-sdk/client-ssm": "3.363.0",
         "esbuild": "0.23.0",
         "jose": "^5.2.2"
@@ -555,7 +556,8 @@
       }
     },
     "lambdas/epoch-time": {
-      "name": "time-in-milliseconds"
+      "name": "time-in-milliseconds",
+      "extraneous": true
     },
     "lambdas/issue-credential": {
       "extraneous": true
@@ -2446,485 +2448,576 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.458.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.458.0.tgz",
-      "integrity": "sha512-4aasF1g/YjXm3E1CQZRFgQj/Yrf2cVD1aney45qYhYmp7VgVYF1qZ7Wf2QKFaVLd8N0+ac9ZeK0uBkYz09hrfw==",
-      "devOptional": true,
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.682.0.tgz",
+      "integrity": "sha512-JrNRuQoam7cD8B7H/Fsoof4pHlCqtvlvmjm83oK7yv0Ma2raiFauwh1FLgC7QrfeP4IE1hoPOEDzU2XYudysUA==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.458.0",
-        "@aws-sdk/core": "3.451.0",
-        "@aws-sdk/credential-provider-node": "3.458.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.451.0",
-        "@aws-sdk/middleware-host-header": "3.451.0",
-        "@aws-sdk/middleware-logger": "3.451.0",
-        "@aws-sdk/middleware-recursion-detection": "3.451.0",
-        "@aws-sdk/middleware-signing": "3.451.0",
-        "@aws-sdk/middleware-user-agent": "3.451.0",
-        "@aws-sdk/region-config-resolver": "3.451.0",
-        "@aws-sdk/types": "3.451.0",
-        "@aws-sdk/util-endpoints": "3.451.0",
-        "@aws-sdk/util-user-agent-browser": "3.451.0",
-        "@aws-sdk/util-user-agent-node": "3.451.0",
-        "@smithy/config-resolver": "^2.0.18",
-        "@smithy/fetch-http-handler": "^2.2.6",
-        "@smithy/hash-node": "^2.0.15",
-        "@smithy/invalid-dependency": "^2.0.13",
-        "@smithy/middleware-content-length": "^2.0.15",
-        "@smithy/middleware-endpoint": "^2.2.0",
-        "@smithy/middleware-retry": "^2.0.20",
-        "@smithy/middleware-serde": "^2.0.13",
-        "@smithy/middleware-stack": "^2.0.7",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/node-http-handler": "^2.1.9",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/smithy-client": "^2.1.15",
-        "@smithy/types": "^2.5.0",
-        "@smithy/url-parser": "^2.0.13",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.19",
-        "@smithy/util-defaults-mode-node": "^2.0.25",
-        "@smithy/util-endpoints": "^1.0.4",
-        "@smithy/util-retry": "^2.0.6",
-        "@smithy/util-utf8": "^2.0.2",
-        "@smithy/util-waiter": "^2.0.13",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.682.0",
+        "@aws-sdk/client-sts": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.679.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.6",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso": {
-      "version": "3.458.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.458.0.tgz",
-      "integrity": "sha512-GTiIH4So0PTU5oAldtOacO/cBonu4NWGfvN3+BUaAb5Ybb9yQiwcO08PS/pXZ0cw4UTVK+zr22WVLR0reomUTA==",
-      "devOptional": true,
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.682.0.tgz",
+      "integrity": "sha512-PYH9RFUMYLFl66HSBq4tIx6fHViMLkhJHTYJoJONpBs+Td+NwVJ895AdLtDsBIhMS0YseCbPpuyjUCJgsUrwUw==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.451.0",
-        "@aws-sdk/middleware-host-header": "3.451.0",
-        "@aws-sdk/middleware-logger": "3.451.0",
-        "@aws-sdk/middleware-recursion-detection": "3.451.0",
-        "@aws-sdk/middleware-user-agent": "3.451.0",
-        "@aws-sdk/region-config-resolver": "3.451.0",
-        "@aws-sdk/types": "3.451.0",
-        "@aws-sdk/util-endpoints": "3.451.0",
-        "@aws-sdk/util-user-agent-browser": "3.451.0",
-        "@aws-sdk/util-user-agent-node": "3.451.0",
-        "@smithy/config-resolver": "^2.0.18",
-        "@smithy/fetch-http-handler": "^2.2.6",
-        "@smithy/hash-node": "^2.0.15",
-        "@smithy/invalid-dependency": "^2.0.13",
-        "@smithy/middleware-content-length": "^2.0.15",
-        "@smithy/middleware-endpoint": "^2.2.0",
-        "@smithy/middleware-retry": "^2.0.20",
-        "@smithy/middleware-serde": "^2.0.13",
-        "@smithy/middleware-stack": "^2.0.7",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/node-http-handler": "^2.1.9",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/smithy-client": "^2.1.15",
-        "@smithy/types": "^2.5.0",
-        "@smithy/url-parser": "^2.0.13",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.19",
-        "@smithy/util-defaults-mode-node": "^2.0.25",
-        "@smithy/util-endpoints": "^1.0.4",
-        "@smithy/util-retry": "^2.0.6",
-        "@smithy/util-utf8": "^2.0.2",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.682.0.tgz",
+      "integrity": "sha512-ZPZ7Y/r/w3nx/xpPzGSqSQsB090Xk5aZZOH+WBhTDn/pBEuim09BYXCLzvvxb7R7NnuoQdrTJiwimdJAhHl7ZQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.682.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sts": {
-      "version": "3.458.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.458.0.tgz",
-      "integrity": "sha512-c34zmQxcP7AM62S7SAiOztxTaHJOG+0aIb2GYUeag5sQzG7FnGGwZ7hA0ggCQc7iMkDL9UYHKKtLs1ynQenW+A==",
-      "devOptional": true,
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.682.0.tgz",
+      "integrity": "sha512-xKuo4HksZ+F8m9DOfx/ZuWNhaPuqZFPwwy0xqcBT6sWH7OAuBjv/fnpOTzyQhpVTWddlf+ECtMAMrxjxuOExGQ==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.451.0",
-        "@aws-sdk/credential-provider-node": "3.458.0",
-        "@aws-sdk/middleware-host-header": "3.451.0",
-        "@aws-sdk/middleware-logger": "3.451.0",
-        "@aws-sdk/middleware-recursion-detection": "3.451.0",
-        "@aws-sdk/middleware-sdk-sts": "3.451.0",
-        "@aws-sdk/middleware-signing": "3.451.0",
-        "@aws-sdk/middleware-user-agent": "3.451.0",
-        "@aws-sdk/region-config-resolver": "3.451.0",
-        "@aws-sdk/types": "3.451.0",
-        "@aws-sdk/util-endpoints": "3.451.0",
-        "@aws-sdk/util-user-agent-browser": "3.451.0",
-        "@aws-sdk/util-user-agent-node": "3.451.0",
-        "@smithy/config-resolver": "^2.0.18",
-        "@smithy/fetch-http-handler": "^2.2.6",
-        "@smithy/hash-node": "^2.0.15",
-        "@smithy/invalid-dependency": "^2.0.13",
-        "@smithy/middleware-content-length": "^2.0.15",
-        "@smithy/middleware-endpoint": "^2.2.0",
-        "@smithy/middleware-retry": "^2.0.20",
-        "@smithy/middleware-serde": "^2.0.13",
-        "@smithy/middleware-stack": "^2.0.7",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/node-http-handler": "^2.1.9",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/smithy-client": "^2.1.15",
-        "@smithy/types": "^2.5.0",
-        "@smithy/url-parser": "^2.0.13",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.19",
-        "@smithy/util-defaults-mode-node": "^2.0.25",
-        "@smithy/util-endpoints": "^1.0.4",
-        "@smithy/util-retry": "^2.0.6",
-        "@smithy/util-utf8": "^2.0.2",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/core": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.451.0.tgz",
-      "integrity": "sha512-SamWW2zHEf1ZKe3j1w0Piauryl8BQIlej0TBS18A4ACzhjhWXhCs13bO1S88LvPR5mBFXok3XOT6zPOnKDFktw==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.679.0.tgz",
+      "integrity": "sha512-CS6PWGX8l4v/xyvX8RtXnBisdCa5+URzKd0L6GvHChype9qKUVxO/Gg6N/y43Hvg7MNWJt9FBPNWIxUB+byJwg==",
       "dependencies": {
-        "@smithy/smithy-client": "^2.1.15",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/core": "^2.4.8",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.451.0.tgz",
-      "integrity": "sha512-9dAav7DcRgaF7xCJEQR5ER9ErXxnu/tdnVJ+UPmb1NPeIZdESv1A3lxFDEq1Fs8c4/lzAj9BpshGyJVIZwZDKg==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.679.0.tgz",
+      "integrity": "sha512-EdlTYbzMm3G7VUNAMxr9S1nC1qUNqhKlAxFU8E7cKsAe8Bp29CD5HAs3POc56AVo9GC4yRIS+/mtlZSmrckzUA==",
       "dependencies": {
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.679.0.tgz",
+      "integrity": "sha512-ZoKLubW5DqqV1/2a3TSn+9sSKg0T8SsYMt1JeirnuLJF0mCoYFUaWMyvxxKuxPoqvUsaycxKru4GkpJ10ltNBw==",
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-stream": "^3.1.9",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.458.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.458.0.tgz",
-      "integrity": "sha512-M293Im4k6QrKlWaPfElYKRPlBXMaXbkqns4YgLGBpabfIVIZEguGj/kVm7gkEKdt8rCHbBqqXgsQrtQbfDkkBQ==",
-      "devOptional": true,
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.682.0.tgz",
+      "integrity": "sha512-6eqWeHdK6EegAxqDdiCi215nT3QZPwukgWAYuVxNfJ/5m0/P7fAzF+D5kKVgByUvGJEbq/FEL8Fw7OBe64AA+g==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.451.0",
-        "@aws-sdk/credential-provider-process": "3.451.0",
-        "@aws-sdk/credential-provider-sso": "3.458.0",
-        "@aws-sdk/credential-provider-web-identity": "3.451.0",
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-env": "3.679.0",
+        "@aws-sdk/credential-provider-http": "3.679.0",
+        "@aws-sdk/credential-provider-process": "3.679.0",
+        "@aws-sdk/credential-provider-sso": "3.682.0",
+        "@aws-sdk/credential-provider-web-identity": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.682.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.458.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.458.0.tgz",
-      "integrity": "sha512-psNXL3/GAoDAqRusdy5umglXTOvxtE9XQTtmOPn4O/H2NpXqe+cB2/W+H+uikgyyck9Lu4DwMk+voFz2Hl8znw==",
-      "devOptional": true,
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.682.0.tgz",
+      "integrity": "sha512-HSmDqZcBVZrTctHCT9m++vdlDfJ1ARI218qmZa+TZzzOFNpKWy6QyHMEra45GB9GnkkMmV6unoDSPMuN0AqcMg==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.451.0",
-        "@aws-sdk/credential-provider-ini": "3.458.0",
-        "@aws-sdk/credential-provider-process": "3.451.0",
-        "@aws-sdk/credential-provider-sso": "3.458.0",
-        "@aws-sdk/credential-provider-web-identity": "3.451.0",
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.679.0",
+        "@aws-sdk/credential-provider-http": "3.679.0",
+        "@aws-sdk/credential-provider-ini": "3.682.0",
+        "@aws-sdk/credential-provider-process": "3.679.0",
+        "@aws-sdk/credential-provider-sso": "3.682.0",
+        "@aws-sdk/credential-provider-web-identity": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.451.0.tgz",
-      "integrity": "sha512-HQywSdKeD5PErcLLnZfSyCJO+6T+ZyzF+Lm/QgscSC+CbSUSIPi//s15qhBRVely/3KBV6AywxwNH+5eYgt4lQ==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.679.0.tgz",
+      "integrity": "sha512-u/p4TV8kQ0zJWDdZD4+vdQFTMhkDEJFws040Gm113VHa/Xo1SYOjbpvqeuFoz6VmM0bLvoOWjxB9MxnSQbwKpQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.458.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.458.0.tgz",
-      "integrity": "sha512-dyRAKvMLF9Ur6M0YtWSU4E5YDVEFO7Rfg5FOTk+Lwnk24UQ0RoHg3c6HZ8sPTNx16cgx4YY68UYi/HTZf56z2g==",
-      "devOptional": true,
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.682.0.tgz",
+      "integrity": "sha512-h7IH1VsWgV6YAJSWWV6y8uaRjGqLY3iBpGZlXuTH/c236NMLaNv+WqCBLeBxkFGUb2WeQ+FUPEJDCD69rgLIkg==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.458.0",
-        "@aws-sdk/token-providers": "3.451.0",
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/token-providers": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.451.0.tgz",
-      "integrity": "sha512-Xtg3Qw65EfDjWNG7o2xD6sEmumPfsy3WDGjk2phEzVg8s7hcZGxf5wYwe6UY7RJvlEKrU0rFA+AMn6Hfj5oOzg==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.679.0.tgz",
+      "integrity": "sha512-a74tLccVznXCaBefWPSysUcLXYJiSkeUmQGtalNgJ1vGkE36W5l/8czFiiowdWdKWz7+x6xf0w+Kjkjlj42Ung==",
       "dependencies": {
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.679.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.451.0.tgz",
-      "integrity": "sha512-j8a5jAfhWmsK99i2k8oR8zzQgXrsJtgrLxc3js6U+525mcZytoiDndkWTmD5fjJ1byU1U2E5TaPq+QJeDip05Q==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.679.0.tgz",
+      "integrity": "sha512-y176HuQ8JRY3hGX8rQzHDSbCl9P5Ny9l16z4xmaiLo+Qfte7ee4Yr3yaAKd7GFoJ3/Mhud2XZ37fR015MfYl2w==",
       "dependencies": {
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.451.0.tgz",
-      "integrity": "sha512-0kHrYEyVeB2QBfP6TfbI240aRtatLZtcErJbhpiNUb+CQPgEL3crIjgVE8yYiJumZ7f0jyjo8HLPkwD1/2APaw==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.679.0.tgz",
+      "integrity": "sha512-0vet8InEj7nvIvGKk+ch7bEF5SyZ7Us9U7YTEgXPrBNStKeRUsgwRm0ijPWWd0a3oz2okaEwXsFl7G/vI0XiEA==",
       "dependencies": {
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.451.0.tgz",
-      "integrity": "sha512-J6jL6gJ7orjHGM70KDRcCP7so/J2SnkN4vZ9YRLTeeZY6zvBuHDjX8GCIgSqPn/nXFXckZO8XSnA7u6+3TAT0w==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.679.0.tgz",
+      "integrity": "sha512-sQoAZFsQiW/LL3DfKMYwBoGjYDEnMbA9WslWN8xneCmBAwKo6IcSksvYs23PP8XMIoBGe2I2J9BSr654XWygTQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.451.0.tgz",
-      "integrity": "sha512-UJ6UfVUEgp0KIztxpAeelPXI5MLj9wUtUCqYeIMP7C1ZhoEMNm3G39VLkGN43dNhBf1LqjsV9jkKMZbVfYXuwg==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.451.0",
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.451.0.tgz",
-      "integrity": "sha512-s5ZlcIoLNg1Huj4Qp06iKniE8nJt/Pj1B/fjhWc6cCPCM7XJYUCejCnRh6C5ZJoBEYodjuwZBejPc1Wh3j+znA==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.5.0",
-        "@smithy/util-middleware": "^2.0.6",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.451.0.tgz",
-      "integrity": "sha512-8NM/0JiKLNvT9wtAQVl1DFW0cEO7OvZyLSUBLNLTHqyvOZxKaZ8YFk7d8PL6l76LeUKRxq4NMxfZQlUIRe0eSA==",
-      "devOptional": true,
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.682.0.tgz",
+      "integrity": "sha512-7TyvYR9HdGH1/Nq0eeApUTM4izB6rExiw87khVYuJwZHr6FmvIL1FsOVFro/4WlXa0lg4LiYOm/8H8dHv+fXTg==",
       "dependencies": {
-        "@aws-sdk/types": "3.451.0",
-        "@aws-sdk/util-endpoints": "3.451.0",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@smithy/core": "^2.4.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.451.0.tgz",
-      "integrity": "sha512-3iMf4OwzrFb4tAAmoROXaiORUk2FvSejnHIw/XHvf/jjR4EqGGF95NZP/n/MeFZMizJWVssrwS412GmoEyoqhg==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.679.0.tgz",
+      "integrity": "sha512-Ybx54P8Tg6KKq5ck7uwdjiKif7n/8g1x+V0V9uTjBjRWqaIgiqzXwKWoPj6NCNkE7tJNtqI4JrNxp/3S3HvmRw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/types": "^2.5.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.6",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/token-providers": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.451.0.tgz",
-      "integrity": "sha512-ij1L5iUbn6CwxVOT1PG4NFjsrsKN9c4N1YEM0lkl6DwmaNOscjLKGSNyj9M118vSWsOs1ZDbTwtj++h0O/BWrQ==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.679.0.tgz",
+      "integrity": "sha512-1/+Zso/x2jqgutKixYFQEGli0FELTgah6bm7aB+m2FAWH4Hz7+iMUsazg6nSWm714sG9G3h5u42Dmpvi9X6/hA==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.451.0",
-        "@aws-sdk/middleware-logger": "3.451.0",
-        "@aws-sdk/middleware-recursion-detection": "3.451.0",
-        "@aws-sdk/middleware-user-agent": "3.451.0",
-        "@aws-sdk/region-config-resolver": "3.451.0",
-        "@aws-sdk/types": "3.451.0",
-        "@aws-sdk/util-endpoints": "3.451.0",
-        "@aws-sdk/util-user-agent-browser": "3.451.0",
-        "@aws-sdk/util-user-agent-node": "3.451.0",
-        "@smithy/config-resolver": "^2.0.18",
-        "@smithy/fetch-http-handler": "^2.2.6",
-        "@smithy/hash-node": "^2.0.15",
-        "@smithy/invalid-dependency": "^2.0.13",
-        "@smithy/middleware-content-length": "^2.0.15",
-        "@smithy/middleware-endpoint": "^2.2.0",
-        "@smithy/middleware-retry": "^2.0.20",
-        "@smithy/middleware-serde": "^2.0.13",
-        "@smithy/middleware-stack": "^2.0.7",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/node-http-handler": "^2.1.9",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/smithy-client": "^2.1.15",
-        "@smithy/types": "^2.5.0",
-        "@smithy/url-parser": "^2.0.13",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.19",
-        "@smithy/util-defaults-mode-node": "^2.0.25",
-        "@smithy/util-endpoints": "^1.0.4",
-        "@smithy/util-retry": "^2.0.6",
-        "@smithy/util-utf8": "^2.0.2",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.679.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/types": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
-      "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+      "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
       "dependencies": {
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.451.0.tgz",
-      "integrity": "sha512-giqLGBTnRIcKkDqwU7+GQhKbtJ5Ku35cjGQIfMyOga6pwTBUbaK0xW1Sdd8sBQ1GhApscnChzI9o/R9x0368vw==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.679.0.tgz",
+      "integrity": "sha512-YL6s4Y/1zC45OvddvgE139fjeWSKKPgLlnfrvhVL7alNyY9n7beR4uhoDpNrt5mI6sn9qiBF17790o+xLAXjjg==",
       "dependencies": {
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/util-endpoints": "^1.0.4",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-endpoints": "^2.1.3",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.451.0.tgz",
-      "integrity": "sha512-Ws5mG3J0TQifH7OTcMrCTexo7HeSAc3cBgjfhS/ofzPUzVCtsyg0G7I6T7wl7vJJETix2Kst2cpOsxygPgPD9w==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.679.0.tgz",
+      "integrity": "sha512-CusSm2bTBG1kFypcsqU8COhnYc6zltobsqs3nRrvYqYaOqtMnuE46K4XTWpnzKgwDejgZGOE+WYyprtAxrPvmQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/types": "^2.5.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/types": "^3.5.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.451.0.tgz",
-      "integrity": "sha512-TBzm6P+ql4mkGFAjPlO1CI+w3yUT+NulaiALjl/jNX/nnUp6HsJsVxJf4nVFQTG5KRV0iqMypcs7I3KIhH+LmA==",
-      "devOptional": true,
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.682.0.tgz",
+      "integrity": "sha512-so5s+j0gPoTS0HM4HPL+G0ajk0T6cQAg8JXzRgvyiQAxqie+zGCZAV3VuVeMNWMVbzsgZl0pYZaatPFTLG/AxA==",
       "dependencies": {
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -2933,6 +3026,614 @@
         "aws-crt": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/abort-controller": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.6.tgz",
+      "integrity": "sha512-0XuhuHQlEqbNQZp7QxxrFTdVWdwxch4vjxYgfInF91hZFkPxf9QDrdQka0KfxFMPqLNzSw0b95uGTrLliQUavQ==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/config-resolver": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.10.tgz",
+      "integrity": "sha512-Uh0Sz9gdUuz538nvkPiyv1DZRX9+D15EKDtnQP5rYVAzM/dnYk3P8cg73jcxyOitPgT3mE3OVj7ky7sibzHWkw==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/core": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.1.tgz",
+      "integrity": "sha512-DujtuDA7BGEKExJ05W5OdxCoyekcKT3Rhg1ZGeiUWaz2BJIWXjZmsG/DIP4W48GHno7AQwRsaCb8NcBgH3QZpg==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-stream": "^3.2.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.5.tgz",
+      "integrity": "sha512-4FTQGAsuwqTzVMmiRVTn0RR9GrbRfkP0wfu/tXWVHd2LgNpTY0uglQpIScXK4NaEyXbB3JmZt8gfVqO50lP8wg==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
+      "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/querystring-builder": "^3.0.7",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/hash-node": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.8.tgz",
+      "integrity": "sha512-tlNQYbfpWXHimHqrvgo14DrMAgUBua/cNoz9fMYcDmYej7MAmUcjav/QKQbFc3NrcPxeJ7QClER4tWZmfwoPng==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.8.tgz",
+      "integrity": "sha512-7Qynk6NWtTQhnGTTZwks++nJhQ1O54Mzi7fz4PqZOiYXb4Z1Flpb2yRvdALoggTS8xjtohWUM+RygOtB30YL3Q==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.10.tgz",
+      "integrity": "sha512-T4dIdCs1d/+/qMpwhJ1DzOhxCZjZHbHazEPJWdB4GDi2HjIZllVzeBEcdJUN0fomV8DURsgOyrbEUzg3vzTaOg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.1.tgz",
+      "integrity": "sha512-wWO3xYmFm6WRW8VsEJ5oU6h7aosFXfszlz3Dj176pTij6o21oZnzkCLzShfmRaaCHDkBXWBdO0c4sQAvLFP6zA==",
+      "dependencies": {
+        "@smithy/core": "^2.5.1",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-middleware": "^3.0.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.25.tgz",
+      "integrity": "sha512-m1F70cPaMBML4HiTgCw5I+jFNtjgz5z5UdGnUbG37vw6kh4UvizFYjqJGHvicfgKMkDL6mXwyPp5mhZg02g5sg==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/service-error-classification": "^3.0.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.8.tgz",
+      "integrity": "sha512-Xg2jK9Wc/1g/MBMP/EUn2DLspN8LNt+GMe7cgF+Ty3vl+Zvu+VeZU5nmhveU+H8pxyTsjrAkci8NqY6OuvZnjA==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.8.tgz",
+      "integrity": "sha512-d7ZuwvYgp1+3682Nx0MD3D/HtkmZd49N3JUndYWQXfRZrYEnCWYc8BHcNmVsPAp9gKvlurdg/mubE6b/rPS9MA==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/node-http-handler": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.5.tgz",
+      "integrity": "sha512-PkOwPNeKdvX/jCpn0A8n9/TyoxjGZB8WVoJmm9YzsnAgggTj4CrjpRHlTQw7dlLZ320n1mY1y+nTRUDViKi/3w==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.6",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/querystring-builder": "^3.0.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/property-provider": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.8.tgz",
+      "integrity": "sha512-ukNUyo6rHmusG64lmkjFeXemwYuKge1BJ8CtpVKmrxQxc6rhUX0vebcptFA9MmrGsnLhwnnqeH83VTU9hwOpjA==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/protocol-http": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.5.tgz",
+      "integrity": "sha512-hsjtwpIemmCkm3ZV5fd/T0bPIugW1gJXwZ/hpuVubt2hEUApIoUTrf6qIdh9MAWlw0vjMrA1ztJLAwtNaZogvg==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.8.tgz",
+      "integrity": "sha512-btYxGVqFUARbUrN6VhL9c3dnSviIwBYD9Rz1jHuN1hgh28Fpv2xjU1HeCeDJX68xctz7r4l1PBnFhGg1WBBPuA==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.8.tgz",
+      "integrity": "sha512-BtEk3FG7Ks64GAbt+JnKqwuobJNX8VmFLBsKIwWr1D60T426fGrV2L3YS5siOcUhhp6/Y6yhBw1PSPxA5p7qGg==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.8.tgz",
+      "integrity": "sha512-uEC/kCCFto83bz5ZzapcrgGqHOh/0r69sZ2ZuHlgoD5kYgXJEThCoTuw/y1Ub3cE7aaKdznb+jD9xRPIfIwD7g==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/signature-v4": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+      "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/smithy-client": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.2.tgz",
+      "integrity": "sha512-dxw1BDxJiY9/zI3cBqfVrInij6ShjpV4fmGHesGZZUiP9OSE/EVfdwdRz0PgvkEvrZHpsj2htRaHJfftE8giBA==",
+      "dependencies": {
+        "@smithy/core": "^2.5.1",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-stream": "^3.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/types": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
+      "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/url-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.8.tgz",
+      "integrity": "sha512-4FdOhwpTW7jtSFWm7SpfLGKIBC9ZaTKG5nBF0wK24aoQKQyDIKUw3+KFWCQ9maMzrgTJIuOvOnsV2lLGW5XjTg==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.25.tgz",
+      "integrity": "sha512-fRw7zymjIDt6XxIsLwfJfYUfbGoO9CmCJk6rjJ/X5cd20+d2Is7xjU5Kt/AiDt6hX8DAf5dztmfP5O82gR9emA==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.25.tgz",
+      "integrity": "sha512-H3BSZdBDiVZGzt8TG51Pd2FvFO0PAx/A0mJ0EH8a13KJ6iUCdYnw/Dk/MdC1kTd0eUuUGisDFaxXVXo4HHFL1g==",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/credential-provider-imds": "^3.2.5",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-endpoints": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.4.tgz",
+      "integrity": "sha512-kPt8j4emm7rdMWQyL0F89o92q10gvCUa6sBkBtDJ7nV2+P7wpXczzOfoDJ49CKXe5CCqb8dc1W+ZdLlrKzSAnQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-middleware": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.8.tgz",
+      "integrity": "sha512-p7iYAPaQjoeM+AKABpYWeDdtwQNxasr4aXQEA/OmbOaug9V0odRVDy3Wx4ci8soljE/JXQo+abV0qZpW8NX0yA==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-retry": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.8.tgz",
+      "integrity": "sha512-TCEhLnY581YJ+g1x0hapPz13JFqzmh/pMWL2KEFASC51qCfw3+Y47MrTmea4bUE5vsdxQ4F6/KFbUeSz22Q1ow==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-stream": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.2.1.tgz",
+      "integrity": "sha512-R3ufuzJRxSJbE58K9AEnL/uSZyVdHzud9wLS8tIbXclxKzoe09CRohj2xV8wpx5tj7ZbiJaKYcutMm1eYgz/0A==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+      "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/querystring-builder": "^3.0.8",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-stream/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-waiter": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.7.tgz",
+      "integrity": "sha512-d5yGlQtmN/z5eoTtIYgkvOw27US2Ous4VycnXatyoImIF9tzlcpnKqQ/V7qhvJmb2p6xZne1NopCLakdTnkBBQ==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.6",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-eventbridge": {
@@ -8416,16 +9117,15 @@
       }
     },
     "node_modules/@aws-sdk/endpoint-cache": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.310.0.tgz",
-      "integrity": "sha512-y3wipforet41EDTI0vnzxILqwAGll1KfI5qcdX9pXF/WF1f+3frcOtPiWtQEZQpy4czRogKm3BHo70QBYAZxlQ==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.679.0.tgz",
+      "integrity": "sha512-6+DMgt91IkyO1gXqANH0lOZr/Em7CpzRQOD7Mku1icXDVfpVFnW4DZyUP+6EYeZlHgi2KwVYh5Hp7++oKcYWiw==",
       "dependencies": {
         "mnemonist": "0.38.3",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
@@ -8458,33 +9158,92 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.451.0.tgz",
-      "integrity": "sha512-OvRb9M12JZaxjpdwPqTndAexjp/s4Ub/GumxED2uy7KDzo95f2A4CA3yRB03ExBERWtKtCShpJG87oTERkDiaQ==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.679.0.tgz",
+      "integrity": "sha512-CawkXT6Bqz6bgLOLY7P+a166lScXabIJOxoBrp3yzt5UORWnUvY7cjRiDMVu6uA9EzAn33m6pT9ULsQtLD71EA==",
       "dependencies": {
-        "@aws-sdk/endpoint-cache": "3.310.0",
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/endpoint-cache": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/types": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
-      "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+      "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
       "dependencies": {
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@smithy/property-provider": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.8.tgz",
+      "integrity": "sha512-ukNUyo6rHmusG64lmkjFeXemwYuKge1BJ8CtpVKmrxQxc6rhUX0vebcptFA9MmrGsnLhwnnqeH83VTU9hwOpjA==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@smithy/protocol-http": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.5.tgz",
+      "integrity": "sha512-hsjtwpIemmCkm3ZV5fd/T0bPIugW1gJXwZ/hpuVubt2hEUApIoUTrf6qIdh9MAWlw0vjMrA1ztJLAwtNaZogvg==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@smithy/types": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
+      "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
@@ -11401,7 +12160,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.1.1.tgz",
       "integrity": "sha512-kYy6BLJJNif+uqNENtJqWdXcpqo1LS+nj1AfXcDhOpqpSHJSAkVySLyZV9fkmuVO21lzGoxjvd1imGGJHph/IA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@smithy/abort-controller": "^2.1.1",
         "@smithy/types": "^2.9.1",
@@ -11680,8 +12439,7 @@
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.31",
@@ -18185,7 +18943,6 @@
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
-      "devOptional": true,
       "dependencies": {
         "obliterator": "^1.6.1"
       }
@@ -18442,8 +19199,7 @@
     "node_modules/obliterator": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
-      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
-      "devOptional": true
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -20189,10 +20945,6 @@
       "dependencies": {
         "real-require": "^0.2.0"
       }
-    },
-    "node_modules/time-in-milliseconds": {
-      "resolved": "lambdas/epoch-time",
-      "link": true
     },
     "node_modules/timers-ext": {
       "version": "0.1.8",
@@ -22556,423 +23308,976 @@
       }
     },
     "@aws-sdk/client-dynamodb": {
-      "version": "3.458.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.458.0.tgz",
-      "integrity": "sha512-4aasF1g/YjXm3E1CQZRFgQj/Yrf2cVD1aney45qYhYmp7VgVYF1qZ7Wf2QKFaVLd8N0+ac9ZeK0uBkYz09hrfw==",
-      "devOptional": true,
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.682.0.tgz",
+      "integrity": "sha512-JrNRuQoam7cD8B7H/Fsoof4pHlCqtvlvmjm83oK7yv0Ma2raiFauwh1FLgC7QrfeP4IE1hoPOEDzU2XYudysUA==",
       "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.458.0",
-        "@aws-sdk/core": "3.451.0",
-        "@aws-sdk/credential-provider-node": "3.458.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.451.0",
-        "@aws-sdk/middleware-host-header": "3.451.0",
-        "@aws-sdk/middleware-logger": "3.451.0",
-        "@aws-sdk/middleware-recursion-detection": "3.451.0",
-        "@aws-sdk/middleware-signing": "3.451.0",
-        "@aws-sdk/middleware-user-agent": "3.451.0",
-        "@aws-sdk/region-config-resolver": "3.451.0",
-        "@aws-sdk/types": "3.451.0",
-        "@aws-sdk/util-endpoints": "3.451.0",
-        "@aws-sdk/util-user-agent-browser": "3.451.0",
-        "@aws-sdk/util-user-agent-node": "3.451.0",
-        "@smithy/config-resolver": "^2.0.18",
-        "@smithy/fetch-http-handler": "^2.2.6",
-        "@smithy/hash-node": "^2.0.15",
-        "@smithy/invalid-dependency": "^2.0.13",
-        "@smithy/middleware-content-length": "^2.0.15",
-        "@smithy/middleware-endpoint": "^2.2.0",
-        "@smithy/middleware-retry": "^2.0.20",
-        "@smithy/middleware-serde": "^2.0.13",
-        "@smithy/middleware-stack": "^2.0.7",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/node-http-handler": "^2.1.9",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/smithy-client": "^2.1.15",
-        "@smithy/types": "^2.5.0",
-        "@smithy/url-parser": "^2.0.13",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.19",
-        "@smithy/util-defaults-mode-node": "^2.0.25",
-        "@smithy/util-endpoints": "^1.0.4",
-        "@smithy/util-retry": "^2.0.6",
-        "@smithy/util-utf8": "^2.0.2",
-        "@smithy/util-waiter": "^2.0.13",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.682.0",
+        "@aws-sdk/client-sts": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.679.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.6",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "dependencies": {
-        "@aws-sdk/client-sso": {
-          "version": "3.458.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.458.0.tgz",
-          "integrity": "sha512-GTiIH4So0PTU5oAldtOacO/cBonu4NWGfvN3+BUaAb5Ybb9yQiwcO08PS/pXZ0cw4UTVK+zr22WVLR0reomUTA==",
-          "devOptional": true,
+        "@aws-crypto/sha256-browser": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+          "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
           "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/core": "3.451.0",
-            "@aws-sdk/middleware-host-header": "3.451.0",
-            "@aws-sdk/middleware-logger": "3.451.0",
-            "@aws-sdk/middleware-recursion-detection": "3.451.0",
-            "@aws-sdk/middleware-user-agent": "3.451.0",
-            "@aws-sdk/region-config-resolver": "3.451.0",
-            "@aws-sdk/types": "3.451.0",
-            "@aws-sdk/util-endpoints": "3.451.0",
-            "@aws-sdk/util-user-agent-browser": "3.451.0",
-            "@aws-sdk/util-user-agent-node": "3.451.0",
-            "@smithy/config-resolver": "^2.0.18",
-            "@smithy/fetch-http-handler": "^2.2.6",
-            "@smithy/hash-node": "^2.0.15",
-            "@smithy/invalid-dependency": "^2.0.13",
-            "@smithy/middleware-content-length": "^2.0.15",
-            "@smithy/middleware-endpoint": "^2.2.0",
-            "@smithy/middleware-retry": "^2.0.20",
-            "@smithy/middleware-serde": "^2.0.13",
-            "@smithy/middleware-stack": "^2.0.7",
-            "@smithy/node-config-provider": "^2.1.5",
-            "@smithy/node-http-handler": "^2.1.9",
-            "@smithy/protocol-http": "^3.0.9",
-            "@smithy/smithy-client": "^2.1.15",
-            "@smithy/types": "^2.5.0",
-            "@smithy/url-parser": "^2.0.13",
-            "@smithy/util-base64": "^2.0.1",
-            "@smithy/util-body-length-browser": "^2.0.0",
-            "@smithy/util-body-length-node": "^2.1.0",
-            "@smithy/util-defaults-mode-browser": "^2.0.19",
-            "@smithy/util-defaults-mode-node": "^2.0.25",
-            "@smithy/util-endpoints": "^1.0.4",
-            "@smithy/util-retry": "^2.0.6",
-            "@smithy/util-utf8": "^2.0.2",
-            "tslib": "^2.5.0"
+            "@aws-crypto/sha256-js": "^5.2.0",
+            "@aws-crypto/supports-web-crypto": "^5.2.0",
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-utf8": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+              "requires": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+          "requires": {
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+          "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-utf8": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+              "requires": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.682.0.tgz",
+          "integrity": "sha512-PYH9RFUMYLFl66HSBq4tIx6fHViMLkhJHTYJoJONpBs+Td+NwVJ895AdLtDsBIhMS0YseCbPpuyjUCJgsUrwUw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/middleware-host-header": "3.679.0",
+            "@aws-sdk/middleware-logger": "3.679.0",
+            "@aws-sdk/middleware-recursion-detection": "3.679.0",
+            "@aws-sdk/middleware-user-agent": "3.682.0",
+            "@aws-sdk/region-config-resolver": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@aws-sdk/util-endpoints": "3.679.0",
+            "@aws-sdk/util-user-agent-browser": "3.679.0",
+            "@aws-sdk/util-user-agent-node": "3.682.0",
+            "@smithy/config-resolver": "^3.0.9",
+            "@smithy/core": "^2.4.8",
+            "@smithy/fetch-http-handler": "^3.2.9",
+            "@smithy/hash-node": "^3.0.7",
+            "@smithy/invalid-dependency": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.9",
+            "@smithy/middleware-endpoint": "^3.1.4",
+            "@smithy/middleware-retry": "^3.0.23",
+            "@smithy/middleware-serde": "^3.0.7",
+            "@smithy/middleware-stack": "^3.0.7",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/node-http-handler": "^3.2.4",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/url-parser": "^3.0.7",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.23",
+            "@smithy/util-defaults-mode-node": "^3.0.23",
+            "@smithy/util-endpoints": "^2.1.3",
+            "@smithy/util-middleware": "^3.0.7",
+            "@smithy/util-retry": "^3.0.7",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.682.0.tgz",
+          "integrity": "sha512-ZPZ7Y/r/w3nx/xpPzGSqSQsB090Xk5aZZOH+WBhTDn/pBEuim09BYXCLzvvxb7R7NnuoQdrTJiwimdJAhHl7ZQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/credential-provider-node": "3.682.0",
+            "@aws-sdk/middleware-host-header": "3.679.0",
+            "@aws-sdk/middleware-logger": "3.679.0",
+            "@aws-sdk/middleware-recursion-detection": "3.679.0",
+            "@aws-sdk/middleware-user-agent": "3.682.0",
+            "@aws-sdk/region-config-resolver": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@aws-sdk/util-endpoints": "3.679.0",
+            "@aws-sdk/util-user-agent-browser": "3.679.0",
+            "@aws-sdk/util-user-agent-node": "3.682.0",
+            "@smithy/config-resolver": "^3.0.9",
+            "@smithy/core": "^2.4.8",
+            "@smithy/fetch-http-handler": "^3.2.9",
+            "@smithy/hash-node": "^3.0.7",
+            "@smithy/invalid-dependency": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.9",
+            "@smithy/middleware-endpoint": "^3.1.4",
+            "@smithy/middleware-retry": "^3.0.23",
+            "@smithy/middleware-serde": "^3.0.7",
+            "@smithy/middleware-stack": "^3.0.7",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/node-http-handler": "^3.2.4",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/url-parser": "^3.0.7",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.23",
+            "@smithy/util-defaults-mode-node": "^3.0.23",
+            "@smithy/util-endpoints": "^2.1.3",
+            "@smithy/util-middleware": "^3.0.7",
+            "@smithy/util-retry": "^3.0.7",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/client-sts": {
-          "version": "3.458.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.458.0.tgz",
-          "integrity": "sha512-c34zmQxcP7AM62S7SAiOztxTaHJOG+0aIb2GYUeag5sQzG7FnGGwZ7hA0ggCQc7iMkDL9UYHKKtLs1ynQenW+A==",
-          "devOptional": true,
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.682.0.tgz",
+          "integrity": "sha512-xKuo4HksZ+F8m9DOfx/ZuWNhaPuqZFPwwy0xqcBT6sWH7OAuBjv/fnpOTzyQhpVTWddlf+ECtMAMrxjxuOExGQ==",
           "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/core": "3.451.0",
-            "@aws-sdk/credential-provider-node": "3.458.0",
-            "@aws-sdk/middleware-host-header": "3.451.0",
-            "@aws-sdk/middleware-logger": "3.451.0",
-            "@aws-sdk/middleware-recursion-detection": "3.451.0",
-            "@aws-sdk/middleware-sdk-sts": "3.451.0",
-            "@aws-sdk/middleware-signing": "3.451.0",
-            "@aws-sdk/middleware-user-agent": "3.451.0",
-            "@aws-sdk/region-config-resolver": "3.451.0",
-            "@aws-sdk/types": "3.451.0",
-            "@aws-sdk/util-endpoints": "3.451.0",
-            "@aws-sdk/util-user-agent-browser": "3.451.0",
-            "@aws-sdk/util-user-agent-node": "3.451.0",
-            "@smithy/config-resolver": "^2.0.18",
-            "@smithy/fetch-http-handler": "^2.2.6",
-            "@smithy/hash-node": "^2.0.15",
-            "@smithy/invalid-dependency": "^2.0.13",
-            "@smithy/middleware-content-length": "^2.0.15",
-            "@smithy/middleware-endpoint": "^2.2.0",
-            "@smithy/middleware-retry": "^2.0.20",
-            "@smithy/middleware-serde": "^2.0.13",
-            "@smithy/middleware-stack": "^2.0.7",
-            "@smithy/node-config-provider": "^2.1.5",
-            "@smithy/node-http-handler": "^2.1.9",
-            "@smithy/protocol-http": "^3.0.9",
-            "@smithy/smithy-client": "^2.1.15",
-            "@smithy/types": "^2.5.0",
-            "@smithy/url-parser": "^2.0.13",
-            "@smithy/util-base64": "^2.0.1",
-            "@smithy/util-body-length-browser": "^2.0.0",
-            "@smithy/util-body-length-node": "^2.1.0",
-            "@smithy/util-defaults-mode-browser": "^2.0.19",
-            "@smithy/util-defaults-mode-node": "^2.0.25",
-            "@smithy/util-endpoints": "^1.0.4",
-            "@smithy/util-retry": "^2.0.6",
-            "@smithy/util-utf8": "^2.0.2",
-            "fast-xml-parser": "4.2.5",
-            "tslib": "^2.5.0"
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/client-sso-oidc": "3.682.0",
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/credential-provider-node": "3.682.0",
+            "@aws-sdk/middleware-host-header": "3.679.0",
+            "@aws-sdk/middleware-logger": "3.679.0",
+            "@aws-sdk/middleware-recursion-detection": "3.679.0",
+            "@aws-sdk/middleware-user-agent": "3.682.0",
+            "@aws-sdk/region-config-resolver": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@aws-sdk/util-endpoints": "3.679.0",
+            "@aws-sdk/util-user-agent-browser": "3.679.0",
+            "@aws-sdk/util-user-agent-node": "3.682.0",
+            "@smithy/config-resolver": "^3.0.9",
+            "@smithy/core": "^2.4.8",
+            "@smithy/fetch-http-handler": "^3.2.9",
+            "@smithy/hash-node": "^3.0.7",
+            "@smithy/invalid-dependency": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.9",
+            "@smithy/middleware-endpoint": "^3.1.4",
+            "@smithy/middleware-retry": "^3.0.23",
+            "@smithy/middleware-serde": "^3.0.7",
+            "@smithy/middleware-stack": "^3.0.7",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/node-http-handler": "^3.2.4",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/url-parser": "^3.0.7",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.23",
+            "@smithy/util-defaults-mode-node": "^3.0.23",
+            "@smithy/util-endpoints": "^2.1.3",
+            "@smithy/util-middleware": "^3.0.7",
+            "@smithy/util-retry": "^3.0.7",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/core": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.451.0.tgz",
-          "integrity": "sha512-SamWW2zHEf1ZKe3j1w0Piauryl8BQIlej0TBS18A4ACzhjhWXhCs13bO1S88LvPR5mBFXok3XOT6zPOnKDFktw==",
-          "devOptional": true,
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.679.0.tgz",
+          "integrity": "sha512-CS6PWGX8l4v/xyvX8RtXnBisdCa5+URzKd0L6GvHChype9qKUVxO/Gg6N/y43Hvg7MNWJt9FBPNWIxUB+byJwg==",
           "requires": {
-            "@smithy/smithy-client": "^2.1.15",
-            "tslib": "^2.5.0"
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/core": "^2.4.8",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/signature-v4": "^4.2.0",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-middleware": "^3.0.7",
+            "fast-xml-parser": "4.4.1",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.451.0.tgz",
-          "integrity": "sha512-9dAav7DcRgaF7xCJEQR5ER9ErXxnu/tdnVJ+UPmb1NPeIZdESv1A3lxFDEq1Fs8c4/lzAj9BpshGyJVIZwZDKg==",
-          "devOptional": true,
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.679.0.tgz",
+          "integrity": "sha512-EdlTYbzMm3G7VUNAMxr9S1nC1qUNqhKlAxFU8E7cKsAe8Bp29CD5HAs3POc56AVo9GC4yRIS+/mtlZSmrckzUA==",
           "requires": {
-            "@aws-sdk/types": "3.451.0",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/types": "^2.5.0",
-            "tslib": "^2.5.0"
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-http": {
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.679.0.tgz",
+          "integrity": "sha512-ZoKLubW5DqqV1/2a3TSn+9sSKg0T8SsYMt1JeirnuLJF0mCoYFUaWMyvxxKuxPoqvUsaycxKru4GkpJ10ltNBw==",
+          "requires": {
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/fetch-http-handler": "^3.2.9",
+            "@smithy/node-http-handler": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/smithy-client": "^3.4.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-stream": "^3.1.9",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.458.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.458.0.tgz",
-          "integrity": "sha512-M293Im4k6QrKlWaPfElYKRPlBXMaXbkqns4YgLGBpabfIVIZEguGj/kVm7gkEKdt8rCHbBqqXgsQrtQbfDkkBQ==",
-          "devOptional": true,
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.682.0.tgz",
+          "integrity": "sha512-6eqWeHdK6EegAxqDdiCi215nT3QZPwukgWAYuVxNfJ/5m0/P7fAzF+D5kKVgByUvGJEbq/FEL8Fw7OBe64AA+g==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.451.0",
-            "@aws-sdk/credential-provider-process": "3.451.0",
-            "@aws-sdk/credential-provider-sso": "3.458.0",
-            "@aws-sdk/credential-provider-web-identity": "3.451.0",
-            "@aws-sdk/types": "3.451.0",
-            "@smithy/credential-provider-imds": "^2.0.0",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/shared-ini-file-loader": "^2.0.6",
-            "@smithy/types": "^2.5.0",
-            "tslib": "^2.5.0"
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/credential-provider-env": "3.679.0",
+            "@aws-sdk/credential-provider-http": "3.679.0",
+            "@aws-sdk/credential-provider-process": "3.679.0",
+            "@aws-sdk/credential-provider-sso": "3.682.0",
+            "@aws-sdk/credential-provider-web-identity": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/credential-provider-imds": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.458.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.458.0.tgz",
-          "integrity": "sha512-psNXL3/GAoDAqRusdy5umglXTOvxtE9XQTtmOPn4O/H2NpXqe+cB2/W+H+uikgyyck9Lu4DwMk+voFz2Hl8znw==",
-          "devOptional": true,
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.682.0.tgz",
+          "integrity": "sha512-HSmDqZcBVZrTctHCT9m++vdlDfJ1ARI218qmZa+TZzzOFNpKWy6QyHMEra45GB9GnkkMmV6unoDSPMuN0AqcMg==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.451.0",
-            "@aws-sdk/credential-provider-ini": "3.458.0",
-            "@aws-sdk/credential-provider-process": "3.451.0",
-            "@aws-sdk/credential-provider-sso": "3.458.0",
-            "@aws-sdk/credential-provider-web-identity": "3.451.0",
-            "@aws-sdk/types": "3.451.0",
-            "@smithy/credential-provider-imds": "^2.0.0",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/shared-ini-file-loader": "^2.0.6",
-            "@smithy/types": "^2.5.0",
-            "tslib": "^2.5.0"
+            "@aws-sdk/credential-provider-env": "3.679.0",
+            "@aws-sdk/credential-provider-http": "3.679.0",
+            "@aws-sdk/credential-provider-ini": "3.682.0",
+            "@aws-sdk/credential-provider-process": "3.679.0",
+            "@aws-sdk/credential-provider-sso": "3.682.0",
+            "@aws-sdk/credential-provider-web-identity": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/credential-provider-imds": "^3.2.4",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.451.0.tgz",
-          "integrity": "sha512-HQywSdKeD5PErcLLnZfSyCJO+6T+ZyzF+Lm/QgscSC+CbSUSIPi//s15qhBRVely/3KBV6AywxwNH+5eYgt4lQ==",
-          "devOptional": true,
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.679.0.tgz",
+          "integrity": "sha512-u/p4TV8kQ0zJWDdZD4+vdQFTMhkDEJFws040Gm113VHa/Xo1SYOjbpvqeuFoz6VmM0bLvoOWjxB9MxnSQbwKpQ==",
           "requires": {
-            "@aws-sdk/types": "3.451.0",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/shared-ini-file-loader": "^2.0.6",
-            "@smithy/types": "^2.5.0",
-            "tslib": "^2.5.0"
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.458.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.458.0.tgz",
-          "integrity": "sha512-dyRAKvMLF9Ur6M0YtWSU4E5YDVEFO7Rfg5FOTk+Lwnk24UQ0RoHg3c6HZ8sPTNx16cgx4YY68UYi/HTZf56z2g==",
-          "devOptional": true,
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.682.0.tgz",
+          "integrity": "sha512-h7IH1VsWgV6YAJSWWV6y8uaRjGqLY3iBpGZlXuTH/c236NMLaNv+WqCBLeBxkFGUb2WeQ+FUPEJDCD69rgLIkg==",
           "requires": {
-            "@aws-sdk/client-sso": "3.458.0",
-            "@aws-sdk/token-providers": "3.451.0",
-            "@aws-sdk/types": "3.451.0",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/shared-ini-file-loader": "^2.0.6",
-            "@smithy/types": "^2.5.0",
-            "tslib": "^2.5.0"
+            "@aws-sdk/client-sso": "3.682.0",
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/token-providers": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.451.0.tgz",
-          "integrity": "sha512-Xtg3Qw65EfDjWNG7o2xD6sEmumPfsy3WDGjk2phEzVg8s7hcZGxf5wYwe6UY7RJvlEKrU0rFA+AMn6Hfj5oOzg==",
-          "devOptional": true,
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.679.0.tgz",
+          "integrity": "sha512-a74tLccVznXCaBefWPSysUcLXYJiSkeUmQGtalNgJ1vGkE36W5l/8czFiiowdWdKWz7+x6xf0w+Kjkjlj42Ung==",
           "requires": {
-            "@aws-sdk/types": "3.451.0",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/types": "^2.5.0",
-            "tslib": "^2.5.0"
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/middleware-host-header": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.451.0.tgz",
-          "integrity": "sha512-j8a5jAfhWmsK99i2k8oR8zzQgXrsJtgrLxc3js6U+525mcZytoiDndkWTmD5fjJ1byU1U2E5TaPq+QJeDip05Q==",
-          "devOptional": true,
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.679.0.tgz",
+          "integrity": "sha512-y176HuQ8JRY3hGX8rQzHDSbCl9P5Ny9l16z4xmaiLo+Qfte7ee4Yr3yaAKd7GFoJ3/Mhud2XZ37fR015MfYl2w==",
           "requires": {
-            "@aws-sdk/types": "3.451.0",
-            "@smithy/protocol-http": "^3.0.9",
-            "@smithy/types": "^2.5.0",
-            "tslib": "^2.5.0"
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/middleware-logger": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.451.0.tgz",
-          "integrity": "sha512-0kHrYEyVeB2QBfP6TfbI240aRtatLZtcErJbhpiNUb+CQPgEL3crIjgVE8yYiJumZ7f0jyjo8HLPkwD1/2APaw==",
-          "devOptional": true,
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.679.0.tgz",
+          "integrity": "sha512-0vet8InEj7nvIvGKk+ch7bEF5SyZ7Us9U7YTEgXPrBNStKeRUsgwRm0ijPWWd0a3oz2okaEwXsFl7G/vI0XiEA==",
           "requires": {
-            "@aws-sdk/types": "3.451.0",
-            "@smithy/types": "^2.5.0",
-            "tslib": "^2.5.0"
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.451.0.tgz",
-          "integrity": "sha512-J6jL6gJ7orjHGM70KDRcCP7so/J2SnkN4vZ9YRLTeeZY6zvBuHDjX8GCIgSqPn/nXFXckZO8XSnA7u6+3TAT0w==",
-          "devOptional": true,
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.679.0.tgz",
+          "integrity": "sha512-sQoAZFsQiW/LL3DfKMYwBoGjYDEnMbA9WslWN8xneCmBAwKo6IcSksvYs23PP8XMIoBGe2I2J9BSr654XWygTQ==",
           "requires": {
-            "@aws-sdk/types": "3.451.0",
-            "@smithy/protocol-http": "^3.0.9",
-            "@smithy/types": "^2.5.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.451.0.tgz",
-          "integrity": "sha512-UJ6UfVUEgp0KIztxpAeelPXI5MLj9wUtUCqYeIMP7C1ZhoEMNm3G39VLkGN43dNhBf1LqjsV9jkKMZbVfYXuwg==",
-          "devOptional": true,
-          "requires": {
-            "@aws-sdk/middleware-signing": "3.451.0",
-            "@aws-sdk/types": "3.451.0",
-            "@smithy/types": "^2.5.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-signing": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.451.0.tgz",
-          "integrity": "sha512-s5ZlcIoLNg1Huj4Qp06iKniE8nJt/Pj1B/fjhWc6cCPCM7XJYUCejCnRh6C5ZJoBEYodjuwZBejPc1Wh3j+znA==",
-          "devOptional": true,
-          "requires": {
-            "@aws-sdk/types": "3.451.0",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/protocol-http": "^3.0.9",
-            "@smithy/signature-v4": "^2.0.0",
-            "@smithy/types": "^2.5.0",
-            "@smithy/util-middleware": "^2.0.6",
-            "tslib": "^2.5.0"
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/middleware-user-agent": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.451.0.tgz",
-          "integrity": "sha512-8NM/0JiKLNvT9wtAQVl1DFW0cEO7OvZyLSUBLNLTHqyvOZxKaZ8YFk7d8PL6l76LeUKRxq4NMxfZQlUIRe0eSA==",
-          "devOptional": true,
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.682.0.tgz",
+          "integrity": "sha512-7TyvYR9HdGH1/Nq0eeApUTM4izB6rExiw87khVYuJwZHr6FmvIL1FsOVFro/4WlXa0lg4LiYOm/8H8dHv+fXTg==",
           "requires": {
-            "@aws-sdk/types": "3.451.0",
-            "@aws-sdk/util-endpoints": "3.451.0",
-            "@smithy/protocol-http": "^3.0.9",
-            "@smithy/types": "^2.5.0",
-            "tslib": "^2.5.0"
+            "@aws-sdk/core": "3.679.0",
+            "@aws-sdk/types": "3.679.0",
+            "@aws-sdk/util-endpoints": "3.679.0",
+            "@smithy/core": "^2.4.8",
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/region-config-resolver": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.451.0.tgz",
-          "integrity": "sha512-3iMf4OwzrFb4tAAmoROXaiORUk2FvSejnHIw/XHvf/jjR4EqGGF95NZP/n/MeFZMizJWVssrwS412GmoEyoqhg==",
-          "devOptional": true,
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.679.0.tgz",
+          "integrity": "sha512-Ybx54P8Tg6KKq5ck7uwdjiKif7n/8g1x+V0V9uTjBjRWqaIgiqzXwKWoPj6NCNkE7tJNtqI4JrNxp/3S3HvmRw==",
           "requires": {
-            "@smithy/node-config-provider": "^2.1.5",
-            "@smithy/types": "^2.5.0",
-            "@smithy/util-config-provider": "^2.0.0",
-            "@smithy/util-middleware": "^2.0.6",
-            "tslib": "^2.5.0"
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.7",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/token-providers": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.451.0.tgz",
-          "integrity": "sha512-ij1L5iUbn6CwxVOT1PG4NFjsrsKN9c4N1YEM0lkl6DwmaNOscjLKGSNyj9M118vSWsOs1ZDbTwtj++h0O/BWrQ==",
-          "devOptional": true,
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.679.0.tgz",
+          "integrity": "sha512-1/+Zso/x2jqgutKixYFQEGli0FELTgah6bm7aB+m2FAWH4Hz7+iMUsazg6nSWm714sG9G3h5u42Dmpvi9X6/hA==",
           "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/middleware-host-header": "3.451.0",
-            "@aws-sdk/middleware-logger": "3.451.0",
-            "@aws-sdk/middleware-recursion-detection": "3.451.0",
-            "@aws-sdk/middleware-user-agent": "3.451.0",
-            "@aws-sdk/region-config-resolver": "3.451.0",
-            "@aws-sdk/types": "3.451.0",
-            "@aws-sdk/util-endpoints": "3.451.0",
-            "@aws-sdk/util-user-agent-browser": "3.451.0",
-            "@aws-sdk/util-user-agent-node": "3.451.0",
-            "@smithy/config-resolver": "^2.0.18",
-            "@smithy/fetch-http-handler": "^2.2.6",
-            "@smithy/hash-node": "^2.0.15",
-            "@smithy/invalid-dependency": "^2.0.13",
-            "@smithy/middleware-content-length": "^2.0.15",
-            "@smithy/middleware-endpoint": "^2.2.0",
-            "@smithy/middleware-retry": "^2.0.20",
-            "@smithy/middleware-serde": "^2.0.13",
-            "@smithy/middleware-stack": "^2.0.7",
-            "@smithy/node-config-provider": "^2.1.5",
-            "@smithy/node-http-handler": "^2.1.9",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/protocol-http": "^3.0.9",
-            "@smithy/shared-ini-file-loader": "^2.0.6",
-            "@smithy/smithy-client": "^2.1.15",
-            "@smithy/types": "^2.5.0",
-            "@smithy/url-parser": "^2.0.13",
-            "@smithy/util-base64": "^2.0.1",
-            "@smithy/util-body-length-browser": "^2.0.0",
-            "@smithy/util-body-length-node": "^2.1.0",
-            "@smithy/util-defaults-mode-browser": "^2.0.19",
-            "@smithy/util-defaults-mode-node": "^2.0.25",
-            "@smithy/util-endpoints": "^1.0.4",
-            "@smithy/util-retry": "^2.0.6",
-            "@smithy/util-utf8": "^2.0.2",
-            "tslib": "^2.5.0"
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/property-provider": "^3.1.7",
+            "@smithy/shared-ini-file-loader": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
-          "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
-          "devOptional": true,
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+          "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
           "requires": {
-            "@smithy/types": "^2.5.0",
-            "tslib": "^2.5.0"
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/util-endpoints": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.451.0.tgz",
-          "integrity": "sha512-giqLGBTnRIcKkDqwU7+GQhKbtJ5Ku35cjGQIfMyOga6pwTBUbaK0xW1Sdd8sBQ1GhApscnChzI9o/R9x0368vw==",
-          "devOptional": true,
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.679.0.tgz",
+          "integrity": "sha512-YL6s4Y/1zC45OvddvgE139fjeWSKKPgLlnfrvhVL7alNyY9n7beR4uhoDpNrt5mI6sn9qiBF17790o+xLAXjjg==",
           "requires": {
-            "@aws-sdk/types": "3.451.0",
-            "@smithy/util-endpoints": "^1.0.4",
-            "tslib": "^2.5.0"
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-endpoints": "^2.1.3",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/util-user-agent-browser": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.451.0.tgz",
-          "integrity": "sha512-Ws5mG3J0TQifH7OTcMrCTexo7HeSAc3cBgjfhS/ofzPUzVCtsyg0G7I6T7wl7vJJETix2Kst2cpOsxygPgPD9w==",
-          "devOptional": true,
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.679.0.tgz",
+          "integrity": "sha512-CusSm2bTBG1kFypcsqU8COhnYc6zltobsqs3nRrvYqYaOqtMnuE46K4XTWpnzKgwDejgZGOE+WYyprtAxrPvmQ==",
           "requires": {
-            "@aws-sdk/types": "3.451.0",
-            "@smithy/types": "^2.5.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/types": "^3.5.0",
             "bowser": "^2.11.0",
-            "tslib": "^2.5.0"
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/util-user-agent-node": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.451.0.tgz",
-          "integrity": "sha512-TBzm6P+ql4mkGFAjPlO1CI+w3yUT+NulaiALjl/jNX/nnUp6HsJsVxJf4nVFQTG5KRV0iqMypcs7I3KIhH+LmA==",
-          "devOptional": true,
+          "version": "3.682.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.682.0.tgz",
+          "integrity": "sha512-so5s+j0gPoTS0HM4HPL+G0ajk0T6cQAg8JXzRgvyiQAxqie+zGCZAV3VuVeMNWMVbzsgZl0pYZaatPFTLG/AxA==",
           "requires": {
-            "@aws-sdk/types": "3.451.0",
-            "@smithy/node-config-provider": "^2.1.5",
-            "@smithy/types": "^2.5.0",
-            "tslib": "^2.5.0"
+            "@aws-sdk/middleware-user-agent": "3.682.0",
+            "@aws-sdk/types": "3.679.0",
+            "@smithy/node-config-provider": "^3.1.8",
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
           }
+        },
+        "@smithy/abort-controller": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.6.tgz",
+          "integrity": "sha512-0XuhuHQlEqbNQZp7QxxrFTdVWdwxch4vjxYgfInF91hZFkPxf9QDrdQka0KfxFMPqLNzSw0b95uGTrLliQUavQ==",
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/config-resolver": {
+          "version": "3.0.10",
+          "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.10.tgz",
+          "integrity": "sha512-Uh0Sz9gdUuz538nvkPiyv1DZRX9+D15EKDtnQP5rYVAzM/dnYk3P8cg73jcxyOitPgT3mE3OVj7ky7sibzHWkw==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/core": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.1.tgz",
+          "integrity": "sha512-DujtuDA7BGEKExJ05W5OdxCoyekcKT3Rhg1ZGeiUWaz2BJIWXjZmsG/DIP4W48GHno7AQwRsaCb8NcBgH3QZpg==",
+          "requires": {
+            "@smithy/middleware-serde": "^3.0.8",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-stream": "^3.2.1",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/credential-provider-imds": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.5.tgz",
+          "integrity": "sha512-4FTQGAsuwqTzVMmiRVTn0RR9GrbRfkP0wfu/tXWVHd2LgNpTY0uglQpIScXK4NaEyXbB3JmZt8gfVqO50lP8wg==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/property-provider": "^3.1.8",
+            "@smithy/types": "^3.6.0",
+            "@smithy/url-parser": "^3.0.8",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.9",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
+          "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.4",
+            "@smithy/querystring-builder": "^3.0.7",
+            "@smithy/types": "^3.5.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/hash-node": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.8.tgz",
+          "integrity": "sha512-tlNQYbfpWXHimHqrvgo14DrMAgUBua/cNoz9fMYcDmYej7MAmUcjav/QKQbFc3NrcPxeJ7QClER4tWZmfwoPng==",
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-buffer-from": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+              "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+              "requires": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@smithy/invalid-dependency": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.8.tgz",
+          "integrity": "sha512-7Qynk6NWtTQhnGTTZwks++nJhQ1O54Mzi7fz4PqZOiYXb4Z1Flpb2yRvdALoggTS8xjtohWUM+RygOtB30YL3Q==",
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-content-length": {
+          "version": "3.0.10",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.10.tgz",
+          "integrity": "sha512-T4dIdCs1d/+/qMpwhJ1DzOhxCZjZHbHazEPJWdB4GDi2HjIZllVzeBEcdJUN0fomV8DURsgOyrbEUzg3vzTaOg==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.1.tgz",
+          "integrity": "sha512-wWO3xYmFm6WRW8VsEJ5oU6h7aosFXfszlz3Dj176pTij6o21oZnzkCLzShfmRaaCHDkBXWBdO0c4sQAvLFP6zA==",
+          "requires": {
+            "@smithy/core": "^2.5.1",
+            "@smithy/middleware-serde": "^3.0.8",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/shared-ini-file-loader": "^3.1.9",
+            "@smithy/types": "^3.6.0",
+            "@smithy/url-parser": "^3.0.8",
+            "@smithy/util-middleware": "^3.0.8",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-retry": {
+          "version": "3.0.25",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.25.tgz",
+          "integrity": "sha512-m1F70cPaMBML4HiTgCw5I+jFNtjgz5z5UdGnUbG37vw6kh4UvizFYjqJGHvicfgKMkDL6mXwyPp5mhZg02g5sg==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/service-error-classification": "^3.0.8",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-retry": "^3.0.8",
+            "tslib": "^2.6.2",
+            "uuid": "^9.0.1"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.8.tgz",
+          "integrity": "sha512-Xg2jK9Wc/1g/MBMP/EUn2DLspN8LNt+GMe7cgF+Ty3vl+Zvu+VeZU5nmhveU+H8pxyTsjrAkci8NqY6OuvZnjA==",
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.8.tgz",
+          "integrity": "sha512-d7ZuwvYgp1+3682Nx0MD3D/HtkmZd49N3JUndYWQXfRZrYEnCWYc8BHcNmVsPAp9gKvlurdg/mubE6b/rPS9MA==",
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+          "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.8",
+            "@smithy/shared-ini-file-loader": "^3.1.9",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.5.tgz",
+          "integrity": "sha512-PkOwPNeKdvX/jCpn0A8n9/TyoxjGZB8WVoJmm9YzsnAgggTj4CrjpRHlTQw7dlLZ320n1mY1y+nTRUDViKi/3w==",
+          "requires": {
+            "@smithy/abort-controller": "^3.1.6",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/querystring-builder": "^3.0.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.8",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.8.tgz",
+          "integrity": "sha512-ukNUyo6rHmusG64lmkjFeXemwYuKge1BJ8CtpVKmrxQxc6rhUX0vebcptFA9MmrGsnLhwnnqeH83VTU9hwOpjA==",
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.5.tgz",
+          "integrity": "sha512-hsjtwpIemmCkm3ZV5fd/T0bPIugW1gJXwZ/hpuVubt2hEUApIoUTrf6qIdh9MAWlw0vjMrA1ztJLAwtNaZogvg==",
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.8.tgz",
+          "integrity": "sha512-btYxGVqFUARbUrN6VhL9c3dnSviIwBYD9Rz1jHuN1hgh28Fpv2xjU1HeCeDJX68xctz7r4l1PBnFhGg1WBBPuA==",
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.8.tgz",
+          "integrity": "sha512-BtEk3FG7Ks64GAbt+JnKqwuobJNX8VmFLBsKIwWr1D60T426fGrV2L3YS5siOcUhhp6/Y6yhBw1PSPxA5p7qGg==",
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/service-error-classification": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.8.tgz",
+          "integrity": "sha512-uEC/kCCFto83bz5ZzapcrgGqHOh/0r69sZ2ZuHlgoD5kYgXJEThCoTuw/y1Ub3cE7aaKdznb+jD9xRPIfIwD7g==",
+          "requires": {
+            "@smithy/types": "^3.6.0"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+          "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+          "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.8",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.2.tgz",
+          "integrity": "sha512-dxw1BDxJiY9/zI3cBqfVrInij6ShjpV4fmGHesGZZUiP9OSE/EVfdwdRz0PgvkEvrZHpsj2htRaHJfftE8giBA==",
+          "requires": {
+            "@smithy/core": "^2.5.1",
+            "@smithy/middleware-endpoint": "^3.2.1",
+            "@smithy/middleware-stack": "^3.0.8",
+            "@smithy/protocol-http": "^4.1.5",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-stream": "^3.2.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
+          "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.8.tgz",
+          "integrity": "sha512-4FdOhwpTW7jtSFWm7SpfLGKIBC9ZaTKG5nBF0wK24aoQKQyDIKUw3+KFWCQ9maMzrgTJIuOvOnsV2lLGW5XjTg==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-buffer-from": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+              "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+              "requires": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@smithy/util-body-length-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+          "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-node": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+          "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-config-provider": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+          "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-browser": {
+          "version": "3.0.25",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.25.tgz",
+          "integrity": "sha512-fRw7zymjIDt6XxIsLwfJfYUfbGoO9CmCJk6rjJ/X5cd20+d2Is7xjU5Kt/AiDt6hX8DAf5dztmfP5O82gR9emA==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.8",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-node": {
+          "version": "3.0.25",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.25.tgz",
+          "integrity": "sha512-H3BSZdBDiVZGzt8TG51Pd2FvFO0PAx/A0mJ0EH8a13KJ6iUCdYnw/Dk/MdC1kTd0eUuUGisDFaxXVXo4HHFL1g==",
+          "requires": {
+            "@smithy/config-resolver": "^3.0.10",
+            "@smithy/credential-provider-imds": "^3.2.5",
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/property-provider": "^3.1.8",
+            "@smithy/smithy-client": "^3.4.2",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-endpoints": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.4.tgz",
+          "integrity": "sha512-kPt8j4emm7rdMWQyL0F89o92q10gvCUa6sBkBtDJ7nV2+P7wpXczzOfoDJ49CKXe5CCqb8dc1W+ZdLlrKzSAnQ==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.9",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.8.tgz",
+          "integrity": "sha512-p7iYAPaQjoeM+AKABpYWeDdtwQNxasr4aXQEA/OmbOaug9V0odRVDy3Wx4ci8soljE/JXQo+abV0qZpW8NX0yA==",
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-retry": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.8.tgz",
+          "integrity": "sha512-TCEhLnY581YJ+g1x0hapPz13JFqzmh/pMWL2KEFASC51qCfw3+Y47MrTmea4bUE5vsdxQ4F6/KFbUeSz22Q1ow==",
+          "requires": {
+            "@smithy/service-error-classification": "^3.0.8",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.2.1.tgz",
+          "integrity": "sha512-R3ufuzJRxSJbE58K9AEnL/uSZyVdHzud9wLS8tIbXclxKzoe09CRohj2xV8wpx5tj7ZbiJaKYcutMm1eYgz/0A==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^4.0.0",
+            "@smithy/node-http-handler": "^3.2.5",
+            "@smithy/types": "^3.6.0",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/fetch-http-handler": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+              "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
+              "requires": {
+                "@smithy/protocol-http": "^4.1.5",
+                "@smithy/querystring-builder": "^3.0.8",
+                "@smithy/types": "^3.6.0",
+                "@smithy/util-base64": "^3.0.0",
+                "tslib": "^2.6.2"
+              }
+            },
+            "@smithy/util-buffer-from": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+              "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+              "requires": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/util-buffer-from": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+              "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+              "requires": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "@smithy/util-waiter": {
+          "version": "3.1.7",
+          "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.7.tgz",
+          "integrity": "sha512-d5yGlQtmN/z5eoTtIYgkvOw27US2Ous4VycnXatyoImIF9tzlcpnKqQ/V7qhvJmb2p6xZne1NopCLakdTnkBBQ==",
+          "requires": {
+            "@smithy/abort-controller": "^3.1.6",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
         }
       }
     },
@@ -27518,13 +28823,12 @@
       }
     },
     "@aws-sdk/endpoint-cache": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.310.0.tgz",
-      "integrity": "sha512-y3wipforet41EDTI0vnzxILqwAGll1KfI5qcdX9pXF/WF1f+3frcOtPiWtQEZQpy4czRogKm3BHo70QBYAZxlQ==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.679.0.tgz",
+      "integrity": "sha512-6+DMgt91IkyO1gXqANH0lOZr/Em7CpzRQOD7Mku1icXDVfpVFnW4DZyUP+6EYeZlHgi2KwVYh5Hp7++oKcYWiw==",
       "requires": {
         "mnemonist": "0.38.3",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/is-array-buffer": {
@@ -27548,27 +28852,71 @@
       }
     },
     "@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.451.0.tgz",
-      "integrity": "sha512-OvRb9M12JZaxjpdwPqTndAexjp/s4Ub/GumxED2uy7KDzo95f2A4CA3yRB03ExBERWtKtCShpJG87oTERkDiaQ==",
-      "devOptional": true,
+      "version": "3.679.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.679.0.tgz",
+      "integrity": "sha512-CawkXT6Bqz6bgLOLY7P+a166lScXabIJOxoBrp3yzt5UORWnUvY7cjRiDMVu6uA9EzAn33m6pT9ULsQtLD71EA==",
       "requires": {
-        "@aws-sdk/endpoint-cache": "3.310.0",
-        "@aws-sdk/types": "3.451.0",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/endpoint-cache": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.451.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
-          "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
-          "devOptional": true,
+          "version": "3.679.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
+          "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
           "requires": {
-            "@smithy/types": "^2.5.0",
-            "tslib": "^2.5.0"
+            "@smithy/types": "^3.5.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+          "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.8",
+            "@smithy/shared-ini-file-loader": "^3.1.9",
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.8",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.8.tgz",
+          "integrity": "sha512-ukNUyo6rHmusG64lmkjFeXemwYuKge1BJ8CtpVKmrxQxc6rhUX0vebcptFA9MmrGsnLhwnnqeH83VTU9hwOpjA==",
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.5.tgz",
+          "integrity": "sha512-hsjtwpIemmCkm3ZV5fd/T0bPIugW1gJXwZ/hpuVubt2hEUApIoUTrf6qIdh9MAWlw0vjMrA1ztJLAwtNaZogvg==",
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+          "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+          "requires": {
+            "@smithy/types": "^3.6.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
+          "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
+          "requires": {
+            "tslib": "^2.6.2"
           }
         }
       }
@@ -29751,7 +31099,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.1.1.tgz",
       "integrity": "sha512-kYy6BLJJNif+uqNENtJqWdXcpqo1LS+nj1AfXcDhOpqpSHJSAkVySLyZV9fkmuVO21lzGoxjvd1imGGJHph/IA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@smithy/abort-controller": "^2.1.1",
         "@smithy/types": "^2.9.1",
@@ -30012,8 +31360,7 @@
     "@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
     },
     "@types/yargs": {
       "version": "17.0.31",
@@ -34924,7 +36271,6 @@
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
-      "devOptional": true,
       "requires": {
         "obliterator": "^1.6.1"
       }
@@ -35109,8 +36455,7 @@
     "obliterator": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
-      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
-      "devOptional": true
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
     },
     "on-exit-leak-free": {
       "version": "2.1.2",
@@ -36345,9 +37690,6 @@
       "requires": {
         "real-require": "^0.2.0"
       }
-    },
-    "time-in-milliseconds": {
-      "version": "file:lambdas/epoch-time"
     },
     "timers-ext": {
       "version": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "deploy": "./deploy.sh"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.682.0",
     "@aws-lambda-powertools/commons": "1.14.2",
     "@aws-lambda-powertools/logger": "2.3.0",
     "@aws-lambda-powertools/metrics": "1.14.2",


### PR DESCRIPTION
## Proposed changes

### What and Why did it change
When we create a log stream, if it already exists, the CloudWatch API will return a HTTP 400. While, for our Lambda this is OK as we ignore the error, the side effect is that Dynatrace alerts that there are errors which means our dashboard will always be red.

To solve this, we create a new DynamoDB table that keeps track of all the log streams that we create (with a TTL of 2 hours). We use this table in our Lambda to check if we should create a new log stream not.

We do not use the DescribeLogStream API because that has a limit of 5 executions per second which does not fit our requirements.


### Issue tracking
- [OJ-2897](https://govukverify.atlassian.net/browse/OJ-2897)


[OJ-2897]: https://govukverify.atlassian.net/browse/OJ-2897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ