### PR TITLE
OJ-3192 - Stop logging fn.name as it is not useful when code has been minified

### DIFF
--- a/lambdas/common/src/util/retry.ts
+++ b/lambdas/common/src/util/retry.ts
@@ -16,14 +16,12 @@ export async function withRetry<T>(
       return await fn();
     } catch (error) {
       if (attempt === maxRetries || !shouldRetry(error, attempt)) {
-        logger.info(
-          `Failed to execute callback '${fn.name}' after ${attempt} retries.`
-        );
+        logger.info(`Failed to execute callback after ${attempt} retries.`);
         throw error;
       }
       const delay = baseDelay * Math.pow(2, attempt);
       logger.info(
-        `Failed to execute callback '${fn.name}' (retry attempt ${attempt}). Waiting ${delay} ms and retrying...`
+        `Failed to execute callback (retry attempt ${attempt}). Waiting ${delay} ms and retrying...`
       );
       await new Promise((resolve) => setTimeout(resolve, delay));
     }


### PR DESCRIPTION
## Proposed changes

### What changed

Removed `fn.name` from `withRetry()` logs.

### Why did it change

When code has been minified, functions' names get changed to single-letter values. This led to log messages such as:

```
Failed to execute callback 'o' (retry attempt 1). Waiting 600 ms and retrying...
```

### Issue tracking

- OJ-3192

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed