### PR TITLE
OJ-3108: Fix scan repo action for non PRs

### DIFF
--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -1,6 +1,7 @@
 name: Scan repository
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [main]
@@ -34,6 +35,7 @@ jobs:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           coverage-artifact: ${{ needs.coverage.outputs.coverage-artifact || 'coverage' }}
+          coverage-run-id: ${{ github.event_name != 'pull_request' && github.run_id || null }}
 
   codeql:
     name: CodeQL


### PR DESCRIPTION
### What changed

- coverage-run-id is passed into the SonarCloud action for none PRs so it does not run the Await coverage report step.
- Added workflow_dispatch to Scan repo action

### Why did it change

Await coverage report was added to the sonarcloud github action which broke our Scan Repo action when running on a schedule. Passing in the workflow id to the action prevents this from happening.

### Issue tracking

- [OJ-3108](https://govukverify.atlassian.net/browse/OJ-3108)



[OJ-3108]: https://govukverify.atlassian.net/browse/OJ-3108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ