### PR TITLE
OJ-3384: Update Dynatrace arn to 1_313

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -146,7 +146,7 @@ Globals:
         - !ImportValue cri-vpc-ProtectedSubnetIdB
     Layers:
       # SEE https://github.com/govuk-one-login/observability-infrastructure/tree/main/lambdalayer
-      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_2_20250307-045250_with_collector_nodejs:1
+      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_313_2_20250404-043044_with_collector_nodejs:1
     Environment:
       Variables:
         NODE_OPTIONS: --enable-source-maps


### PR DESCRIPTION
## Proposed changes

Update Dynatrace Arn to version 1_313

### Why did it change

There is a more update version of dynatrace, [previous PR ](https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/pull/688) should now enable upgrading to it 

### Issue tracking

- [OJ-3384](https://govukverify.atlassian.net/browse/OJ-3384)



[OJ-3384]: https://govukverify.atlassian.net/browse/OJ-3384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ