### PR TITLE
OJ-3197: Add metrics decorator to ensure metrics queue is flushed before Lambda spins down

### DIFF
--- a/lambdas/common/src/util/metrics.ts
+++ b/lambdas/common/src/util/metrics.ts
@@ -1,7 +1,7 @@
 import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
 import { MetricDimensions, MetricNames } from "../../../logging/metric-types";
 
-const metrics = new Metrics();
+export const metrics = new Metrics();
 
 const singleMetric = metrics.singleMetric();
 

--- a/lambdas/nino-check/src/handler.ts
+++ b/lambdas/nino-check/src/handler.ts
@@ -12,7 +12,7 @@ import { retrieveSession } from "./helpers/retrieve-session";
 import { retrieveAttempts } from "./helpers/retrieve-attempts";
 import { retrievePersonIdentity } from "./helpers/retrieve-person-identity";
 import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
-import { captureMetric } from "../../common/src/util/metrics";
+import { captureMetric, metrics } from "../../common/src/util/metrics";
 import { getTokenFromOtg } from "./hmrc-apis/otg";
 import { sendRequestSentEvent, sendResponseReceivedEvent } from "./helpers/audit";
 import { matchUserDetailsWithPdv } from "./hmrc-apis/pdv";
@@ -28,6 +28,7 @@ const MAX_PAST_ATTEMPTS = 1;
 
 class NinoCheckHandler implements LambdaInterface {
   @logger.injectLambdaContext({ resetKeys: true })
+  @metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
   public async handler({ body, headers }: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> {
     try {
       logger.info(`${context.functionName} invoked.`);


### PR DESCRIPTION
## Proposed changes

### What changed

Added [metrics decorator](https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics/#using-the-class-decorator) to NINo check handler

### Why did it change

Metrics were not being consistently pushed to CloudWatch

### Issue tracking

- OJ-3197

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
