### PR TITLE
OJ-3193: Add slack actions to lambda error alarm

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -378,8 +378,10 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
       OKActions:
         - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
       InsufficientDataActions: []
       MetricName: Errors
       Namespace: AWS/Lambda


### PR DESCRIPTION
## Proposed changes

### What changed

Add slack actions to lambda error alarm.

### Why did it change

Improve visibility of lambda errors. 

### Issue tracking

- [OJ-3193](https://govukverify.atlassian.net/browse/OJ-3193)


[OJ-3193]: https://govukverify.atlassian.net/browse/OJ-3193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ