### PR TITLE
OJ-3384: Introduced hard code dynatrace arn

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -145,9 +145,8 @@ Globals:
         - !ImportValue cri-vpc-ProtectedSubnetIdA
         - !ImportValue cri-vpc-ProtectedSubnetIdB
     Layers:
-      - !Sub
-        - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
-        - SecretArn: !FindInMap [Dynatrace, SecretArn, !Ref Environment]
+      # SEE https://github.com/govuk-one-login/observability-infrastructure/tree/main/lambdalayer
+      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_2_20250307-045250_with_collector_nodejs:1
     Environment:
       Variables:
         NODE_OPTIONS: --enable-source-maps


### PR DESCRIPTION
## Proposed changes

Explicitly specify the arn of the Dynatrace layer, hard coding for the **FIRST TIME** requires version with **1_311**

see: https://govukverify.atlassian.net/browse/OJ-3384

### What changed

There’s a bug in the {{resolve:secretsmanager}} syntax that prevents the current configuration from deploying the latest available Dynatrace layer.


<img width="1444" height="695" alt="image" src="https://github.com/user-attachments/assets/1e27fe1a-efa5-4819-a664-7197003d1fe9" />


- [OJ-3384](https://govukverify.atlassian.net/browse/OJ-3384)



[OJ-3384]: https://govukverify.atlassian.net/browse/OJ-3384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ