### PR TITLE
OJ-3131: improve individual integration test speed

### DIFF
--- a/integration-tests/api-gateway/abandon/abandon-happy.test.ts
+++ b/integration-tests/api-gateway/abandon/abandon-happy.test.ts
@@ -1,4 +1,3 @@
-import { stackOutputs } from "../../resources/cloudformation-helper";
 import {
   clearAttemptsTable,
   clearItemsFromTables,
@@ -20,26 +19,11 @@ describe("Given the session is valid and expecting to abandon the journey", () =
   let sessionTableName: string;
   let privateApi: string;
 
-  let output: Partial<{
-    CommonStackName: string;
-    StackName: string;
-    NinoUsersTable: string;
-    UserAttemptsTable: string;
-    PrivateApiGatewayId: string;
-  }>;
-
-  let commonStack: string;
-
-  beforeAll(async () => {
-    output = await stackOutputs(process.env.STACK_NAME);
-    commonStack = `${output.CommonStackName}`;
-    sessionTableName = `session-${commonStack}`;
-  });
-
   beforeEach(async () => {
     const data = await getJarAuthorization();
     const request = await data.json();
-    privateApi = `${output.PrivateApiGatewayId}`;
+    privateApi = `${process.env.PRIVATE_API}`;
+    sessionTableName = `${process.env.SESSION_TABLE}`;
     const session = await createSession(privateApi, request);
     const sessionData = await session.json();
     sessionId = sessionData.session_id;
@@ -56,11 +40,11 @@ describe("Given the session is valid and expecting to abandon the journey", () =
   afterEach(async () => {
     await clearItemsFromTables(
       {
-        tableName: `person-identity-${commonStack}`,
+        tableName: `${process.env.PERSON_IDENTITY_TABLE}`,
         items: { sessionId: sessionId },
       },
       {
-        tableName: `${output.NinoUsersTable}`,
+        tableName: `${process.env.NINO_USERS_TABLE}`,
         items: { sessionId: sessionId },
       },
       {
@@ -68,7 +52,7 @@ describe("Given the session is valid and expecting to abandon the journey", () =
         items: { sessionId: sessionId },
       }
     );
-    await clearAttemptsTable(sessionId, `${output.UserAttemptsTable}`);
+    await clearAttemptsTable(sessionId, `${process.env.USERS_ATTEMPTS_TABLE}`);
   });
 
   it("Should receive a 200 response when /abandon endpoint is called without optional headers", async () => {

--- a/integration-tests/api-gateway/authorization/authorization-happy.test.ts
+++ b/integration-tests/api-gateway/authorization/authorization-happy.test.ts
@@ -19,30 +19,13 @@ describe("Given the session is valid and expecting to be authorized", () => {
   let sessionId: string;
   let state: string;
   let privateApi: string;
-
-  let output: Partial<{
-    CommonStackName: string;
-    StackName: string;
-    NinoUsersTable: string;
-    UserAttemptsTable: string;
-    PrivateApiGatewayId: string;
-  }>;
-
   let sessionTableName: string;
-
-  let commonStack: string;
-
-  beforeAll(async () => {
-    output = await stackOutputs(process.env.STACK_NAME);
-    commonStack = `${output.CommonStackName}`;
-    sessionTableName = `session-${commonStack}`;
-
-    privateApi = `${output.PrivateApiGatewayId}`;
-  });
 
   beforeEach(async () => {
     const data = await getJarAuthorization();
     const request = await data.json();
+    privateApi = `${process.env.PRIVATE_API}`;
+    sessionTableName = `${process.env.SESSION_TABLE}`;
     const session = await createSession(privateApi, request);
     const sessionData = await session.json();
 
@@ -55,11 +38,11 @@ describe("Given the session is valid and expecting to be authorized", () => {
   afterEach(async () => {
     await clearItemsFromTables(
       {
-        tableName: `person-identity-${commonStack}`,
+        tableName: `${process.env.PERSON_IDENTITY_TABLE}`,
         items: { sessionId: sessionId },
       },
       {
-        tableName: `${output.NinoUsersTable}`,
+        tableName: `${process.env.NINO_USERS_TABLE}`,
         items: { sessionId: sessionId },
       },
       {
@@ -67,7 +50,7 @@ describe("Given the session is valid and expecting to be authorized", () => {
         items: { sessionId: sessionId },
       }
     );
-    await clearAttemptsTable(sessionId, `${output.UserAttemptsTable}`);
+    await clearAttemptsTable(sessionId, `${process.env.USERS_ATTEMPTS_TABLE}`);
   });
 
   it("Should return an authorizationCode when /authorization endpoint is called", async () => {

--- a/integration-tests/api-gateway/authorization/authorization-unhappy.test.ts
+++ b/integration-tests/api-gateway/authorization/authorization-unhappy.test.ts
@@ -1,4 +1,3 @@
-import { stackOutputs } from "../../resources/cloudformation-helper";
 import {
   clearAttemptsTable,
   clearItemsFromTables,
@@ -17,26 +16,13 @@ describe("Given the session is invalid and expecting it not to be authorized", (
   let sessionId: string;
   let state: string;
   let privateApi: string;
-
-  let output: Partial<{
-    CommonStackName: string;
-    StackName: string;
-    NinoUsersTable: string;
-    UserAttemptsTable: string;
-    PrivateApiGatewayId: string;
-  }>;
-
-  let commonStack: string;
-  beforeAll(async () => {
-    output = await stackOutputs(process.env.STACK_NAME);
-    commonStack = `${output.CommonStackName}`;
-
-    privateApi = `${output.PrivateApiGatewayId}`;
-  });
+  let sessionTableName: string;
 
   beforeEach(async () => {
     const data = await getJarAuthorization();
     const request = await data.json();
+    privateApi = `${process.env.PRIVATE_API}`;
+    sessionTableName = `${process.env.SESSION_TABLE}`;
     const session = await createSession(privateApi, request);
     const sessionData = await session.json();
     sessionId = sessionData.session_id;
@@ -47,19 +33,19 @@ describe("Given the session is invalid and expecting it not to be authorized", (
   afterEach(async () => {
     await clearItemsFromTables(
       {
-        tableName: `person-identity-${commonStack}`,
+        tableName: `${process.env.PERSON_IDENTITY_TABLE}`,
         items: { sessionId: sessionId },
       },
       {
-        tableName: `${output.NinoUsersTable}`,
+        tableName: `${process.env.NINO_USERS_TABLE}`,
         items: { sessionId: sessionId },
       },
       {
-        tableName: `session-${commonStack}`,
+        tableName: sessionTableName,
         items: { sessionId: sessionId },
       }
     );
-    await clearAttemptsTable(sessionId, `${output.UserAttemptsTable}`);
+    await clearAttemptsTable(sessionId, `${process.env.USERS_ATTEMPTS_TABLE}`);
   });
 
   it("Should return an 400 response when /authorization endpoint is called when session id is empty", async () => {

--- a/integration-tests/api-gateway/check/check-unhappy.test.ts
+++ b/integration-tests/api-gateway/check/check-unhappy.test.ts
@@ -8,34 +8,21 @@ import {
   clearItemsFromTables,
 } from "../../resources/dynamodb-helper";
 import { NINO } from "../env-variables";
-import { stackOutputs } from "../../resources/cloudformation-helper";
 
 jest.setTimeout(30_000);
 
 describe("Given the session and NINO is invalid", () => {
   let sessionId: string;
   let privateApi: string;
+  let sessionTableName: string;
   let sessionData: { session_id: string };
-
-  let output: Partial<{
-    CommonStackName: string;
-    StackName: string;
-    NinoUsersTable: string;
-    UserAttemptsTable: string;
-    PrivateApiGatewayId: string;
-  }>;
-  let commonStack: string;
-
-  beforeAll(async () => {
-    output = await stackOutputs(process.env.STACK_NAME);
-    commonStack = `${output.CommonStackName}`;
-  });
 
   beforeEach(async () => {
     const data = await getJarAuthorization();
     const request = await data.json();
 
-    privateApi = `${output.PrivateApiGatewayId}`;
+    privateApi = `${process.env.PRIVATE_API}`;
+    sessionTableName = `${process.env.SESSION_TABLE}`;
     const session = await createSession(privateApi, request);
     sessionData = await session.json();
   });
@@ -43,19 +30,19 @@ describe("Given the session and NINO is invalid", () => {
   afterEach(async () => {
     await clearItemsFromTables(
       {
-        tableName: `person-identity-${commonStack}`,
+        tableName: `${process.env.PERSON_IDENTITY_TABLE}`,
         items: { sessionId: sessionId },
       },
       {
-        tableName: `${output.NinoUsersTable}`,
+        tableName: `${process.env.NINO_USERS_TABLE}`,
         items: { sessionId: sessionId },
       },
       {
-        tableName: `session-${commonStack}`,
+        tableName: sessionTableName,
         items: { sessionId: sessionId },
       }
     );
-    await clearAttemptsTable(sessionId, `${output.UserAttemptsTable}`);
+    await clearAttemptsTable(sessionId, `${process.env.USERS_ATTEMPTS_TABLE}`);
   });
 
   it("Should receive a 400 response when /check endpoint is called without session id value and optional header", async () => {

--- a/integration-tests/api-gateway/contract/utils/PactJwtFormatter.ts
+++ b/integration-tests/api-gateway/contract/utils/PactJwtFormatter.ts
@@ -1,4 +1,5 @@
-import { base64url, decodeJwt, decodeProtectedHeader } from "jose";
+import { base64url, decodeJwt, decodeProtectedHeader, JWTPayload } from "jose";
+import { JWTClaimsSet } from "../../types";
 
 export const formatJwtForPactTest = (body: string) => {
   const decodedVc = decodeJwt(body);
@@ -8,15 +9,12 @@ export const formatJwtForPactTest = (body: string) => {
   const vcWithReplacedFields = replaceDynamicVcFieldsIfPresent(parseVc);
   const reorderedVc = reorderVc(vcWithReplacedFields);
 
-  return (
-    getJwtHeader(body) +
-    "." +
-    base64url.encode(JSON.stringify(reorderedVc)) +
-    "."
-  );
+  return `${getJwtHeader(body)}.${base64url.encode(
+    JSON.stringify(reorderedVc)
+  )}.`;
 };
 
-const replaceDynamicVcFieldsIfPresent = (parseVc: any) => {
+const replaceDynamicVcFieldsIfPresent = (parseVc: JWTClaimsSet) => {
   parseVc.nbf = parseVc.nbf == null ? parseVc.nbf : 4070908800;
   parseVc.iss = parseVc.iss == null ? parseVc.iss : "dummyNinoComponentId";
   parseVc.exp = parseVc.exp == null ? parseVc.exp : 4070909400;
@@ -24,7 +22,7 @@ const replaceDynamicVcFieldsIfPresent = (parseVc: any) => {
   return parseVc;
 };
 
-const reorderVc = (vc: any) => ({
+const reorderVc = (vc: JWTPayload) => ({
   sub: vc.sub,
   nbf: vc.nbf,
   iss: vc.iss,

--- a/integration-tests/api-gateway/jest.config.ts
+++ b/integration-tests/api-gateway/jest.config.ts
@@ -5,4 +5,5 @@ export default {
   ...baseConfig,
   projects: [],
   displayName: "integration-tests/api-gateway",
+  globalSetup: "../globalStackOutputSetup.ts",
 } satisfies Config;

--- a/integration-tests/api-gateway/session/session-happy.test.ts
+++ b/integration-tests/api-gateway/session/session-happy.test.ts
@@ -1,27 +1,18 @@
 import { createSession, getJarAuthorization } from "../endpoints";
 import { clearItemsFromTables } from "../../resources/dynamodb-helper";
-import { stackOutputs } from "../../resources/cloudformation-helper";
 
 jest.setTimeout(30_000);
 describe("Given the session is valid", () => {
   let sessionId: string;
+  let sessionTableName: string;
   let jsonSession: { session_id: string };
   let sessionResponse: Response;
-
-  let output: Partial<{
-    CommonStackName: string;
-    PrivateApiGatewayId: string;
-  }>;
-
-  beforeAll(async () => {
-    output = await stackOutputs(process.env.STACK_NAME);
-  });
 
   beforeEach(async () => {
     const data = await getJarAuthorization();
     const request = await data.json();
-
-    const privateApi = `${output.PrivateApiGatewayId}`;
+    const privateApi = `${process.env.PRIVATE_API}`;
+    sessionTableName = `${process.env.SESSION_TABLE}`;
 
     sessionResponse = await createSession(privateApi, request);
     jsonSession = await sessionResponse.json();
@@ -30,11 +21,11 @@ describe("Given the session is valid", () => {
   afterEach(async () => {
     await clearItemsFromTables(
       {
-        tableName: `person-identity-${output.CommonStackName}`,
+        tableName: `${process.env.PERSON_IDENTITY_TABLE}`,
         items: { sessionId: sessionId },
       },
       {
-        tableName: `session-${output.CommonStackName}`,
+        tableName: sessionTableName,
         items: { sessionId: sessionId },
       }
     );

--- a/integration-tests/api-gateway/session/session-unhappy.test.ts
+++ b/integration-tests/api-gateway/session/session-unhappy.test.ts
@@ -1,13 +1,15 @@
-import { stackOutputs } from "../../resources/cloudformation-helper";
 import { createSession } from "../endpoints";
 jest.setTimeout(35_000);
 describe("Given the session is invalid", () => {
-  it("Should receive a 400 response when /session endpoint is called with null request body", async () => {
-    const preOutput = await stackOutputs(process.env.STACK_NAME);
-    const privateApi = `${preOutput.PrivateApiGatewayId}`;
-    const anInValidSession = createSession(privateApi, null);
+  let anInValidSession: Response;
 
-    const sessionResponse = await anInValidSession;
-    expect(sessionResponse.status).toEqual(400);
+  beforeEach(async () => {
+    const privateApi = `${process.env.PRIVATE_API}`;
+
+    anInValidSession = await createSession(privateApi, null);
+  });
+
+  it("Should receive a 400 response when /session endpoint is called with null request body", async () => {
+    expect(anInValidSession.status).toEqual(400);
   });
 });

--- a/integration-tests/api-gateway/types.ts
+++ b/integration-tests/api-gateway/types.ts
@@ -6,6 +6,7 @@ export type JWTClaimsSet = {
   iat: number;
   exp: number;
   nbf: number;
+  jti: string;
   response_type: string;
   client_id: string;
   redirect_uri: string;

--- a/integration-tests/eventbridge/jest.config.ts
+++ b/integration-tests/eventbridge/jest.config.ts
@@ -5,4 +5,5 @@ export default {
   ...baseConfig,
   projects: [],
   displayName: "integration-tests/eventbridge",
+  globalSetup: "../globalStackOutputSetup.ts",
 } satisfies Config;

--- a/integration-tests/globalStackOutputSetup.ts
+++ b/integration-tests/globalStackOutputSetup.ts
@@ -1,0 +1,64 @@
+import { stackOutputs } from "./resources/cloudformation-helper";
+let outputs: Partial<{
+  CommonStackName: string;
+  StackName: string;
+  PrivateApiGatewayId: string;
+  PublicApiGatewayId: string;
+  NinoUsersTable: string;
+  UserAttemptsTable: string;
+  AbandonStateMachineArn: string;
+  CheckSessionStateMachineArn: string;
+  NinoCheckStateMachineArn: string;
+  NinoIssueCredentialStateMachineArn: string;
+  TxMaAuditEventRule: string;
+  TxMaAuditEventRuleArn: string;
+  AuditEventAbandonedRule: string;
+  AuditEventAbandonedRuleArn: string;
+  AuditEventVcIssuedRule: string;
+  AuditEventVcIssuedRuleArn: string;
+  AuditEventEndRule: string;
+  AuditEventEndRuleArn: string;
+  AuditEventRequestSentRule: string;
+  AuditEventRequestSentRuleArn: string;
+  AuditEventResponseReceivedRule: string;
+  AuditEventResponseReceivedRuleArn: string;
+}>;
+
+export default async function globalSetup() {
+  outputs = await stackOutputs(process.env.STACK_NAME);
+
+  process.env.AWS_REGION = "eu-west-2";
+  process.env.COMMON_STACK_NAME = outputs.CommonStackName;
+  process.env.STACK_NAME = outputs.StackName;
+  process.env.PRIVATE_API = outputs.PrivateApiGatewayId;
+  process.env.PUBLIC_API = outputs.PublicApiGatewayId;
+  process.env.NINO_USERS_TABLE = outputs.NinoUsersTable;
+  process.env.USERS_ATTEMPTS_TABLE = outputs.UserAttemptsTable;
+  process.env.PERSON_IDENTITY_TABLE = `person-identity-${outputs.CommonStackName}`;
+  process.env.SESSION_TABLE = `session-${outputs.CommonStackName}`;
+  process.env.ABANDON_STATE_MACHINE_ARN = outputs.AbandonStateMachineArn;
+  process.env.CHECK_SESSION_STATE_MACHINE_ARN =
+    outputs.CheckSessionStateMachineArn;
+  process.env.NINO_CHECK_STATE_MACHINE_ARN = outputs.NinoCheckStateMachineArn;
+  process.env.NINO_CREDENTIAL_STATE_MACHINE_ARN =
+    outputs.NinoIssueCredentialStateMachineArn;
+  process.env.TXMA_AUDIT_EVENT_RULE_ENV = outputs.TxMaAuditEventRule;
+  process.env.TXMA_AUDIT_EVENT_RULE_ARN = outputs.TxMaAuditEventRuleArn;
+  process.env.AUDIT_EVENT_ABANDON_RULE_ENV = outputs.AuditEventAbandonedRule;
+  process.env.AUDIT_EVENT_ABANDON_RULE_ARN = outputs.AuditEventAbandonedRuleArn;
+  process.env.AUDIT_EVENT_VC_ISSUED_RULE = outputs.AuditEventVcIssuedRule;
+  process.env.AUDIT_EVENT_VC_ISSUED_RULE_ARN =
+    outputs.AuditEventVcIssuedRuleArn;
+  process.env.AUDIT_EVENT_END_RULE = outputs.AuditEventEndRule;
+  process.env.AUDIT_EVENT_END_RULE_ARN = outputs.AuditEventEndRuleArn;
+  process.env.AUDIT_EVENT_REQUEST_SENT_RULE = outputs.AuditEventRequestSentRule;
+  process.env.AUDIT_EVENT_REQUEST_SENT_RULE_ARN =
+    outputs.AuditEventRequestSentRuleArn;
+  process.env.AUDIT_EVENT_RESPONSE_RECEIVED_RULE =
+    outputs.AuditEventResponseReceivedRule;
+  process.env.AUDIT_EVENT_RESPONSE_RECEIVED_RULE_ARN =
+    outputs.AuditEventResponseReceivedRuleArn;
+
+  // eslint-disable-next-line no-console
+  console.log("✅ Env vars set in globalSetup");
+}

--- a/integration-tests/globalStackOutputSetup.ts
+++ b/integration-tests/globalStackOutputSetup.ts
@@ -25,40 +25,59 @@ let outputs: Partial<{
 }>;
 
 export default async function globalSetup() {
-  outputs = await stackOutputs(process.env.STACK_NAME);
+  try {
+    const stackName = process.env.STACK_NAME;
+    if (!stackName)
+      throw new Error("STACK_NAME environment variable is not set.");
 
-  process.env.AWS_REGION = "eu-west-2";
-  process.env.COMMON_STACK_NAME = outputs.CommonStackName;
-  process.env.STACK_NAME = outputs.StackName;
-  process.env.PRIVATE_API = outputs.PrivateApiGatewayId;
-  process.env.PUBLIC_API = outputs.PublicApiGatewayId;
-  process.env.NINO_USERS_TABLE = outputs.NinoUsersTable;
-  process.env.USERS_ATTEMPTS_TABLE = outputs.UserAttemptsTable;
-  process.env.PERSON_IDENTITY_TABLE = `person-identity-${outputs.CommonStackName}`;
-  process.env.SESSION_TABLE = `session-${outputs.CommonStackName}`;
-  process.env.ABANDON_STATE_MACHINE_ARN = outputs.AbandonStateMachineArn;
-  process.env.CHECK_SESSION_STATE_MACHINE_ARN =
-    outputs.CheckSessionStateMachineArn;
-  process.env.NINO_CHECK_STATE_MACHINE_ARN = outputs.NinoCheckStateMachineArn;
-  process.env.NINO_CREDENTIAL_STATE_MACHINE_ARN =
-    outputs.NinoIssueCredentialStateMachineArn;
-  process.env.TXMA_AUDIT_EVENT_RULE_ENV = outputs.TxMaAuditEventRule;
-  process.env.TXMA_AUDIT_EVENT_RULE_ARN = outputs.TxMaAuditEventRuleArn;
-  process.env.AUDIT_EVENT_ABANDON_RULE_ENV = outputs.AuditEventAbandonedRule;
-  process.env.AUDIT_EVENT_ABANDON_RULE_ARN = outputs.AuditEventAbandonedRuleArn;
-  process.env.AUDIT_EVENT_VC_ISSUED_RULE = outputs.AuditEventVcIssuedRule;
-  process.env.AUDIT_EVENT_VC_ISSUED_RULE_ARN =
-    outputs.AuditEventVcIssuedRuleArn;
-  process.env.AUDIT_EVENT_END_RULE = outputs.AuditEventEndRule;
-  process.env.AUDIT_EVENT_END_RULE_ARN = outputs.AuditEventEndRuleArn;
-  process.env.AUDIT_EVENT_REQUEST_SENT_RULE = outputs.AuditEventRequestSentRule;
-  process.env.AUDIT_EVENT_REQUEST_SENT_RULE_ARN =
-    outputs.AuditEventRequestSentRuleArn;
-  process.env.AUDIT_EVENT_RESPONSE_RECEIVED_RULE =
-    outputs.AuditEventResponseReceivedRule;
-  process.env.AUDIT_EVENT_RESPONSE_RECEIVED_RULE_ARN =
-    outputs.AuditEventResponseReceivedRuleArn;
+    outputs = await stackOutputs(stackName);
+    if (!outputs?.CommonStackName)
+      throw new Error("Missing CommonStackName in stack outputs.");
 
-  // eslint-disable-next-line no-console
-  console.log("✅ Env vars set in globalSetup");
+    process.env.AWS_REGION = "eu-west-2";
+    process.env.COMMON_STACK_NAME = outputs.CommonStackName;
+    process.env.STACK_NAME = outputs.StackName;
+    process.env.PRIVATE_API = outputs.PrivateApiGatewayId || "";
+    process.env.PUBLIC_API = outputs.PublicApiGatewayId || "";
+    process.env.NINO_USERS_TABLE =
+      outputs.NinoUsersTable || "check-hmrc-cri-api-nino-users";
+    process.env.USERS_ATTEMPTS_TABLE =
+      outputs.UserAttemptsTable || "check-hmrc-cri-api-user-attempts";
+    process.env.PERSON_IDENTITY_TABLE =
+      `person-identity-${outputs.CommonStackName}` ||
+      "person-identity-common-cri-api";
+    process.env.SESSION_TABLE =
+      `session-${outputs.CommonStackName}` || "session-common-cri-api";
+    process.env.ABANDON_STATE_MACHINE_ARN = outputs.AbandonStateMachineArn;
+    process.env.CHECK_SESSION_STATE_MACHINE_ARN =
+      outputs.CheckSessionStateMachineArn;
+    process.env.NINO_CHECK_STATE_MACHINE_ARN = outputs.NinoCheckStateMachineArn;
+    process.env.NINO_CREDENTIAL_STATE_MACHINE_ARN =
+      outputs.NinoIssueCredentialStateMachineArn;
+    process.env.TXMA_AUDIT_EVENT_RULE_ENV = outputs.TxMaAuditEventRule;
+    process.env.TXMA_AUDIT_EVENT_RULE_ARN = outputs.TxMaAuditEventRuleArn;
+    process.env.AUDIT_EVENT_ABANDON_RULE_ENV = outputs.AuditEventAbandonedRule;
+    process.env.AUDIT_EVENT_ABANDON_RULE_ARN =
+      outputs.AuditEventAbandonedRuleArn;
+    process.env.AUDIT_EVENT_VC_ISSUED_RULE = outputs.AuditEventVcIssuedRule;
+    process.env.AUDIT_EVENT_VC_ISSUED_RULE_ARN =
+      outputs.AuditEventVcIssuedRuleArn;
+    process.env.AUDIT_EVENT_END_RULE = outputs.AuditEventEndRule;
+    process.env.AUDIT_EVENT_END_RULE_ARN = outputs.AuditEventEndRuleArn;
+    process.env.AUDIT_EVENT_REQUEST_SENT_RULE =
+      outputs.AuditEventRequestSentRule;
+    process.env.AUDIT_EVENT_REQUEST_SENT_RULE_ARN =
+      outputs.AuditEventRequestSentRuleArn;
+    process.env.AUDIT_EVENT_RESPONSE_RECEIVED_RULE =
+      outputs.AuditEventResponseReceivedRule;
+    process.env.AUDIT_EVENT_RESPONSE_RECEIVED_RULE_ARN =
+      outputs.AuditEventResponseReceivedRuleArn;
+
+    // eslint-disable-next-line no-console
+    console.log("✅ Env vars set in globalSetup");
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error("❌ Failed to set up environment for tests:", error);
+    throw error;
+  }
 }

--- a/integration-tests/step-functions/aws/abandon/abandon.test.ts
+++ b/integration-tests/step-functions/aws/abandon/abandon.test.ts
@@ -1,4 +1,3 @@
-import { stackOutputs } from "../../../resources/cloudformation-helper";
 import {
   clearItems,
   getItemByKey,
@@ -12,30 +11,18 @@ describe("Abandon", () => {
     "txma-audit-encoded": "test encoded header",
   };
 
-  let output: Partial<{
-    CommonStackName: string;
-    AbandonStateMachineArn: string;
-    AuditEventAbandonedRule: string;
-    AuditEventAbandonedRuleArn: string;
-    TxMaAuditEventRule: string;
-    TxMaAuditEventRuleArn: string;
-  }>;
-
   let sessionTableName: string;
 
   it("should return a 400 when session does not exist", async () => {
-    output = await stackOutputs(process.env.STACK_NAME);
-
     const startExecutionResult = await executeStepFunction(
-      output.AbandonStateMachineArn as string,
+      `${process.env.ABANDON_STATE_MACHINE_ARN}`,
       input
     );
     expect(startExecutionResult.output).toBe('{"httpStatus":400}');
   });
   describe("step function execution", () => {
     beforeEach(async () => {
-      output = await stackOutputs(process.env.STACK_NAME);
-      sessionTableName = `session-${output.CommonStackName}`;
+      sessionTableName = `${process.env.SESSION_TABLE}`;
 
       await populateTable(sessionTableName, {
         sessionId: input.sessionId,
@@ -56,7 +43,7 @@ describe("Abandon", () => {
     });
     it("should remove the authorizationCode when session exists", async () => {
       const startExecutionResult = await executeStepFunction(
-        output.AbandonStateMachineArn as string,
+        `${process.env.ABANDON_STATE_MACHINE_ARN}`,
         input
       );
 

--- a/integration-tests/step-functions/aws/check-session/check-session.test.ts
+++ b/integration-tests/step-functions/aws/check-session/check-session.test.ts
@@ -1,4 +1,3 @@
-import { stackOutputs } from "../../../resources/cloudformation-helper";
 import { clearItems, populateTable } from "../../../resources/dynamodb-helper";
 import { executeStepFunction } from "../../../resources/stepfunction-helper";
 
@@ -25,16 +24,12 @@ describe("check-session", () => {
     persistentSessionId: "156714ef-f9df-48c2-ada8-540e7bce44f7",
   };
 
-  let output: Partial<{
-    CommonStackName: string;
-    CheckSessionStateMachineArn: string;
-  }>;
-
   let sessionTableName: string;
+  let checkSessionStateMachineArn: string;
 
   beforeEach(async () => {
-    output = await stackOutputs(process.env.STACK_NAME);
-    sessionTableName = `session-${output.CommonStackName}`;
+    sessionTableName = `${process.env.SESSION_TABLE}`;
+    checkSessionStateMachineArn = `${process.env.CHECK_SESSION_STATE_MACHINE_ARN}`;
   });
 
   afterEach(async () => {
@@ -47,7 +42,7 @@ describe("check-session", () => {
     await populateTable(sessionTableName, sessionItem);
 
     const startExecutionResult = await executeStepFunction(
-      output.CheckSessionStateMachineArn as string,
+      checkSessionStateMachineArn,
       input
     );
 
@@ -61,7 +56,7 @@ describe("check-session", () => {
     await populateTable(sessionTableName, sessionItem);
 
     const startExecutionResult = await executeStepFunction(
-      output.CheckSessionStateMachineArn as string,
+      checkSessionStateMachineArn,
       input
     );
 
@@ -70,7 +65,7 @@ describe("check-session", () => {
 
   it("should return SESSION_NOT_FOUND when sessionId does not exist", async () => {
     const startExecutionResult = await executeStepFunction(
-      output.CheckSessionStateMachineArn as string,
+      checkSessionStateMachineArn,
       input
     );
 
@@ -82,7 +77,7 @@ describe("check-session", () => {
     await populateTable(sessionTableName, sessionItem);
 
     const startExecutionResult = await executeStepFunction(
-      output.CheckSessionStateMachineArn as string,
+      checkSessionStateMachineArn,
       input
     );
 
@@ -91,7 +86,7 @@ describe("check-session", () => {
 
   it("should return SESSION_NOT_PROVIDED when sessionId is missing", async () => {
     const startExecutionResult = await executeStepFunction(
-      output.CheckSessionStateMachineArn as string
+      checkSessionStateMachineArn
     );
 
     expect(startExecutionResult.output).toBe(

--- a/integration-tests/step-functions/aws/jest.config.ts
+++ b/integration-tests/step-functions/aws/jest.config.ts
@@ -6,4 +6,5 @@ export default {
   projects: [],
   displayName: "integration-tests/step-functions/aws",
   setupFiles: ["<rootDir>/setEnvVars.js"],
+  globalSetup: "../../globalStackOutputSetup.ts",
 } satisfies Config;


### PR DESCRIPTION
## Proposed changes

Improve the individual time each integration test component was taken

![image](https://github.com/user-attachments/assets/5a5d9d03-5324-4b21-8cf2-08e3eaafdacd)

### How

Introduced a global api-test-context, which would get the stack information once, instead of in every test

### Why did it change

Running test locally was a flakky adjusting the timeout locally often worked, these changes should result in a more consistent experience

### Issue tracking

- [OJ-3131](https://govukverify.atlassian.net/browse/OJ-3131)

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3131]: https://govukverify.atlassian.net/browse/OJ-3131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ