### PR TITLE
IPS-1120 PII Redact alias permission added

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -2176,6 +2176,14 @@ Resources:
       Principal: !Join [ ".", [ "logs", !Ref "AWS::Region", "amazonaws.com" ] ]
       SourceAccount: !Ref AWS::AccountId
 
+  PIIRedactFunctionCloudWatchAliasPermissions:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref PIIRedactFunction.Alias
+      Action: lambda:InvokeFunction
+      Principal: !Join [ ".", [ "logs", !Ref "AWS::Region", "amazonaws.com" ] ]
+      SourceAccount: !Ref AWS::AccountId
+
   NinoCheckStateMachineLogsSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn: PIIRedactFunctionCloudWatchPermissions


### PR DESCRIPTION
## Proposed changes

### What changed

PII redact alias permission added. 

### Why did it change

This is to allow this function to be invoked using the alias. Alias is needed due to canary deployments and using versions. Alias is the live version of the lambda.

For backwards compatibility permission needs to be added first, and then the DestinationArn can be changed from !GetAtt PIIRedactFunction.Arn to !Ref PIIRedactFunction.Alias. Second [PR](https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/pull/488) to follow. 

### Issue tracking
- [IPS-1120](https://govukverify.atlassian.net/browse/IPS-1120)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1120]: https://govukverify.atlassian.net/browse/IPS-1120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ