### PR TITLE
OJ-3209: handle internal pdv errors better

### DIFF
--- a/lambdas/matching/src/matching-handler.ts
+++ b/lambdas/matching/src/matching-handler.ts
@@ -79,6 +79,14 @@ export class MatchingHandler implements LambdaInterface {
           );
         }
 
+        if (response.status >= 500) {
+          return {
+            status: response.status.toString(),
+            body: "Internal server error",
+            txn: txn,
+          };
+        }
+
         return {
           status: response.status.toString(),
           body: responseBody,

--- a/lambdas/matching/tests/matching-handler.test.ts
+++ b/lambdas/matching/tests/matching-handler.test.ts
@@ -108,6 +108,28 @@ describe("matching-handler", () => {
     expect(result.txn).toStrictEqual("mock-txn");
   });
 
+  it("should return 500 with internal server error", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValueOnce("mock-txn")
+          .mockReturnValueOnce("application/json"),
+      },
+      text: jest
+        .fn()
+        .mockResolvedValueOnce("dummy-error-message-containing-pii"),
+      status: 500,
+    });
+
+    const matchingHandler = new MatchingHandler();
+    const result = await matchingHandler.handler(testEvent, {} as Context);
+
+    expect(result.status).toBe("500");
+    expect(result.body).toStrictEqual("Internal server error");
+    expect(result.txn).toStrictEqual("mock-txn");
+  });
+
   it("should return a valid response when the content-type is application/json and the body is not valid JSON", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       headers: {

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -360,9 +360,17 @@
           "Next": "Store Deceased Attempt"
         },
         {
-          "Variable": "$.hmrc_response.payload.body.code",
-          "StringEquals": "INVALID_CREDENTIALS",
-          "Next": "Err: Failed Auth"
+          "Next": "Err: Failed Auth",
+          "And": [
+            {
+              "Variable": "$.hmrc_response.payload.body.code",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.hmrc_response.payload.body.code",
+              "StringEquals": "INVALID_CREDENTIALS"
+            }
+          ]
         }
       ],
       "Default": "Err: API Error"


### PR DESCRIPTION
## Proposed changes

### What changed
* Added test for internal server error
* Updated `NinoCheckStateMachine` to check if the `code` value is present in the error handling block
* Updated the `MatchingFunction` to not return the API response body on 5xx errors. This is because their errors may contain PII and we cannot be sure that the error message will be consistent. 

### Why did it change
The HMRC PDV matching API was down which caused an incident. While, functionally, this wasn't a problem for us, we didn't handle the exception properly in the step function. The same effect still occurred (i.e. step function execution failure) but this should ideally happen on our `Err: API Error.` fail state. 

Additionally, on any 5xx error, we return "Internal server error" as the parsed PDV matching response body. This is because we have seen PII being returned in their response bodies. Instead of redacting the known error message, not pushing the entire response body is more safer as we cannot determine what internal HMRC error messages may contain. So another scenario containing PII could arise that we do not know of. 

**Screenshot**
<img width="414" alt="Screenshot 2025-05-27 at 12 21 30" src="https://github.com/user-attachments/assets/3e2a16e8-93f8-43b1-8325-0edf67e32345" />

**Log Group**
Note: The error message returned by the API on 5xx is no longer in the step function logs.
<img width="1620" alt="Screenshot 2025-05-27 at 12 31 04" src="https://github.com/user-attachments/assets/ba06b962-0ae7-4bd9-8284-9c6426f909f9" />

### Issue tracking
- [OJ-3209](https://govukverify.atlassian.net/browse/OJ-3209)


[OJ-3209]: https://govukverify.atlassian.net/browse/OJ-3209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ