### PR TITLE
BAU: Minor refactor to state machine alarms

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -838,15 +838,15 @@ Resources:
         - !ImportValue platform-alarm-critical-alert-topic
       AlarmDescription: !Sub "${CheckSessionStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
       AlarmName: !Sub "${AWS::StackName}-${Environment}-CheckSessionStateMachine-alarm"
-      ComparisonOperator: GreaterThanThreshold
-      DatapointsToAlarm: 4
-      EvaluationPeriods: 12
       MetricName: "ExecutionsFailed"
       Namespace: AWS/States
-      Period: 300
+      ComparisonOperator: GreaterThanThreshold
       Statistic: Sum
-      Threshold: 0
-      TreatMissingData: missing
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      Period: 3600
+      Threshold: 3
+      TreatMissingData: notBreaching
       Dimensions:
         - Name: StateMachineArn
           Value: !Ref CheckSessionStateMachine
@@ -983,15 +983,15 @@ Resources:
         - !ImportValue platform-alarm-critical-alert-topic
       AlarmDescription: !Sub "${NinoCheckStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
       AlarmName: !Sub "${AWS::StackName}-${Environment}-NinoCheckStateMachine-ExecutionsFailed-alarm"
-      ComparisonOperator: GreaterThanThreshold
-      DatapointsToAlarm: 4
-      EvaluationPeriods: 12
       MetricName: "ExecutionsFailed"
       Namespace: AWS/States
-      Period: 300
+      ComparisonOperator: GreaterThanThreshold
       Statistic: Sum
-      Threshold: 0
-      TreatMissingData: missing
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      Period: 3600
+      Threshold: 3
+      TreatMissingData: notBreaching
       Dimensions:
         - Name: StateMachineArn
           Value: !Ref NinoCheckStateMachine
@@ -1086,15 +1086,15 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "${AbandonStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
       AlarmName: !Sub "${AWS::StackName}-${Environment}-AbandonStateMachine-ExecutionsFailed-alarm"
-      ComparisonOperator: GreaterThanThreshold
-      DatapointsToAlarm: 4
-      EvaluationPeriods: 12
       MetricName: "ExecutionsFailed"
       Namespace: AWS/States
-      Period: 300
+      ComparisonOperator: GreaterThanThreshold
       Statistic: Sum
-      Threshold: 0
-      TreatMissingData: missing
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      Period: 3600
+      Threshold: 3
+      TreatMissingData: notBreaching
       Dimensions:
         - Name: StateMachineArn
           Value: !Ref AbandonStateMachine
@@ -1226,15 +1226,15 @@ Resources:
         - !ImportValue platform-alarm-critical-alert-topic
       AlarmDescription: !Sub "${NinoIssueCredentialStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
       AlarmName: !Sub "${AWS::StackName}-${Environment}-NinoIssueCredentialStateMachine-ExecutionsFailed-alarm"
-      ComparisonOperator: GreaterThanThreshold
-      DatapointsToAlarm: 4
-      EvaluationPeriods: 12
       MetricName: "ExecutionsFailed"
       Namespace: AWS/States
-      Period: 300
+      ComparisonOperator: GreaterThanThreshold
       Statistic: Sum
-      Threshold: 0
-      TreatMissingData: missing
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      Period: 3600
+      Threshold: 3
+      TreatMissingData: notBreaching
       Dimensions:
         - Name: StateMachineArn
           Value: !Ref NinoIssueCredentialStateMachine


### PR DESCRIPTION
## Proposed changes

### What changed

Refactored StateMachine alarms to treatMissingData as notBreaching.
Refactored StateMachine alarms to make the alarm match the description.

### Why did it change

The alarms are transition to OK every morning due to MissingData being treated as missing. These alarms all trigger slack messages causing the channel to get spammed. 

Also, previously the alarms did not match the description, rather than 4 failures within an hour, it was atleast 1 failure in 4 different 5 minute periods within an hour. This would mean if for example, if 100 executions failed but only within a 5 minute period it would not trigger the alarm. 

### Similar PR for otg
https://github.com/govuk-one-login/ipv-cri-otg-hmrc/pull/167

### Issue

Note: See alarm threshold is `ExecutionsFailed > 0 for 4 datapoints within 1 hour`, to match the description (`... failed 4 or more requests in the last hour.`) we want this to be `ExecutionsFailed > 3 for 1 datapoints within 1 hour` (which this PR will do)

![image](https://github.com/user-attachments/assets/e11037cc-7961-4d46-9d6c-97f799742a1d)
<img width="753" alt="image" src="https://github.com/user-attachments/assets/7c8687b3-2487-439a-8e18-29eb22a2a532">

