### PR TITLE
OJ-3336: Add 5xx canary alarms for check and issue credential

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -67,7 +67,6 @@ Conditions:
   UseCanaryDeploymentAlarms: !Or
     - !Not [!Equals [!Ref StepFunctionsDeploymentPreference, ALL_AT_ONCE]]
     - !Not [!Equals [!Ref LambdaDeploymentPreference, AllAtOnce]]
-  CanaryAlarmsAndDevLikeEnvironment: !And [!Condition IsDevLikeEnvironment, !Condition UseCanaryDeploymentAlarms]
   DeployAlarms: !Or
     - !Condition IsNotDevLikeEnvironment
     - !Equals [!Ref DeployAlarmsInDevEnvironment, "true"]
@@ -1326,7 +1325,7 @@ Resources:
       DeploymentPreference:
         Type: !Ref LambdaDeploymentPreference
         Alarms: !If
-          - CanaryAlarmsAndDevLikeEnvironment
+          - UseCanaryDeploymentAlarms
           - [!Ref IssueCredentialFunctionCanaryErrors, !Ref IssueCredentialFunction5xxCanaryErrors]
           - [!Ref AWS::NoValue]
         Role: !GetAtt CodeDeployServiceRole.Arn
@@ -2227,7 +2226,7 @@ Resources:
 
   IssueCredentialFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
-    Condition: CanaryAlarmsAndDevLikeEnvironment
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: true
       AlarmActions:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1242,7 +1242,7 @@ Resources:
         Type: !Ref LambdaDeploymentPreference
         Alarms: !If
           - UseCanaryDeploymentAlarms
-          - [!Ref NinoCheckFunctionCanaryErrors]
+          - [!Ref NinoCheckFunctionCanaryErrors, !Ref NinoCheckFunction5xxCanaryErrors]
           - [!Ref AWS::NoValue]
         Role: !GetAtt CodeDeployServiceRole.Arn
       Handler: lambdas/nino-check/src/handler.handler
@@ -1327,7 +1327,7 @@ Resources:
         Type: !Ref LambdaDeploymentPreference
         Alarms: !If
           - CanaryAlarmsAndDevLikeEnvironment
-          - [!Ref IssueCredentialFunctionCanaryErrors]
+          - [!Ref IssueCredentialFunctionCanaryErrors, !Ref IssueCredentialFunction5xxCanaryErrors]
           - [!Ref AWS::NoValue]
         Role: !GetAtt CodeDeployServiceRole.Arn
       Handler: lambdas/issue-credential/src/handler.handler
@@ -2194,6 +2194,37 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
+  NinoCheckFunction5xxCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Check HRMC NINO Check Lambda returning 5xx response."
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-NinoCheckFunction5xxCanaryErrors
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName}-public"
+        - Name: Method
+          Value: POST
+        - Name: Stage
+          Value: !Ref Environment
+        - Name: Resource
+          Value: /credential/issue
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
   IssueCredentialFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Condition: CanaryAlarmsAndDevLikeEnvironment
@@ -2217,6 +2248,37 @@ Resources:
       Unit: Count
       Period: 60
       EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  IssueCredentialFunction5xxCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Check HRMC Issue credential Lambda returning 5xx response."
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-IssueCredentialFunction5xxCanaryErrors
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName}-public"
+        - Name: Method
+          Value: POST
+        - Name: Resource
+          Value: /credential/issue
+        - Name: Stage
+          Value: !Ref Environment
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching


### PR DESCRIPTION
## Proposed changes

### What changed

Add 5xx canary alarms for check and issue credential

### Why did it change

So that errors are caught by canary deployments

### Screenshots

<img width="1144" height="160" alt="image" src="https://github.com/user-attachments/assets/a380b70f-0420-46d7-8c5a-501013943190" />

<img width="1296" height="539" alt="image" src="https://github.com/user-attachments/assets/94a61491-cbbb-4868-b2e8-cdf6e3b42ae0" />

<img width="1154" height="542" alt="image" src="https://github.com/user-attachments/assets/bf5b2a86-088c-48ea-a884-85357b2888fd" />

<img width="1147" height="144" alt="image" src="https://github.com/user-attachments/assets/d879ec60-78de-4a2f-9ff6-c548d0e88984" />

<img width="1301" height="540" alt="image" src="https://github.com/user-attachments/assets/d4e47f66-dc59-4237-94e7-65627eb57373" />


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3336](https://govukverify.atlassian.net/browse/OJ-3336)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


[OJ-3336]: https://govukverify.atlassian.net/browse/OJ-3336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ