### PR TITLE
IPS-1120 piiredact function to be invoked on the alias

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -2189,7 +2189,7 @@ Resources:
     DependsOn: PIIRedactFunctionCloudWatchPermissions
     Properties:
       FilterName: "PII Redaction"
-      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      DestinationArn: !Ref PIIRedactFunction.Alias
       FilterPattern: ""
       LogGroupName: !Ref NinoCheckStateMachineLogGroup
 
@@ -2198,7 +2198,7 @@ Resources:
     DependsOn: PIIRedactFunctionCloudWatchPermissions
     Properties:
       FilterName: "PII Redaction"
-      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      DestinationArn: !Ref PIIRedactFunction.Alias
       FilterPattern: ""
       LogGroupName: !Ref AbandonStateMachineLogGroup
 
@@ -2207,7 +2207,7 @@ Resources:
     DependsOn: PIIRedactFunctionCloudWatchPermissions
     Properties:
       FilterName: "PII Redaction"
-      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      DestinationArn: !Ref PIIRedactFunction.Alias
       FilterPattern: ""
       LogGroupName: !Ref NinoIssueCredentialLogGroup
 
@@ -2216,7 +2216,7 @@ Resources:
     DependsOn: PIIRedactFunctionCloudWatchPermissions
     Properties:
       FilterName: "PII Redaction"
-      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      DestinationArn: !Ref PIIRedactFunction.Alias
       FilterPattern: ""
       LogGroupName: !Ref CheckSessionStateMachineLogGroup
 
@@ -2225,7 +2225,7 @@ Resources:
     DependsOn: PIIRedactFunctionCloudWatchPermissions
     Properties:
       FilterName: "PII Redaction"
-      DestinationArn: !GetAtt PIIRedactFunction.Arn
+      DestinationArn: !Ref PIIRedactFunction.Alias
       FilterPattern: ""
       LogGroupName: !Ref AuditEventStateMachineLogGroup
 


### PR DESCRIPTION
## Proposed changes

### What changed

Subscription filter to use the live version of the PII Redact function

### Why did it change

This change is needed to ensure the live version of the lambda function is invoked. This is especially important if the lambda rolls back to use the live and working version.

### Issue tracking
- [IPS-1120](https://govukverify.atlassian.net/browse/IPS-1120)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1120]: https://govukverify.atlassian.net/browse/IPS-1120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ