### PR TITLE
feat: remove 422 response from openapi spec

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -125,8 +125,6 @@ paths:
           description: OK
         "400":
           description: Bad Request
-        "422":
-          description: Unprocessable Content
         "500":
           description: Internal Server Error
       x-amazon-apigateway-integration:


### PR DESCRIPTION
## Proposed changes

### What changed and why
Removed the 422 status from the private-api.yaml as this is no longer returned by the API

### Issue tracking
- [OJ-2921](https://govukverify.atlassian.net/browse/OJ-2921)

[OJ-2921]: https://govukverify.atlassian.net/browse/OJ-2921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ