### PR TITLE
Linear10PercentEvery1Minute allowed value added

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -54,6 +54,7 @@ Parameters:
       - Canary10Percent10Minutes
       - Canary10Percent15Minutes
       - Canary10Percent30Minutes
+      - Linear10PercentEvery1Minute
   StepFunctionsDeploymentPreference:
     Description: "Specifies the configuration to enable gradual StepFunction deployments. It can be used to set deployment type and also allows skipping canary deployment by setting to 'ALL_AT_ONCE'"
     Type: String


### PR DESCRIPTION

## Proposed changes

### What changed

Linear10PercentEvery1Minute allowed value added for canary deployment

### Why did it change

Value required for lambda canary deployment in lower envs
Dev and build will use Linear10PercentEvery1Minute therefore this is required value

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
