### PR TITLE
OJ-2932: Redact CI and reasons from logs

### DIFF
--- a/lambdas/pii-redact/src/pii-redactor.ts
+++ b/lambdas/pii-redact/src/pii-redactor.ts
@@ -3,6 +3,7 @@ import { ipAddressPatterns } from "./regex/ip-address";
 import { namePatterns } from "./regex/name-pattern";
 import { dobPatterns } from "./regex/date-of-birth";
 import { addressPatterns } from "./regex/address";
+import { ciPatterns } from "./regex/contra-indicator";
 import { otherPatterns } from "./regex/uncategorised-patterns";
 
 export const defaultPatterns = [
@@ -11,6 +12,7 @@ export const defaultPatterns = [
   ...namePatterns,
   ...dobPatterns,
   ...addressPatterns,
+  ...ciPatterns,
   ...otherPatterns,
 ];
 

--- a/lambdas/pii-redact/src/regex/contra-indicator.ts
+++ b/lambdas/pii-redact/src/regex/contra-indicator.ts
@@ -1,0 +1,48 @@
+export const ciPatterns = [
+  {
+    regex: /\\"reason\\":\s*\\"([^"]*)\\"/g,
+    replacement: '\\"reason\\": \\"***\\"',
+  },
+  {
+    regex: /\\\\"reason\\\\":\s*\\\\"([^"]*)\\\\"/g,
+    replacement: '\\\\"reason\\\\": \\\\"***\\\\"',
+  },
+  {
+    regex: /\\\\\\"reason\\\\\\":\s*\\\\\\"([^"]*)\\\\\\"/g,
+    replacement: '\\\\\\"reason\\\\\\": \\\\\\"***\\\\\\"',
+  },
+  {
+    regex: /\\"ci\\":\s*\\"([^"]*)\\"/g,
+    replacement: '\\"ci\\": \\"***\\"',
+  },
+  {
+    regex: /\\\\\\"ci\\\\\\":\s*\\\\\\"([^"]*)\\\\\\"/g,
+    replacement: '\\\\\\"ci\\\\\\": \\\\\\"***\\\\\\"',
+  },
+  {
+    regex: /\\\\\\"ci\\\\\\":\[\\\\\\"[^\\"]*\\\\\\"]/g,
+    replacement: '\\\\\\"ci\\\\\\": [\\\\\\"***\\\\\\"]',
+  },
+  {
+    regex: /\\"ci\\":\[\\"[^\\"]*\\"]/g,
+    replacement: '\\"ci\\": [\\"***\\"]',
+  },
+  {
+    regex: /\\"contraIndicationMapping\\"\s*:\s*\[[^\]]*]/g,
+    replacement: '\\"contraindicationMapping\\": [\\"***\\"]',
+  },
+  {
+    regex: /\\"contraindicationMappings\\":\s*\\"([^"]*)\\"/g,
+    replacement: '\\"contraindicationMappings\\": \\"***\\"',
+  },
+  {
+    regex: /\\"contraindicatorReasonMappings\\":\s*\\"([^"]*)\\"/g,
+    replacement: '\\"contraindicatorReasonMappings\\": \\"***\\"',
+  },
+  {
+    regex:
+      /\\"Name\\":\s*\\"\/check-hmrc-cri-api\/contraindicationMappings\\",\s*\\"Value\\":\s*\\"([^"]*)\\/g,
+    replacement:
+      '\\"Name\\":\\"/check-hmrc-cri-api/contraindicationMappings\\",\\"Value\\":\\"***\\',
+  },
+];

--- a/lambdas/pii-redact/tests/redact-pii.test.ts
+++ b/lambdas/pii-redact/tests/redact-pii.test.ts
@@ -51,6 +51,23 @@ describe("redact-pii", () => {
     });
   });
 
+  describe("NiNO", () => {
+    it("should redact a ci and reason", async () => {
+      const input =
+        '{\\"ci\\":\\"dummy-ci\\", \\"reason\\": \\"dummy-reason\\"}';
+      expect(redactPII(input)).toStrictEqual(
+        '{\\"ci\\": \\"***\\", \\"reason\\": \\"***\\"}'
+      );
+    });
+
+    it("should redact the mapping", async () => {
+      const input = '"\\"contraindicatorReasonMappings\\": \\"dummy\\"';
+      expect(redactPII(input)).toStrictEqual(
+        '"\\"contraindicatorReasonMappings\\": \\"***\\"'
+      );
+    });
+  });
+
   describe("Dates of Birth", () => {
     it("should redact birthDates field", async () => {
       const birthDatesRedacted = '{\\"birthDates\\": \\"***\\"}';


### PR DESCRIPTION
## Proposed changes

### What changed
Added contra-indicator.ts to redaction Lambda

### Why did it change
We should not be logging CIs and their reasons to Splunk.

### Issue tracking
- [OJ-2932](https://govukverify.atlassian.net/browse/OJ-2932)


[OJ-2932]: https://govukverify.atlassian.net/browse/OJ-2932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ