### PR TITLE
OJ-3220 - Handle ResourceAlreadyExistsException in PIIRedactFunction createLogStream()

### DIFF
--- a/lambdas/pii-redact/src/pii-redact-handler.ts
+++ b/lambdas/pii-redact/src/pii-redact-handler.ts
@@ -20,24 +20,22 @@ import { initOpenTelemetry } from "../../open-telemetry/src/otel-setup";
 
 initOpenTelemetry();
 
-const logger = new Logger();
 const cloudwatch = new CloudWatchLogsClient();
 
 const logStreamTrackingTable = process.env.RedactionLogStreamTrackingTable;
 
 export class PiiRedactHandler implements LambdaInterface {
-  private readonly dynamodb: DynamoDBClient;
-
-  constructor(dynamodb = new DynamoDBClient()) {
-    this.dynamodb = dynamodb;
-  }
+  constructor(
+    private readonly dynamodb = new DynamoDBClient(),
+    private readonly logger = new Logger()
+  ) {}
 
   public async handler(
     event: CloudWatchLogsEvent,
     _context: unknown
   ): Promise<object> {
     try {
-      logger.info("Received " + JSON.stringify(event));
+      this.logger.info("Received " + JSON.stringify(event));
 
       const logDataBase64 = event.awslogs.data;
       const logDataBuffer = Buffer.from(logDataBase64, "base64");
@@ -57,7 +55,7 @@ export class PiiRedactHandler implements LambdaInterface {
       return {};
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      logger.error(`Error in PiiRedactHandler: ${message}`);
+      this.logger.error(`Error in PiiRedactHandler: ${message}`);
       throw error;
     }
   }
@@ -67,7 +65,7 @@ export class PiiRedactHandler implements LambdaInterface {
     logStream: string,
     logEvents: CloudWatchLogsDecodedData
   ) {
-    logger.info("Putting redacted logs into " + redactLogGroup);
+    this.logger.info("Putting redacted logs into " + redactLogGroup);
 
     try {
       const response: PutLogEventsCommandOutput = await cloudwatch.send(
@@ -82,16 +80,18 @@ export class PiiRedactHandler implements LambdaInterface {
           })),
         })
       );
-      logger.info(JSON.stringify(response));
+      this.logger.info(JSON.stringify(response));
     } catch (error) {
-      logger.error(`Error putting log events into ${redactLogGroup}: ${error}`);
+      this.logger.error(
+        `Error putting log events into ${redactLogGroup}: ${error}`
+      );
       throw error;
     }
   }
 
   private async createLogStream(logStreamName: string, logGroupName: string) {
     if (!(await this.logStreamExists(logStreamName))) {
-      logger.info("Creating log stream " + logStreamName);
+      this.logger.info("Creating log stream " + logStreamName);
 
       try {
         await cloudwatch.send(
@@ -102,12 +102,16 @@ export class PiiRedactHandler implements LambdaInterface {
         );
       } catch (error: unknown) {
         if (error instanceof ResourceAlreadyExistsException) {
-          logger.info(logStreamName + " already exists");
+          this.logger.info(logStreamName + " already exists");
+        } else {
+          throw error;
         }
       }
 
       await this.saveLogStreamRecordInDB(logStreamName);
-      logger.info("Added " + logStreamName + " to " + logStreamTrackingTable);
+      this.logger.info(
+        "Added " + logStreamName + " to " + logStreamTrackingTable
+      );
     }
   }
 

--- a/lambdas/pii-redact/tests/utils.ts
+++ b/lambdas/pii-redact/tests/utils.ts
@@ -1,0 +1,9 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+
+export const mockLogger = {
+  info: jest.fn(),
+  critical: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+} as unknown as Logger;


### PR DESCRIPTION
## Proposed changes

### What changed

Added exception handling to createLogStream() to resolve race condition where multiple simultaneous executions try to create the same log stream.

### Why did it change

This morning (09/06/2025) we found that the CheckHmrcLambdaErrors alarm was being triggered repeatedly, causing Amazon Q to fill the #di-orange-critical-non-prod channel with errors. This has been traced to the PIIRedactFunction throwing the following error:

```json
{
    "errorType": "ResourceAlreadyExistsException",
    "errorMessage": "The specified log stream already exists",
    "name": "ResourceAlreadyExistsException",
    "$fault": "client",
    "$metadata": {
        "httpStatusCode": 400,
        "requestId": "0f0efd2e-cf6c-4e77-b9ca-7029c12e2055",
        "attempts": 1,
        "totalRetryDelay": 0
    },
    "__type": "ResourceAlreadyExistsException",
    "stack": [
        "ResourceAlreadyExistsException: The specified log stream already exists",
        "    at de_ResourceAlreadyExistsExceptionRes (/tmp/tmp2mzif1ut/node_modules/@aws-sdk/client-cloudwatch-logs/dist-cjs/index.js:2286:21)",
        "    at de_CommandError (/tmp/tmp2mzif1ut/node_modules/@aws-sdk/client-cloudwatch-logs/dist-cjs/index.js:2177:19)",
        "    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)",
        "    at async <anonymous> (/tmp/tmp2mzif1ut/node_modules/@smithy/middleware-serde/dist-cjs/index.js:35:20)",
        "    at async <anonymous> (/tmp/tmp2mzif1ut/node_modules/@smithy/core/dist-cjs/index.js:165:18)",
        "    at async <anonymous> (/tmp/tmp2mzif1ut/node_modules/@smithy/middleware-retry/dist-cjs/index.js:320:38)",
        "    at async <anonymous> (/tmp/tmp2mzif1ut/node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/middleware-logger/dist-cjs/index.js:33:22)",
        "    at async PV.createLogStream (/tmp/tmp2mzif1ut/lambdas/pii-redact/src/pii-redact-handler.ts:95:7)",
        "    at async PV.handler (/tmp/tmp2mzif1ut/lambdas/pii-redact/src/pii-redact-handler.ts:48:7)"
    ]
}
```

This ticket is to resolve the issue in the same way as was already done for HMRC OTG ([PR](https://github.com/govuk-one-login/ipv-cri-otg-hmrc/pull/247)).

### Issue tracking

OJ-3220

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
