### PR TITLE
OJ-3384: Change Dynatrace OneAgent Layer arn

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -145,9 +145,8 @@ Globals:
         - !ImportValue cri-vpc-ProtectedSubnetIdA
         - !ImportValue cri-vpc-ProtectedSubnetIdB
     Layers:
-      - !Sub
-        - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
-        - SecretArn: !FindInMap [Dynatrace, SecretArn, !Ref Environment]
+      # SEE https://github.com/govuk-one-login/observability-infrastructure/tree/main/lambdalayer
+      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_313_2_20250404-043044_with_collector_nodejs:1
     Environment:
       Variables:
         NODE_OPTIONS: --enable-source-maps


### PR DESCRIPTION
## Proposed changes

see: https://govukverify.atlassian.net/browse/OJ-3384

Explicitly specify the arn of the Dynatrace layer

### Why did it change

There’s a bug in the {{resolve:secretsmanager}} syntax that prevents the current configuration from deploying the latest available Dynatrace layer.

Before:

<img width="1631" height="169" alt="image" src="https://github.com/user-attachments/assets/837338a7-fff4-467d-8227-0a444d993302" />


**After**

<img width="1638" height="172" alt="image" src="https://github.com/user-attachments/assets/1d392af4-3f97-4e44-8cf3-41640ff9b944" />

- [OJ-3384](https://govukverify.atlassian.net/browse/OJ-3384)

Test on dev local stack

<img width="1289" height="846" alt="image" src="https://github.com/user-attachments/assets/426ddd11-374f-45f3-83cc-8b560a9825e7" />


## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3384]: https://govukverify.atlassian.net/browse/OJ-3384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ