### PR TITLE
feat: http 200 for retry and return requestRetry to signify if the FE should retry

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -167,6 +167,7 @@ paths:
                 #else
                 #set($context.responseOverride.status = 200)
                 #end
+                $output.body
   /abandon:
     post:
       summary: "IP address of the client."

--- a/integration-tests/api-gateway/check/check-happy.test.ts
+++ b/integration-tests/api-gateway/check/check-happy.test.ts
@@ -1,4 +1,8 @@
-import { checkEndpoint, createMultipleNamesSession, createSession } from "../endpoints";
+import {
+  checkEndpoint,
+  createMultipleNamesSession,
+  createSession,
+} from "../endpoints";
 import {
   clearAttemptsTable,
   clearItemsFromTables,

--- a/integration-tests/api-gateway/e2e/e2e-happy-path.test.ts
+++ b/integration-tests/api-gateway/e2e/e2e-happy-path.test.ts
@@ -143,7 +143,11 @@ describe("End to end happy path journey", () => {
     });
 
     const checkData = checkResponse.status;
+    const checkBody = JSON.parse(await checkResponse.text());
     expect(checkData).toEqual(200);
+    expect(checkBody).toStrictEqual({
+      requestRetry: false,
+    });
 
     const queryString = new URLSearchParams({
       client_id: CLIENT_ID,

--- a/integration-tests/api-gateway/e2e/e2e-retry-path.test.ts
+++ b/integration-tests/api-gateway/e2e/e2e-retry-path.test.ts
@@ -145,7 +145,11 @@ describe("Retry Scenario Path Tests", () => {
     });
 
     const checkData = checkRetryResponse.status;
-    expect(checkData).toEqual(422);
+    const checkBody = JSON.parse(await checkRetryResponse.text());
+    expect(checkData).toEqual(200);
+    expect(checkBody).toStrictEqual({
+      requestRetry: true,
+    });
 
     const checkResponse = await fetch(checkApiUrl, {
       method: "POST",
@@ -155,7 +159,11 @@ describe("Retry Scenario Path Tests", () => {
       },
       body: jsonData,
     });
+    const checkResponseBody = JSON.parse(await checkResponse.text());
     expect(checkResponse.status).toEqual(200);
+    expect(checkResponseBody).toStrictEqual({
+      requestRetry: false,
+    });
 
     const queryString = new URLSearchParams({
       client_id: CLIENT_ID,

--- a/integration-tests/eventbridge/nino-check/nino-check-publish.test.ts
+++ b/integration-tests/eventbridge/nino-check/nino-check-publish.test.ts
@@ -208,7 +208,9 @@ describe("Nino Hmrc Check Step Function", () => {
     const { "detail-type": requestSentDetailType, source: requestSentSource } =
       JSON.parse(requestSentQueueMessage[0].Body as string);
 
-    expect(startExecutionResult.output).toBe('{"httpStatus":200}');
+    expect(startExecutionResult.output).toBe(
+      '{"httpStatus":200,"body":"{\\"requestRetry\\":false}"}'
+    );
 
     expect(startExecutionResult.output).toBeDefined();
     expect(requestSentQueueMessage).not.toHaveLength(0);
@@ -229,9 +231,12 @@ describe("Nino Hmrc Check Step Function", () => {
       source: responseReceivedSource,
     } = JSON.parse(responseReceivedQueueMessage[0].Body as string);
 
-    expect(startExecutionResult.output).toBe('{"httpStatus":200}');
-
     expect(startExecutionResult.output).toBeDefined();
+    expect(JSON.parse(startExecutionResult.output || "")).toStrictEqual({
+      httpStatus: 200,
+      body: '{"requestRetry":false}',
+    });
+
     expect(responseReceivedQueueMessage).not.toHaveLength(0);
     expect(responseReceivedDetailType).toBe("RESPONSE_RECEIVED");
     expect(responseReceivedSource).toBe("review-hc.localdev.account.gov.uk");
@@ -292,9 +297,11 @@ describe("Nino Hmrc Check Step Function", () => {
         user_id: "test",
       },
       extensions: {
-        evidence: [{
-          txn: "mock_txn_header"
-        }]
+        evidence: [
+          {
+            txn: "mock_txn_header",
+          },
+        ],
       },
     };
 

--- a/integration-tests/step-functions/aws/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/step-functions/aws/nino-check/nino-check-happy.test.ts
@@ -115,7 +115,10 @@ describe("nino-check-happy", () => {
         input
       );
 
-      expect(startExecutionResult.output).toBe('{"httpStatus":200}');
+      expect(JSON.parse(startExecutionResult.output || "")).toStrictEqual({
+        httpStatus: 200,
+        body: '{"requestRetry":false}',
+      });
     });
 
     it("should return 200 Ok while retrying the 2nd attempt", async () => {
@@ -180,9 +183,15 @@ describe("nino-check-happy", () => {
         input
       );
 
-      expect(firstExecutionResult.output).toBe('{"httpStatus":422}');
+      expect(JSON.parse(firstExecutionResult.output || "")).toStrictEqual({
+        httpStatus: 200,
+        body: '{"requestRetry":true}',
+      });
 
-      expect(secondExecutionResult.output).toBe('{"httpStatus":200}');
+      expect(JSON.parse(secondExecutionResult.output || "")).toStrictEqual({
+        httpStatus: 200,
+        body: '{"requestRetry":false}',
+      });
     });
   });
 });

--- a/integration-tests/step-functions/aws/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/step-functions/aws/nino-check/nino-check-unhappy.test.ts
@@ -114,7 +114,10 @@ describe("nino-check-unhappy", () => {
       input
     );
 
-    expect(startExecutionResult.output).toBe('{"httpStatus":200}');
+    expect(JSON.parse(startExecutionResult.output || "")).toStrictEqual({
+      httpStatus: 200,
+      body: '{"requestRetry":false}',
+    });
   });
 
   it("should fail when there is no user present for given nino", async () => {
@@ -185,7 +188,10 @@ describe("nino-check-unhappy", () => {
       inputDeceased
     );
 
-    expect(startExecutionResult.output).toBe('{"httpStatus":422}');
+    expect(JSON.parse(startExecutionResult.output || "")).toStrictEqual({
+      httpStatus: 200,
+      body: '{"requestRetry":true}',
+    });
   });
 
   it("should fail when user NINO does not match with HMRC DB", async () => {
@@ -229,7 +235,9 @@ describe("nino-check-unhappy", () => {
       inputNoCidNinoUser
     );
 
-    expect(startExecutionResult.output).toBe('{"httpStatus":422}');
+    expect(startExecutionResult.output).toBe(
+      '{"httpStatus":200,"body":"{\\"requestRetry\\":true}"}'
+    );
   });
 
   describe("NINO check URL is unavailable", () => {

--- a/integration-tests/step-functions/mocked/nino-check/nino-check-happy.test.ts
+++ b/integration-tests/step-functions/mocked/nino-check/nino-check-happy.test.ts
@@ -31,9 +31,12 @@ describe("nino-check-happy", () => {
         event?.stateExitedEventDetails?.name === "Nino check completed",
       responseStepFunction
     );
-    expect(results[0].stateExitedEventDetails?.output).toEqual(
-      '{"httpStatus":200}'
-    );
+    expect(
+      JSON.parse(results[0].stateExitedEventDetails?.output || "")
+    ).toStrictEqual({
+      httpStatus: 200,
+      body: '{"requestRetry":false}',
+    });
   });
 
   it.each([
@@ -54,8 +57,11 @@ describe("nino-check-happy", () => {
         event?.stateExitedEventDetails?.name === "Nino check completed",
       responseStepFunction
     );
-    expect(results[0].stateExitedEventDetails?.output).toEqual(
-      '{"httpStatus":200}'
-    );
+    expect(
+      JSON.parse(results[0].stateExitedEventDetails?.output || "")
+    ).toStrictEqual({
+      httpStatus: 200,
+      body: '{"requestRetry":false}',
+    });
   });
 });

--- a/integration-tests/step-functions/mocked/nino-check/nino-check-unhappy.test.ts
+++ b/integration-tests/step-functions/mocked/nino-check/nino-check-unhappy.test.ts
@@ -30,7 +30,7 @@ describe("nino-check-unhappy", () => {
       responseStepFunction
     );
     expect(results[0].executionSucceededEventDetails?.output).toBe(
-      '{"httpStatus":200}'
+      '{"httpStatus":200,"body":"{\\"requestRetry\\":false}"}'
     );
   });
 
@@ -66,7 +66,7 @@ describe("nino-check-unhappy", () => {
       responseStepFunction
     );
     expect(results[0].executionSucceededEventDetails?.output).toEqual(
-      '{"httpStatus":422}'
+      '{"httpStatus":200,"body":"{\\"requestRetry\\":true}"}'
     );
   });
 
@@ -85,9 +85,12 @@ describe("nino-check-unhappy", () => {
         event?.stateExitedEventDetails?.name === "Err: Attempts exceeded",
       responseStepFunction
     );
-    expect(results[0].stateExitedEventDetails?.output).toEqual(
-      '{"httpStatus":200}'
-    );
+    expect(
+      JSON.parse(results[0].stateExitedEventDetails?.output || "")
+    ).toStrictEqual({
+      httpStatus: 200,
+      body: '{"requestRetry":false}',
+    });
   });
 
   it("should fail when user cannot be found for the given nino", async () => {
@@ -159,7 +162,7 @@ describe("nino-check-unhappy", () => {
       responseStepFunction
     );
     expect(results[0].executionSucceededEventDetails?.output).toEqual(
-      '{"httpStatus":422}'
+      '{"httpStatus":200,"body":"{\\"requestRetry\\":true}"}'
     );
   });
 

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -109,7 +109,8 @@
       "Type": "Pass",
       "End": true,
       "Parameters": {
-        "httpStatus": 200
+        "httpStatus": 200,
+        "body": "{\"requestRetry\":false}"
       }
     },
     "Query Person Identity Table": {
@@ -410,7 +411,8 @@
       "Type": "Pass",
       "End": true,
       "Parameters": {
-        "httpStatus": 422
+        "httpStatus": 200,
+        "body": "{\"requestRetry\":true}"
       }
     },
     "Fetch Auth Code Expiry": {
@@ -477,7 +479,8 @@
       "Type": "Pass",
       "Next": "Nino check completed",
       "Parameters": {
-        "httpStatus": 200
+        "httpStatus": 200,
+        "body": "{\"requestRetry\":false}"
       }
     },
     "Nino check completed": {


### PR DESCRIPTION
To be merged after successful deployment of: https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/pull/315

## Proposed changes

### What changed
Updated retry logic to return a http 200 and body containing `requestRetry: true`

The previous http 422 was causing our dashboards to go red since it was considered a 4xx error. 

### Issue tracking

- [OJ-2921](https://govukverify.atlassian.net/browse/OJ-2921)


[OJ-2921]: https://govukverify.atlassian.net/browse/OJ-2921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ