### PR TITLE
OJ-3214: Update SupportManualURL to be a mapping

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "The unique credential issuer identifier"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/common-cri-parameters/CriIdentifier"
-  SupportManualURL:
-    Type: String
-    Default: "https://team-manual.account.gov.uk/teams/CRI-Orange-team/supporting-cri-orange/hmrc-nino-runbook/#backend-api-alarms"
-    Description: The support manual URL to be provided in alarm messages.
   LambdaDeploymentPreference:
     Description: "Specifies the configuration to enable gradual Lambda deployments. It can be used to set deployment type and also allows skipping canary deployment by setting to 'AllAtOnce'"
     Type: String
@@ -77,6 +73,9 @@ Conditions:
     !Not [!Equals [!FindInMap [EnvironmentConfiguration, !Ref Environment, provisionedConcurrency], 0]]
 
 Mappings:
+  StaticVariables:
+    Urls:
+      SupportManualURL: "https://team-manual.account.gov.uk/teams/CRI-Orange-team/supporting-cri-orange/hmrc-nino-runbook/#backend-api-alarms"
   # Only numeric values should be assigned here
   MaxJwtTtl:
     Environment:
@@ -353,7 +352,9 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${AWS::StackName}-CheckHmrcLambdaConcurrency80-alarm
-      AlarmDescription: !Sub Check HMRC ${Environment} lambdas alarm if over 80% of concurrent executions is used ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Check HMRC ${Environment} lambdas alarm if over 80% of concurrent executions is used. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -374,7 +375,9 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${AWS::StackName}-CheckHmrcLambdaErrors-alarm
-      AlarmDescription: !Sub Check HMRC ${Environment} lambda errors"
+      AlarmDescription: !Sub
+        - "Check HMRC ${Environment} lambda errors. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
@@ -397,7 +400,9 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${AWS::StackName}-CheckHmrcLambdaThrottle-alarm
-      AlarmDescription: !Sub Check HMRC ${Environment} lambda throttle"
+      AlarmDescription: !Sub
+        - "Check HMRC ${Environment} lambda throttle. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
@@ -605,7 +610,9 @@ Resources:
     Condition: "DeployAlarms"
     Properties:
       AlarmName: !Sub "${AWS::StackName}-${Environment}-PublicNinoCheckApi-FatalError-alarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal ${PublicNinoCheckApi} Error occurs. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger an alarm when Fatal ${PublicNinoCheckApi} Error occurs. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
@@ -708,7 +715,9 @@ Resources:
     Condition: "DeployAlarms"
     Properties:
       AlarmName: !Sub "${AWS::StackName}-${Environment}-PrivateNinoCheckApi-FatalError-alarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal ${PrivateNinoCheckApi} Error occurs. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger an alarm when Fatal ${PrivateNinoCheckApi} Error occurs.Runbook:  ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
@@ -894,7 +903,9 @@ Resources:
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
         - !ImportValue platform-alarm-critical-alert-topic
-      AlarmDescription: !Sub "${CheckSessionStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "${CheckSessionStateMachine} failed 4 or more requests in the last hour. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-${Environment}-CheckSessionStateMachine-alarm"
       MetricName: "ExecutionsFailed"
       Namespace: AWS/States
@@ -1040,7 +1051,9 @@ Resources:
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
         - !ImportValue platform-alarm-critical-alert-topic
-      AlarmDescription: !Sub "${NinoCheckStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "${NinoCheckStateMachine} failed 4 or more requests in the last hour. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-${Environment}-NinoCheckStateMachine-ExecutionsFailed-alarm"
       MetricName: "ExecutionsFailed"
       Namespace: AWS/States
@@ -1144,7 +1157,9 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "${AbandonStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "${AbandonStateMachine} failed 4 or more requests in the last hour. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-${Environment}-AbandonStateMachine-ExecutionsFailed-alarm"
       MetricName: "ExecutionsFailed"
       Namespace: AWS/States
@@ -1285,7 +1300,9 @@ Resources:
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
         - !ImportValue platform-alarm-critical-alert-topic
-      AlarmDescription: !Sub "${NinoIssueCredentialStateMachine} failed 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "${NinoIssueCredentialStateMachine} failed 4 or more requests in the last hour. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-${Environment}-NinoIssueCredentialStateMachine-ExecutionsFailed-alarm"
       MetricName: "ExecutionsFailed"
       Namespace: AWS/States
@@ -1466,7 +1483,9 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "${TxMaAuditEventRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "${TxMaAuditEventRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-${Environment}-TxMaAuditEventRule-FailedInvocations-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
@@ -1491,7 +1510,9 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "${AuditEventRequestSentRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "${AuditEventRequestSentRule} (Failed Invocations) 4 or more requests in the last hour. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventRequestSentRule-FailedInvocations-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
@@ -1516,7 +1537,9 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "${AuditEventResponseReceivedRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "${AuditEventResponseReceivedRule} (Failed Invocations) 4 or more requests in the last hour. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventResponseReceivedRule-FailedInvocations-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
@@ -1541,7 +1564,9 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "${AuditEventVcIssuedRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "${AuditEventVcIssuedRule} (Failed Invocations) 4 or more requests in the last hour. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventVcIssuedRule-FailedInvocations-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
@@ -1566,7 +1591,9 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "${AuditEventEndRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "${AuditEventEndRule} (Failed Invocations) 4 or more requests in the last hour. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventEndRule-FailedInvocations-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
@@ -1591,7 +1618,9 @@ Resources:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "${AuditEventAbandonedRule} (Failed Invocations) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "${AuditEventAbandonedRule} (Failed Invocations) 4 or more requests in the last hour. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-${Environment}-AuditEventAbandonedRule-FailedInvocations-alarm"
       MetricName: "FailedInvocations"
       Namespace: "AWS/Events"
@@ -1617,7 +1646,9 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       InsufficientDataActions: []
-      AlarmDescription: !Sub "${AWS::StackName}-${Environment} PutEvents (PutEvents Failed) 4 or more requests in the last hour. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "${AWS::StackName}-${Environment} PutEvents (PutEvents Failed) 4 or more requests in the last hour. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-${Environment}-CheckHmrcEventBus-PutEventsApproximateFailedCount-alarm"
       MetricName: PutEventsApproximateFailedCount
       ComparisonOperator: GreaterThanThreshold


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update SupportManualURL to be a mapping

### Why did it change

Because cloudformation params can't be easily updated. Note that this follows pattern from [mobile](https://github.com/govuk-one-login/mobile-id-check-async/blob/112899215e89db31f4d1412c4f04665a3a5133ca/backend-api/infra/monitoring/sqsAlarms.yaml#L10C35-L10C50)

### Screenshots

Before
<img width="1135" alt="Screenshot 2025-06-11 at 12 49 09 pm" src="https://github.com/user-attachments/assets/293720fa-6d20-44cc-a6f8-6546d21194d0" />

After
<img width="1124" alt="Screenshot 2025-06-11 at 12 49 33 pm" src="https://github.com/user-attachments/assets/10e70aae-8270-4554-b511-31c05b8e1a25" />

<img width="777" alt="image" src="https://github.com/user-attachments/assets/87b40469-16bc-40d9-a72e-5980522e08ba" />


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3214](https://govukverify.atlassian.net/browse/OJ-3214)



[OJ-3214]: https://govukverify.atlassian.net/browse/OJ-3214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ