### PR TITLE
OJ-3341: Fix issue cred logs not showing in Splunk

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1391,7 +1391,7 @@ Resources:
         - Name: Resource
           Value: !Sub "${AWS::StackName}-IssueCredentialFunction:live"
         - Name: FunctionName
-          Value: !Ref NinoCheckFunction
+          Value: !Ref IssueCredentialFunction
         - Name: ExecutedVersion
           Value: !GetAtt IssueCredentialFunction.Version.Version
       Namespace: AWS/Lambda

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1213,6 +1213,14 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/IssueCredentialFunction
       RetentionInDays: 30
 
+  IssueCredentialFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevLikeEnvironment
+    Properties:
+      DestinationArn: !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref IssueCredentialFunctionLogGroup
+
   IssueCredentialFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:


### PR DESCRIPTION
## Proposed changes

### What changed

Added SubscriptionFilter to `IssueCredentialFunction` log group.
Fixed a C&P error in `IssueCredentialFunction5xxCanaryErrors` alarm.

### Why did it change

IssueCredential logs were not showing in Splunk

### Issue tracking

- [OJ-3341](https://govukverify.atlassian.net/browse/OJ-3341)


[OJ-3341]: https://govukverify.atlassian.net/browse/OJ-3341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ