### PR TITLE
OJ-3259: Fix duplicated VCissuedMetric

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -2751,7 +2751,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref NinoIssueCredentialLogGroup
-      FilterPattern: '{($.details.name = "Create Signed JWT")}'
+      FilterPattern: '{($.details.name = "Create Signed JWT") && ($.type = "PassStateExited")}'
       MetricTransformations:
         - MetricValue: 1
           MetricName: VCIssuedMetric


### PR DESCRIPTION
## Proposed changes

### What changed

Add condition to metric filer to only be on `PassStateExited`

### Why did it change

VCIssuedMetric is reporting twice

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3259](https://govukverify.atlassian.net/browse/OJ-3259)

### Screenshot

![image](https://github.com/user-attachments/assets/69d12700-3767-478a-95a1-b034ae09312e)



[OJ-3259]: https://govukverify.atlassian.net/browse/OJ-3259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ