### PR TITLE
OJ-3228: Deploy IssueCredential Function to prod

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1301,7 +1301,6 @@ Resources:
       Principal: apigateway.amazonaws.com
 
   IssueCredentialFunction:
-    Condition: IsDevLikeEnvironment
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -1356,14 +1355,12 @@ Resources:
           COMMON_STACK_NAME: !Sub ${CommonStackName}
 
   IssueCredentialFunctionLogGroup:
-    Condition: IsDevLikeEnvironment
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/IssueCredentialFunction
       RetentionInDays: 30
 
   IssueCredentialFunctionPermission:
-    Condition: IsDevLikeEnvironment
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction

--- a/lambdas/issue-credential/src/handler.ts
+++ b/lambdas/issue-credential/src/handler.ts
@@ -82,7 +82,10 @@ class IssueCredentialHandler implements LambdaInterface {
 
       return {
         statusCode: 200,
-        body: JSON.stringify(signedJwt),
+        headers: {
+          "Content-Type": "application/jwt",
+        },
+        body: signedJwt,
       };
     } catch (error: unknown) {
       return handleErrorResponse(error, logger);

--- a/lambdas/issue-credential/tests/handler.test.ts
+++ b/lambdas/issue-credential/tests/handler.test.ts
@@ -137,7 +137,10 @@ describe("issue-credential handler", () => {
 
     expect(response).toStrictEqual({
       statusCode: 200,
-      body: expect.any(String),
+      headers: {
+        "Content-Type": "application/jwt",
+      },
+      body: expectedJwt,
     });
     expect(spyVcConfig).toHaveBeenCalledWith("common-cri-api");
     expect(mockLogger.appendKeys).toHaveBeenCalledWith({ govuk_signin_journey_id: mockSession.clientSessionId });


### PR DESCRIPTION
## Proposed changes

Removed dev Like condition

### What changed

IssueCredential Function is dev and can be deployed to prod

**VC PASSED**
<img width="1300" height="861" alt="image" src="https://github.com/user-attachments/assets/56ac8246-4122-4ea6-9ccd-7cc2ab68c11d" />

**VC FAILED**

<img width="1294" height="900" alt="image" src="https://github.com/user-attachments/assets/fed11719-ac8c-4b60-b30c-d19770a11961" />


### Why did it change

Ongoing work to replace IssueCredential statemachine with IssueCredential Function

### Issue tracking


- [OJ-3228](https://govukverify.atlassian.net/browse/OJ-3228)


[OJ-3228]: https://govukverify.atlassian.net/browse/OJ-3228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ