### PR TITLE
OJ-3193: Add APIGW 5xx alarm

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -728,6 +728,53 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
+  NinoCheckAPIGW5XXErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: "DeployAlarms"
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-NinoCheckApi-5XXError-alarm"
+      AlarmDescription: !Sub Check HMRC ${Environment} API Gateway 5XX errors
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
+      OKActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
+      InsufficientDataActions: []
+      DatapointsToAlarm: 3
+      EvaluationPeriods: 3
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: e1
+          Label: Expression1
+          ReturnData: true
+          Expression: SUM(METRICS())
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5XXError
+              Dimensions:
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName}-public"
+            Period: 300
+            Stat: Sum
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5XXError
+              Dimensions:
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName}-private"
+            Period: 300
+            Stat: Sum
+
   ExecuteStateMachineRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
## Proposed changes

### What changed

Added APIGW 5XX alarm. 

This alarm has been copied from Address and KBV and kept the same for consistency. 

### Why did it change

When we replace some state machines with lambdas, we will remove the current alarms in place. This ensure backend 5xx errors will still trigger an alarm.

### Issue tracking

- [OJ-3193](https://govukverify.atlassian.net/browse/OJ-3193)

## Screenshot

![image](https://github.com/user-attachments/assets/533aa66f-8dac-4c9e-8444-9b6a843e7d66)

[OJ-3193]: https://govukverify.atlassian.net/browse/OJ-3193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ