### PR TITLE
OJ-3291 - Remove unnecessary metrics

### DIFF
--- a/lambdas/common/src/database/get-record-by-session-id.ts
+++ b/lambdas/common/src/database/get-record-by-session-id.ts
@@ -6,7 +6,6 @@ import { UnixSecondsTimestamp } from "../types/brands";
 import { logger } from "../util/logger";
 import { dynamoDBClient } from "../util/dynamo";
 import { CriError } from "../errors/cri-error";
-import { captureMetric } from "../util/metrics";
 import { SessionItem } from "./types/session-item";
 
 export type SessionIdRecord = { sessionId: string; expiryDate?: UnixSecondsTimestamp };
@@ -65,13 +64,10 @@ export async function getRecordBySessionId<
   return unmarshall(queryResult[0]) as ReturnType;
 }
 
-export async function getSessionBySessionId(tableName: string, sessionId: string, publishMetric = false) {
+export async function getSessionBySessionId(tableName: string, sessionId: string) {
   try {
     return await getRecordBySessionId<SessionItem>(dynamoDBClient, tableName, sessionId, "expiryDate");
   } catch (error: unknown) {
-    if (publishMetric) {
-      captureMetric(`InvalidSessionErrorMetric`);
-    }
     if (error instanceof RecordNotFoundError) {
       throw new CriError(400, "Session not found");
     }

--- a/lambdas/common/tests/database/get-record-by-session-id.test.ts
+++ b/lambdas/common/tests/database/get-record-by-session-id.test.ts
@@ -9,7 +9,7 @@ import { UnixSecondsTimestamp } from "../../src/types/brands";
 import { getRecordBySessionId, getSessionBySessionId } from "../../src/database/get-record-by-session-id";
 import { NinoUser } from "../../src/types/nino-user";
 import { CriError } from "../../src/errors/cri-error";
-import { captureMetric, metrics } from "../../src/util/metrics";
+import { metrics } from "../../src/util/metrics";
 
 describe("getRecordBySessionId()", () => {
   const tableName = "some-table-some-stack";
@@ -299,10 +299,8 @@ describe("getSessionBySessionId()", () => {
   });
 
   it("should throw an exception when it errors retrievings a record", async () => {
-    const spy = jest.spyOn(metrics, "addMetric");
     ddbMock.on(QueryCommand).rejects();
 
-    await expect(getSessionBySessionId("session-table", "session-123", true)).rejects.toThrow(Error);
-    expect(spy).toHaveBeenCalledWith("InvalidSessionErrorMetric", "Count", 1);
+    await expect(getSessionBySessionId("session-table", "session-123")).rejects.toThrow(Error);
   });
 });

--- a/lambdas/nino-check/src/handler.ts
+++ b/lambdas/nino-check/src/handler.ts
@@ -43,7 +43,7 @@ class NinoCheckHandler implements LambdaInterface {
 
       logger.info(`Function initialised. Retrieving session...`);
 
-      const session = await getSessionBySessionId(functionConfig.tableNames.sessionTable, sessionId, true);
+      const session = await getSessionBySessionId(functionConfig.tableNames.sessionTable, sessionId);
 
       logger.appendKeys({
         govuk_signin_journey_id: session.clientSessionId,
@@ -116,7 +116,6 @@ class NinoCheckHandler implements LambdaInterface {
           buildPdvInput(personIdentity, nino)
         );
       } catch (error) {
-        captureMetric(`MatchingLambdaErrorMetric`);
         logger.error(`Error in ${context.functionName}: ${safeStringifyError(error)}`);
         throw new CriError(500, "Unexpected error when validating NINo");
       }

--- a/lambdas/nino-check/src/helpers/nino.ts
+++ b/lambdas/nino-check/src/helpers/nino.ts
@@ -86,7 +86,6 @@ export async function handleResponseAndSaveAttempt(
   const responseHttpStatus = pdvMatchResponse.httpStatus;
 
   if (responseHttpStatus === 200) {
-    captureMetric(`SuccessfulFirstAttemptMetric`);
     await saveAttempt(dynamoClient, attemptTableName, session, "PASS", responseHttpStatus);
     return true;
   }
@@ -114,14 +113,12 @@ export async function handleResponseAndSaveAttempt(
   }
 
   if (isInvalidCredentialResponse(parsedErrorBody)) {
-    captureMetric(`FailedHMRCAuthMetric`);
     logger.info(
       `Failed to authenticate with HMRC API: response had a code of ${parsedErrorBody.errorMessage} & http status of ${responseHttpStatus}`
     );
     throw new CriError(500, "Failed to authenticate with HMRC API");
   }
 
-  captureMetric(`HMRCAPIErrorMetric`);
   logger.info(`Received an unexpected error response from the PDV API - status: ${responseHttpStatus}`);
   throw new CriError(500, "Unexpected error with the PDV API");
 }

--- a/lambdas/nino-check/tests/handler.test.ts
+++ b/lambdas/nino-check/tests/handler.test.ts
@@ -148,7 +148,7 @@ describe("nino-check handler", () => {
     expect(response).toStrictEqual(internalServerError);
 
     expect(NinoCheckFunctionConfig).toHaveBeenCalled();
-    expect(getSessionBySessionId).toHaveBeenCalledWith(mockFunctionConfig.tableNames.sessionTable, mockSessionId, true);
+    expect(getSessionBySessionId).toHaveBeenCalledWith(mockFunctionConfig.tableNames.sessionTable, mockSessionId);
     expect(getHmrcConfig).not.toHaveBeenCalled();
   });
 
@@ -179,7 +179,6 @@ describe("nino-check handler", () => {
 
     expect(response).toStrictEqual(internalServerError);
 
-    expect(captureMetric).toHaveBeenCalledWith("MatchingLambdaErrorMetric");
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining("Error"));
     expect(saveTxn).not.toHaveBeenCalled();
   });

--- a/lambdas/nino-check/tests/helpers/nino.test.ts
+++ b/lambdas/nino-check/tests/helpers/nino.test.ts
@@ -28,7 +28,6 @@ describe("getHmrcConfig()", () => {
     [pdvParamName]: "billybob",
   };
 
-
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -110,7 +109,6 @@ describe("handleResponseAndSaveAttempt()", () => {
     const match = await handleResponseAndSaveAttempt(mockDynamoClient, attemptTableName, mockSession, mockPdvRes);
 
     expect(match).toEqual(true);
-    expect(captureMetric).toHaveBeenCalledWith("SuccessfulFirstAttemptMetric");
     expect(ddbMock).toHaveReceivedCommandWith(PutItemCommand, {
       TableName: attemptTableName,
       Item: {
@@ -189,18 +187,8 @@ describe("handleResponseAndSaveAttempt()", () => {
   it("handles an invalid credentials response correctly", async () => {
     let thrown = false;
 
-    const body = {
-      code: "INVALID_CREDENTIALS",
-      message: "bruh",
-    } as const;
-
     try {
-      const match = await handleResponseAndSaveAttempt(
-        mockDynamoClient,
-        attemptTableName,
-        mockSession,
-        mockPdvInvalidCredsRes
-      );
+      await handleResponseAndSaveAttempt(mockDynamoClient, attemptTableName, mockSession, mockPdvInvalidCredsRes);
     } catch (error) {
       thrown = true;
 
@@ -208,7 +196,6 @@ describe("handleResponseAndSaveAttempt()", () => {
     }
 
     expect(thrown).toEqual(true);
-    expect(captureMetric).toHaveBeenCalledWith("FailedHMRCAuthMetric");
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("400"));
   });
 
@@ -227,7 +214,6 @@ describe("handleResponseAndSaveAttempt()", () => {
     }
 
     expect(thrown).toEqual(true);
-    expect(captureMetric).toHaveBeenCalledWith("HMRCAPIErrorMetric");
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("999"));
   });
 });


### PR DESCRIPTION
## Proposed changes

### What changed

- Removed references & calls for unnecessary metrics from application code and unit tests
- Removed upstream logic relating to pushing metrics (eg, `publishMetric` parameter on `getSessionBySessionId()`)
- Minor tidy of unused variables in `/lambdas/nino-check/tests/helpers/nino.test.ts`

### Why did it change

As part of an [ongoing review](https://govukverify.atlassian.net/wiki/spaces/OJ/pages/5490212930/Check+HMRC+-+Metrics) of Check HMRC metrics, these metrics have been deemed unnecessary.

### Issue tracking

- OJ-3291

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
