### PR TITLE
OJ-3159: 

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -128,7 +128,8 @@
         "HMRCBearerToken",
         "goodToken",
         "badToken",
-        "02ba5dbd2a3664670bf5c4689a9f8e014fe2c019209c9e5db7641a2b2a4bc7a8"
+        "02ba5dbd2a3664670bf5c4689a9f8e014fe2c019209c9e5db7641a2b2a4bc7a8",
+        "74c5b00d698a18178a738f5305ee67f9d50fc620f8be6b89d94638fa16a4c828"
       ]
     }
   ],

--- a/integration-tests/api-gateway/cri-decrypt-verify/index.test.ts
+++ b/integration-tests/api-gateway/cri-decrypt-verify/index.test.ts
@@ -1,0 +1,226 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { stackOutputs } from "../../resources/cloudformation-helper";
+import { JweDecrypter } from "../crypto/jwe-decrypter";
+import { JwtVerifierFactory, ClaimNames } from "../crypto/jwt-verifier";
+import { AUDIENCE, CLIENT_ID, CLIENT_URL, CORE_INFRASTRUCTURE } from "../env-variables";
+import { getSSMParameter } from "../../resources/ssm-param-helper";
+import { base64url, JWTVerifyResult } from "jose";
+import { kmsClient } from "../../resources/kms-helper";
+import { createSession, getJarAuthorization } from "../endpoints";
+import { clearItemsFromTables } from "../../resources/dynamodb-helper";
+
+interface StartEndpointResponse {
+  client_id: string;
+  request: string;
+}
+
+describe.each([
+  {
+    keyRotation: "true",
+    legacyFallback: "true",
+    description: "when key rotation is enabled and legacy fallback feature is enabled",
+  },
+  {
+    keyRotation: "true",
+    legacyFallback: "false",
+    description: "when key rotation is enabled and legacy fallback feature is disabled",
+  },
+])(
+  "Given there is a ./well-known/jwks with a key to encrypt claims",
+  ({ keyRotation, legacyFallback, description }) => {
+    let response: Response;
+    let jarRequest: StartEndpointResponse;
+    let decryptedJwt: Buffer;
+    let verificationResult: JWTVerifyResult | null;
+    let originalRotationFlag: string | undefined;
+    let originalFallbackFlag: string | undefined;
+
+    const jwtVerifierFactory = new JwtVerifierFactory(new Logger());
+    let jweDecrypter: JweDecrypter;
+    let authenticationAlg: string | undefined;
+
+    beforeAll(async () => {
+      originalRotationFlag = process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION;
+      originalFallbackFlag = process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK;
+
+      process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION = keyRotation;
+      process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK = legacyFallback;
+
+      const { CriDecryptionKey1Id: decryptionKeyId } = await stackOutputs(CORE_INFRASTRUCTURE);
+      authenticationAlg = await getSSMParameter(
+        `/${process.env.COMMON_STACK_NAME}/clients/${CLIENT_ID}/jwtAuthentication/authenticationAlg`
+      );
+      jweDecrypter = new JweDecrypter(kmsClient, () => decryptionKeyId);
+    });
+
+    afterAll(() => {
+      process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION = originalRotationFlag;
+      process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK = originalFallbackFlag;
+    });
+
+    describe(description, () => {
+      it("then the headless core stub makes a request to the Start Endpoint", async () => {
+        response = await getJarAuthorization();
+        jarRequest = await response.json();
+      });
+
+      it("and the request is successful", () => {
+        expect(response.status).toBe(200);
+        expect(jarRequest.client_id).toBe(CLIENT_ID);
+      });
+
+      it(`any KMS aliases succeeds in decryption ${description}`, async () => {
+        const decryptKeyWithKmsSpy = jest.spyOn(jweDecrypter, "decryptKeyWithKms");
+
+        await jweDecrypter.decryptJwe(jarRequest.request);
+
+        expect(decryptKeyWithKmsSpy).toHaveBeenCalledTimes(1);
+
+        expect(decryptKeyWithKmsSpy).toHaveBeenCalledWith(expect.any(Uint8Array), expect.stringMatching(/alias\//));
+
+        decryptKeyWithKmsSpy.mockRestore();
+      });
+
+      it("then the response can be decrypted", async () => {
+        expect(jarRequest.request).toBeDefined();
+        decryptedJwt = await jweDecrypter.decryptJwe(jarRequest.request);
+        expect(decryptedJwt).toBeDefined();
+      });
+
+      it("and response is verified successfully", async () => {
+        const jwtVerifier = jwtVerifierFactory.create(authenticationAlg as string);
+        verificationResult = await jwtVerifier.verify(
+          decryptedJwt,
+          new Set([ClaimNames.EXPIRATION_TIME, ClaimNames.SUBJECT, ClaimNames.NOT_BEFORE, ClaimNames.STATE]),
+          new Map([
+            [ClaimNames.AUDIENCE, AUDIENCE],
+            [ClaimNames.ISSUER, CLIENT_URL],
+          ])
+        );
+
+        expect(verificationResult?.protectedHeader.alg).toBe("ES256");
+        expect(verificationResult?.protectedHeader.typ).toBe("JWT");
+        expect(verificationResult?.payload.iss).toBe(CLIENT_URL);
+        expect(verificationResult?.payload.aud).toBe(AUDIENCE);
+
+        expect(verificationResult?.payload.shared_claims).toEqual({
+          name: [
+            {
+              nameParts: [
+                {
+                  type: "GivenName",
+                  value: "KENNETH",
+                },
+                {
+                  type: "FamilyName",
+                  value: "DECERQUEIRA",
+                },
+              ],
+            },
+          ],
+          birthDate: [{ value: "1965-07-08" }],
+          address: [
+            {
+              addressLocality: "BATH",
+              buildingNumber: "8",
+              postalCode: "BA2 5AA",
+              streetName: "HADLEY ROAD",
+              validFrom: "2021-01-01",
+            },
+          ],
+        });
+        const decodedState = JSON.parse(
+          new TextDecoder().decode(base64url.decode(verificationResult?.payload.state as string))
+        );
+        expect(decodedState).toEqual({
+          aud: AUDIENCE,
+          redirect_uri: expect.stringContaining("callback"),
+        });
+      });
+
+      describe("Check HMRC CRI", () => {
+        let sessionId: string;
+        let sessionTableName: string;
+        let sessionResponse: Response;
+        let jsonSession: { session_id: string };
+
+        beforeAll(async () => {
+          sessionTableName = `${process.env.SESSION_TABLE}`;
+          sessionResponse = await createSession(`${process.env.PRIVATE_API}`, jarRequest);
+          jsonSession = await sessionResponse.json();
+          sessionId = jsonSession.session_id;
+        });
+
+        afterEach(async () => {
+          await clearItemsFromTables(
+            {
+              tableName: `${process.env.PERSON_IDENTITY_TABLE}`,
+              items: { sessionId: sessionId },
+            },
+            {
+              tableName: sessionTableName,
+              items: { sessionId: sessionId },
+            }
+          );
+        });
+
+        it("session endpoint is called", () => {
+          expect(sessionResponse).toBeDefined();
+          expect(jsonSession).toBeDefined();
+        });
+
+        it("and successfully receives a 201 created with a valid session id", () => {
+          expect(sessionResponse.status).toEqual(201);
+          expect(sessionId).toBeDefined();
+        });
+      });
+    });
+  }
+);
+
+describe("Given there is a ./well-known/jwks with a key to encrypt claims - when key rotation is disabled", () => {
+  let response: Response;
+  let jarRequest: StartEndpointResponse;
+  let originalRotationFlag: string | undefined;
+  let originalFallbackFlag: string | undefined;
+
+  let jweDecrypter: JweDecrypter;
+
+  beforeAll(async () => {
+    originalRotationFlag = process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION;
+    originalFallbackFlag = process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK;
+
+    process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION = "false";
+    process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK = "false";
+
+    const { CriDecryptionKey1Id: decryptionKeyId } = await stackOutputs(CORE_INFRASTRUCTURE);
+
+    jweDecrypter = new JweDecrypter(kmsClient, () => decryptionKeyId);
+  });
+
+  afterAll(() => {
+    process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION = originalRotationFlag;
+    process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK = originalFallbackFlag;
+  });
+
+  it("when the headless core stub makes a request to the Start Endpoint", async () => {
+    response = await getJarAuthorization();
+    jarRequest = await response.json();
+  });
+
+  it("and the request is successful", () => {
+    expect(response.status).toBe(200);
+    expect(jarRequest.client_id).toBe(CLIENT_ID);
+  });
+
+  it("uses legacy KMS ID and throws error when decrypting JWE", async () => {
+    const decryptKeyWithKmsSpy = jest.spyOn(jweDecrypter, "decryptKeyWithKms");
+
+    await expect(jweDecrypter.decryptJwe(jarRequest.request)).rejects.toThrow(/Failed to decrypt with legacy key/);
+
+    expect(decryptKeyWithKmsSpy).toHaveBeenCalledTimes(1);
+    expect(decryptKeyWithKmsSpy).toHaveBeenCalledWith(expect.any(Uint8Array), expect.not.stringMatching(/alias\//));
+
+    decryptKeyWithKmsSpy.mockRestore();
+  });
+});

--- a/integration-tests/api-gateway/crypto/jwe-decrypter.ts
+++ b/integration-tests/api-gateway/crypto/jwe-decrypter.ts
@@ -114,7 +114,7 @@ export class JweDecrypter {
     }
   }
 
-  private async decryptKeyWithKms(
+  public async decryptKeyWithKms(
     encryptedContentEncKey: Uint8Array,
     kmsKeyIdOrAlias: string
   ): Promise<Uint8Array | undefined> {

--- a/integration-tests/api-gateway/crypto/jwe-decrypter.ts
+++ b/integration-tests/api-gateway/crypto/jwe-decrypter.ts
@@ -1,0 +1,129 @@
+/* eslint-disable no-console */
+import { base64url } from "jose";
+import { CipherGCMTypes, createDecipheriv, KeyObject } from "crypto";
+import { DecryptCommand, EncryptionAlgorithmSpec, KMSClient } from "@aws-sdk/client-kms";
+const DecryptionKeyAliases = [
+  "session_decryption_key_active_alias",
+  "session_decryption_key_inactive_alias",
+  "session_decryption_key_previous_alias",
+] as const;
+
+const ALL_ALIASES_UNAVAILABLE = "all_aliases_unavailable_for_decryption";
+
+export class JweDecrypter {
+  private kmsEncryptionKeyId: string | undefined;
+  constructor(
+    private readonly kmsClient: KMSClient,
+    private readonly getEncryptionKeyId: () => string
+  ) {}
+
+  public async decryptJwe(compactJwe: string): Promise<Buffer> {
+    const { 0: jweProtectedHeader, 1: encryptedKey, 2: iv, 3: cipherText, 4: tag, length } = compactJwe.split(".");
+
+    if (length !== 5) {
+      throw new Error(`Invalid number of JWE parts encountered: ${length}`);
+    }
+
+    const decryptedContentEncKey = await this.fetchKey(encryptedKey);
+
+    const buff = Buffer.from(jweProtectedHeader, "base64");
+    const jweHeader = JSON.parse(buff.toString("utf8"));
+
+    const protectedHeaderArray: Uint8Array = new TextEncoder().encode(jweProtectedHeader);
+
+    try {
+      return this.gcmDecrypt(
+        jweHeader.enc,
+        decryptedContentEncKey as Uint8Array,
+        base64url.decode(cipherText),
+        base64url.decode(iv),
+        base64url.decode(tag),
+        protectedHeaderArray
+      );
+    } catch (error) {
+      console.error("Error decrypting JWE", error);
+      throw error;
+    }
+  }
+
+  // TODO: check if we can import this from the jose package
+  private gcmDecrypt(
+    enc: string,
+    cek: KeyObject | Uint8Array,
+    cipherText: Uint8Array,
+    iv: Uint8Array,
+    tag: Uint8Array,
+    aad: Uint8Array
+  ): Buffer {
+    const keySize = parseInt(enc.slice(1, 4), 10);
+
+    const algorithm = <CipherGCMTypes>`aes-${keySize}-gcm`;
+
+    const decipher = createDecipheriv(algorithm, cek, iv, { authTagLength: 16 });
+    decipher.setAuthTag(tag);
+    if (aad.byteLength) {
+      decipher.setAAD(aad, { plaintextLength: cipherText.length });
+    }
+    const plainText = decipher.update(cipherText);
+    decipher.final();
+    return plainText;
+  }
+
+  private async fetchKey(encryptedKey: string): Promise<Uint8Array | undefined> {
+    const decodedEncryptedKey = base64url.decode(encryptedKey);
+    if (process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION === "true") {
+      return await this.fetchKeyUsingAlias(decodedEncryptedKey);
+    }
+    return await this.fetchKeyUsingKeyId(decodedEncryptedKey);
+  }
+
+  private async fetchKeyUsingAlias(encryptedEncKey: Uint8Array): Promise<Uint8Array | undefined> {
+    console.log("Key rotation enabled. Attempting to decrypt with key aliases.");
+    for (const aliasName of DecryptionKeyAliases) {
+      const alias = `alias/${aliasName}`;
+      try {
+        const cek = await this.decryptKeyWithKms(encryptedEncKey, alias);
+        console.log({ message: "Key rotation enabled", alias, status: "Successfully decrypted using Alias" });
+        return cek;
+      } catch (error: unknown) {
+        console.warn({ message: "Key rotation enabled", alias, error });
+      }
+    }
+
+    console.log(`add metrics for ${ALL_ALIASES_UNAVAILABLE}`);
+
+    if (process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK === "true") {
+      console.warn("Failed to decrypt with all available key aliases, falling back to legacy key.");
+      return await this.fetchKeyUsingKeyId(encryptedEncKey);
+    }
+    throw new Error("Failed to decrypt with all available key aliases.");
+  }
+
+  private async fetchKeyUsingKeyId(encryptedContentEncKey: Uint8Array): Promise<Uint8Array | undefined> {
+    if (!this.kmsEncryptionKeyId) {
+      this.kmsEncryptionKeyId = this.getEncryptionKeyId();
+    }
+    const kmsDecryptionKeyId = this.kmsEncryptionKeyId;
+    try {
+      const cek = await this.decryptKeyWithKms(encryptedContentEncKey, kmsDecryptionKeyId);
+      console.log({ message: "Decryption successful with legacy key" });
+      return cek;
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to decrypt with legacy key: ${message}`);
+    }
+  }
+
+  private async decryptKeyWithKms(
+    encryptedContentEncKey: Uint8Array,
+    kmsKeyIdOrAlias: string
+  ): Promise<Uint8Array | undefined> {
+    const decryptCommand = new DecryptCommand({
+      CiphertextBlob: encryptedContentEncKey,
+      KeyId: kmsKeyIdOrAlias,
+      EncryptionAlgorithm: EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256,
+    });
+    const response = await this.kmsClient.send(decryptCommand);
+    return response.Plaintext;
+  }
+}

--- a/integration-tests/api-gateway/crypto/jwt-verifier.ts
+++ b/integration-tests/api-gateway/crypto/jwt-verifier.ts
@@ -1,0 +1,91 @@
+import {
+  createRemoteJWKSet,
+  JWTPayload,
+  jwtVerify,
+  JWTVerifyOptions,
+  JWTVerifyResult,
+  RemoteJWKSetOptions,
+} from "jose";
+import { Logger } from "@aws-lambda-powertools/logger";
+interface JwtVerificationConfig {
+  jwtSigningAlgorithm: string;
+}
+export enum ClaimNames {
+  ISSUER = "iss",
+  SUBJECT = "sub",
+  AUDIENCE = "aud",
+  EXPIRATION_TIME = "exp",
+  NOT_BEFORE = "nbf",
+  ISSUED_AT = "iat",
+  JWT_ID = "jti",
+  REDIRECT_URI = "redirect_uri",
+  EVIDENCE_REQUESTED = "evidence_requested",
+  STATE = "state",
+}
+
+export class JwtVerifier {
+  static ClaimNames = ClaimNames;
+  constructor(
+    private jwtVerifierConfig: JwtVerificationConfig,
+    private logger: Logger
+  ) {}
+
+  public async verify(
+    encodedJwt: Buffer,
+    mandatoryClaims: Set<string>,
+    expectedClaimValues: Map<string, string>
+  ): Promise<JWTVerifyResult | null> {
+    const jwtVerifyOptions = this.createJwtVerifyOptions(expectedClaimValues);
+
+    try {
+      this.logger.info("Expected claims:", JSON.stringify(expectedClaimValues));
+
+      const verifyResult = await jwtVerify(
+        encodedJwt.toString(),
+        this.getPublicKeyUsingJwksUri(expectedClaimValues.get(JwtVerifier.ClaimNames.ISSUER)), // wellknown endpoint for test is the core-stub but in live it's going to be the CRI i.e audience
+        jwtVerifyOptions
+      );
+      this.checkMandatoryClaims(verifyResult.payload, mandatoryClaims);
+      return verifyResult;
+    } catch (error) {
+      this.logger.error("JWT verification failed", error as Error);
+      return null;
+    }
+  }
+  private checkMandatoryClaims(payload: JWTPayload, mandatoryClaims: Set<string>) {
+    mandatoryClaims.forEach((mandatoryClaim) => {
+      if (!payload[mandatoryClaim]) {
+        throw new Error(`Claims-set missing mandatory claim: ${mandatoryClaim}`);
+      }
+    });
+  }
+
+  private getPublicKeyUsingJwksUri(issuer?: string) {
+    const jwkEndpoint = `${issuer}/.well-known/jwks.json`;
+    this.logger.info({ message: "Retrieving publicSigningKey from JwkEndpoint", jwkEndpoint });
+
+    this.logger.info("JWK_ENDPOINT", jwkEndpoint.toString());
+    return createRemoteJWKSet(new URL(jwkEndpoint), { cache: false } as RemoteJWKSetOptions);
+  }
+
+  private createJwtVerifyOptions(expectedClaimValues: Map<string, string>): JWTVerifyOptions {
+    return {
+      algorithms: [this.jwtVerifierConfig.jwtSigningAlgorithm],
+      audience: expectedClaimValues.get(JwtVerifier.ClaimNames.AUDIENCE),
+      issuer: expectedClaimValues.get(JwtVerifier.ClaimNames.ISSUER),
+      subject: expectedClaimValues.get(JwtVerifier.ClaimNames.SUBJECT),
+    };
+  }
+}
+
+export class JwtVerifierFactory {
+  public constructor(private readonly logger: Logger) {}
+  public create(jwtSigningAlgo: string): JwtVerifier {
+    return new JwtVerifier(
+      {
+        jwtSigningAlgorithm: jwtSigningAlgo,
+      },
+      this.logger
+    );
+  }
+}

--- a/integration-tests/api-gateway/env-variables.ts
+++ b/integration-tests/api-gateway/env-variables.ts
@@ -4,21 +4,19 @@ export type EvidenceRequest = {
 };
 
 export const CLIENT_ID = process.env.CLIENTID || "ipv-core-stub-aws-headless";
-export const AUDIENCE =
-  process.env.AUDIENCE || "https://review-hc.dev.account.gov.uk";
-export const CLIENT_URL =
-  process.env.CLIENT_URL ||
-  "https://test-resources.review-hc.dev.account.gov.uk";
+export const AUDIENCE = process.env.AUDIENCE || "https://review-hc.dev.account.gov.uk";
+export const CLIENT_URL = process.env.CLIENT_URL || "https://test-resources.review-hc.dev.account.gov.uk";
+
+export const CHECK_CRI_STACK_NAME = process.env.STACK_NAME || "check-hmrc-cri-api";
+export const CORE_INFRASTRUCTURE = process.env.CORE_INFRASTRUCTURE || "core-infrastructure";
 
 export const REDIRECT_URL = new URL("callback", CLIENT_URL).toString();
 
 export const NINO = "AA123456C";
-export const CLIENT_ASSERTION_TYPE =
-  "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+export const CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 export const GRANT_TYPE = "authorization_code";
 export const environment = process.env.Environment || "localdev";
-export const testResourcesStack =
-  process.env.TEST_RESOURCES || "test-resources";
+export const testResourcesStack = process.env.TEST_RESOURCES || "test-resources";
 
 export const getClaimSet = async () => {
   const data = {

--- a/integration-tests/api-gateway/env-variables.ts
+++ b/integration-tests/api-gateway/env-variables.ts
@@ -7,7 +7,6 @@ export const CLIENT_ID = process.env.CLIENTID || "ipv-core-stub-aws-headless";
 export const AUDIENCE = process.env.AUDIENCE || "https://review-hc.dev.account.gov.uk";
 export const CLIENT_URL = process.env.CLIENT_URL || "https://test-resources.review-hc.dev.account.gov.uk";
 
-export const CHECK_CRI_STACK_NAME = process.env.STACK_NAME || "check-hmrc-cri-api";
 export const CORE_INFRASTRUCTURE = process.env.CORE_INFRASTRUCTURE || "core-infrastructure";
 
 export const REDIRECT_URL = new URL("callback", CLIENT_URL).toString();

--- a/integration-tests/resources/kms-helper.ts
+++ b/integration-tests/resources/kms-helper.ts
@@ -1,8 +1,8 @@
 import { createSendCommand } from "./aws-helper";
 import { KMSClient, GetPublicKeyCommand } from "@aws-sdk/client-kms";
-const sendCommand = createSendCommand(() => new KMSClient());
+const kmsClient = new KMSClient();
+const sendCommand = createSendCommand(() => kmsClient);
 
+export { kmsClient };
 export const getPublicKey = (kid: string) =>
-  sendCommand(GetPublicKeyCommand, { KeyId: kid }).then(
-    (result) => result.PublicKey
-  );
+  sendCommand(GetPublicKeyCommand, { KeyId: kid }).then((result) => result.PublicKey);


### PR DESCRIPTION
## Proposed changes

The publish key lambda has been run, completely overwritting the content of the bucket, the original un-aliased kms key is in the bucket, we expect all alias keys to be tried for decryption and eventually fallback to using kid decryption

<img width="744" height="443" alt="image" src="https://github.com/user-attachments/assets/bb755877-15f6-4642-aa26-01502452ba0f" />

Afterwards the **key rotation step function is run**, so there are now two keys. the published **un-aliased** and **an alias** new one that can be used for decryption

<img width="693" height="534" alt="image" src="https://github.com/user-attachments/assets/ddcade20-2f06-4efc-b573-b626ac72f93d" />

**JAR Requests** are encrypted using the **new alias key** i.e the on created by Key rotation this see

https://github.com/govuk-one-login/ipv-cri-common-lambdas/blob/main/test-resources/headless-core-stub/lambdas/start/src/services/signing-service.ts#L69

The logic in above link reverses the array and picks the new key

The key rotation and legacy flag has been enabled in both dev and build in check-hmrc see https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/519

The above screen shot test has been modified to fit when there is a rotated new key

<img width="1170" height="532" alt="image" src="https://github.com/user-attachments/assets/56848bdf-ff99-4ff0-934a-292fd7718075" />


### Issue tracking

- [OJ-3183](https://govukverify.atlassian.net/browse/OJ-3183)
- [OJ-3159](https://govukverify.atlassian.net/browse/OJ-3159)



[OJ-3183]: https://govukverify.atlassian.net/browse/OJ-3183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ