### PR TITLE
Ips 1234 50 percent 5 minutes canary deployment

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -62,6 +62,7 @@ Conditions:
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, ""]]
   IsDevEnvironment: !Equals [!Ref Environment, dev]
   IsLocalDevEnvironment: !Equals [!Ref Environment, localdev]
+  IsProdEnvironment: !Equals [!Ref Environment, production]
   IsDevLikeEnvironment:
     !Or [!Condition IsLocalDevEnvironment, !Condition IsDevEnvironment]
   IsNotDevLikeEnvironment: !Not
@@ -776,8 +777,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
-        Interval: 15
-        Percentage: 10
+        Interval: !If [IsProdEnvironment, 15, 5]
+        Percentage: !If [IsProdEnvironment, 10, 50]
         Alarms: !If
           - UseCanaryDeploymentAlarms
           - - !Ref TimeFunctionCanaryErrors
@@ -850,8 +851,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
-        Interval: 15
-        Percentage: 10
+        Interval: !If [IsProdEnvironment, 15, 5]
+        Percentage: !If [IsProdEnvironment, 10, 50]
         Alarms: !If
           - UseCanaryDeploymentAlarms
           - - !Ref OTGFunctionCanaryErrors
@@ -995,8 +996,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
-        Interval: 15
-        Percentage: 10
+        Interval: !If [IsProdEnvironment, 15, 5]
+        Percentage: !If [IsProdEnvironment, 10, 50]
         Alarms: !If
           - UseCanaryDeploymentAlarms
           - - !Ref SsmParametersFunctionCanaryErrors
@@ -1098,8 +1099,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
-        Interval: 15
-        Percentage: 10
+        Interval: !If [IsProdEnvironment, 15, 5]
+        Percentage: !If [IsProdEnvironment, 10, 50]
         Alarms: !If
           - UseCanaryDeploymentAlarms
           - - !Ref CiMappingFunctionCanaryErrors
@@ -1917,8 +1918,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionsDeploymentPreference
-        Interval: 15
-        Percentage: 10
+        Interval: !If [IsProdEnvironment, 15, 5]
+        Percentage: !If [IsProdEnvironment, 10, 50]
         Alarms: !If
           - UseCanaryDeploymentAlarms
           - - !Ref CredentialSubjectFunctionCanaryErrors


### PR DESCRIPTION
Implementation for 50Percent 5Minute canary traffic shifting for non prod envs.

## Proposed changes

### What changed

State machine conditional added that sets deployment to 50Percent 5Minutes for non prod env. 

        Interval: !If [IsProdEnvironment, 15, 5]
        Percentage: !If [IsProdEnvironment, 10, 50]

This means if environment is not production, use 5 minute interval and 50 Percent, but if it is production, then use the agreed strategy 10Percent 15 minutes.

The non prod strategy is only enabled when the pipeline parameter is set to CANARY from ALLATONCE e.g. here for [build](https://github.com/govuk-one-login/identity-common-infra/blob/main/terraform/orange/hmrc-check/build/pipelines/main.tf#L25)

### Why did it change

Setting 50 Percent 5 Minutes  state machine deployments means the pipeline can run faster and test changes in lower envs in a more even split.

### Issue tracking

- [IPS-1234](https://govukverify.atlassian.net/browse/IPS-1234)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

step function 50 Percent split:
![image](https://github.com/user-attachments/assets/b7181d84-2bba-4242-aca8-03c59d5ddee6)

Lambda 50 Percent split:
<img width="1146" alt="image" src="https://github.com/user-attachments/assets/e2b1592d-e212-47cf-9d86-edf18b0eaa6a">

[IPS-1234]: https://govukverify.atlassian.net/browse/IPS-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ