### PR TITLE
OJ-2860 - Remove record check logic from credential issue function

### DIFF
--- a/lambdas/common/src/types/evidence.ts
+++ b/lambdas/common/src/types/evidence.ts
@@ -1,12 +1,17 @@
+import { ContraIndicator } from "../../../issue-credential/src/vc/contraIndicator/ci-mapping-util";
 import { CiReasonsMapping } from "../../../issue-credential/src/vc/contraIndicator/ci-mappings-validator";
 
 export const CHECK_METHOD = "data" as const;
-export const DATA_CHECK = "record_check" as const;
 export const EVIDENCE_TYPE = "IdentityCheck" as const;
+
+export const STRENGTH_SCORE = 2;
 
 export type CheckDetail = {
   checkMethod: typeof CHECK_METHOD;
-  dataCheck?: typeof DATA_CHECK;
+};
+
+export const CHECK_DETAIL: CheckDetail = {
+  checkMethod: CHECK_METHOD,
 };
 
 export type Evidence = {
@@ -19,4 +24,9 @@ export type Evidence = {
   type: typeof EVIDENCE_TYPE;
   ciReasons?: CiReasonsMapping[];
   attemptNum?: number;
+};
+
+export type AuditEvidence = Evidence & {
+  attemptNum: number;
+  ciReasons?: ContraIndicator[];
 };

--- a/lambdas/issue-credential/src/evidence/evidence-creator.ts
+++ b/lambdas/issue-credential/src/evidence/evidence-creator.ts
@@ -1,6 +1,12 @@
-import { CHECK_METHOD, CheckDetail, DATA_CHECK, Evidence, EVIDENCE_TYPE } from "../../../common/src/types/evidence";
+import {
+  AuditEvidence,
+  CheckDetail,
+  Evidence,
+  EVIDENCE_TYPE,
+  STRENGTH_SCORE,
+} from "../../../common/src/types/evidence";
 import { ContraIndicator } from "../vc/contraIndicator/ci-mapping-util";
-import { EvidenceRequest, SessionItem } from "../../../common/src/database/types/session-item";
+import { SessionItem } from "../../../common/src/database/types/session-item";
 import { CiReasonsMapping } from "../vc/contraIndicator/types/ci-reasons-mapping";
 import { AttemptsResult } from "../../../common/src/types/attempt";
 import { captureMetric } from "../../../common/src/util/metrics";
@@ -11,32 +17,30 @@ export const getEvidence = (
   checkDetail: CheckDetail,
   contraIndicators: ContraIndicator[]
 ): Evidence => {
-  const evidence: Evidence = { txn: session.txn as string, type: EVIDENCE_TYPE };
+  const strengthScore = session.evidenceRequest?.strengthScore ?? STRENGTH_SCORE;
+
+  let validityScore = strengthScore;
+  let checkDetailsKey: keyof Evidence = "checkDetails";
+  let ciObj: Pick<Evidence, "ci"> | undefined;
+
   if (hasUserFailedCheck(attempts)) {
-    evidence.failedCheckDetails = [checkDetail];
-  } else {
-    evidence.checkDetails = [checkDetail];
+    validityScore = 0;
+    checkDetailsKey = "failedCheckDetails";
+
+    const validContraIndicators = contraIndicators.filter(isValidContraIndicator);
+    ciObj = { ci: [...new Set(validContraIndicators.map((item) => item.ci))] };
+
+    captureMetric("CIRaisedMetric");
   }
 
-  if (session.evidenceRequest) {
-    evidence.strengthScore = session.evidenceRequest.strengthScore;
-    evidence.validityScore = hasUserFailedCheck(attempts) ? 0 : session.evidenceRequest.strengthScore;
-
-    if (hasUserFailedCheck(attempts)) {
-      const validContraIndicators = contraIndicators.filter(isValidContraIndicator);
-      evidence.ci = [...new Set(validContraIndicators.map((item) => item.ci))];
-      captureMetric("CIRaisedMetric");
-    }
-  }
-  //PACT expects the evidence to be in this order
+  // PACT expects the evidence to be in this order
   return {
     type: EVIDENCE_TYPE,
-    strengthScore: evidence.strengthScore,
-    validityScore: evidence.validityScore,
-    failedCheckDetails: evidence.failedCheckDetails,
-    checkDetails: evidence.checkDetails,
-    ci: evidence.ci,
-    txn: evidence.txn,
+    strengthScore: strengthScore,
+    validityScore,
+    [checkDetailsKey]: [checkDetail],
+    ...ciObj,
+    txn: session.txn as string,
   };
 };
 
@@ -44,7 +48,7 @@ export const getAuditEvidence = (
   attempts: AttemptsResult,
   contraIndicators: ContraIndicator[],
   vcEvidence: Evidence
-) => {
+): AuditEvidence => {
   let attemptNum: number;
   let ciReasons: ContraIndicator[] | undefined;
   if (vcEvidence.ci?.length) {
@@ -61,11 +65,6 @@ export const getAuditEvidence = (
 
   return { ...vcEvidence, attemptNum, ciReasons };
 };
-
-export const getCheckDetail = (evidenceRequest?: EvidenceRequest): CheckDetail => ({
-  checkMethod: CHECK_METHOD,
-  ...(!evidenceRequest && { dataCheck: DATA_CHECK }),
-});
 
 const isValidContraIndicator = (item: ContraIndicator): item is CiReasonsMapping =>
   typeof item.ci === "string" && typeof item.reason === "string";

--- a/lambdas/issue-credential/src/vc/vc-builder.ts
+++ b/lambdas/issue-credential/src/vc/vc-builder.ts
@@ -4,9 +4,10 @@ import { VerifiableIdentityCredential, VC_CONTEXT, VC_TYPE, JwtClass } from "../
 import { CredentialSubject } from "../types/credential-subject";
 import { AttemptsResult } from "../../../common/src/types/attempt";
 import { SessionItem } from "../../../common/src/database/types/session-item";
-import { getCheckDetail, getEvidence } from "../evidence/evidence-creator";
+import { getEvidence } from "../evidence/evidence-creator";
 import { ContraIndicator } from "./contraIndicator/ci-mapping-util";
 import { logger } from "../../../common/src/util/logger";
+import { CHECK_DETAIL } from "../../../common/src/types/evidence";
 
 /**
  * Builds a Verifiable Credential (VC) need all fields to be in the order
@@ -35,7 +36,7 @@ export const buildVerifiableCredential = (
     iss: jwtClaims.iss,
     exp: jwtClaims.exp,
     vc: {
-      evidence: [getEvidence(session, attempts, getCheckDetail(session.evidenceRequest), contraIndicators)],
+      evidence: [getEvidence(session, attempts, CHECK_DETAIL, contraIndicators)],
       credentialSubject,
       type: VC_TYPE,
       "@context": VC_CONTEXT,

--- a/lambdas/issue-credential/tests/vc/vc-builder.test.ts
+++ b/lambdas/issue-credential/tests/vc/vc-builder.test.ts
@@ -51,281 +51,71 @@ describe("vc-builder", () => {
   };
 
   describe("buildVcClaimSet", () => {
-    describe("Identity Check", () => {
-      const evidenceRequest = {
-        scoringPolicy: "gpg45",
-        strengthScore: 2,
-      };
-      it("creates VC with checkDetails when user has passed with score 2 and strength 2", () => {
-        const session: SessionItem = {
-          sessionId: "test-session",
-          txn: "mock-txn",
-          evidenceRequest,
-        } as SessionItem;
-
-        const result = buildVerifiableCredential(
-          passedAttempt,
-          mockPersonIdentity as PersonIdentityItem,
-          mockNinoUser as NinoUser,
-          session,
-          mockJwtClaims,
-          []
-        );
-
-        expect(result).toEqual({
-          exp: 1710403763,
-          iss: "https://review-hc.dev.account.gov.uk",
-          jti: "urn:uuid:f540b78c-9e52-4a0f-b033-c78e7ab327ea",
-          nbf: 1710396563,
-          sub: "test",
-          vc: {
-            "@context": [
-              "https://www.w3.org/2018/credentials/v1",
-              "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld",
-            ],
-            credentialSubject: {
-              birthDate: [{ value: "1948-04-23" }],
-              name: [
-                {
-                  nameParts: [
-                    { type: "GivenName", value: "Jim" },
-                    { type: "FamilyName", value: "Ferguson" },
-                  ],
-                },
-              ],
-              socialSecurityRecord: [{ personalNumber: "AA000003D" }],
-            },
-            evidence: [
-              {
-                checkDetails: [{ checkMethod: "data" }],
-                strengthScore: 2,
-                txn: "mock-txn",
-                type: "IdentityCheck",
-                validityScore: 2,
-              },
-            ],
-            type: ["VerifiableCredential", "IdentityCheckCredential"],
-          },
-        });
-      });
-      it("creates VC with failedCheckDetails and ci non-existent, when user has failed with score 0 and strength 2", () => {
-        const session: SessionItem = {
-          sessionId: "test-session",
-          txn: "mock-txn",
-          evidenceRequest,
-        } as SessionItem;
-
-        const result = buildVerifiableCredential(
-          failedAttempt,
-          mockPersonIdentity,
-          mockNinoUser,
-          session,
-          mockJwtClaims,
-          []
-        );
-
-        expect(result).toEqual({
-          exp: 1710403763,
-          iss: "https://review-hc.dev.account.gov.uk",
-          jti: "urn:uuid:f540b78c-9e52-4a0f-b033-c78e7ab327ea",
-          nbf: 1710396563,
-          sub: "test",
-          vc: {
-            "@context": [
-              "https://www.w3.org/2018/credentials/v1",
-              "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld",
-            ],
-            credentialSubject: {
-              birthDate: [{ value: "1948-04-23" }],
-              name: [
-                {
-                  nameParts: [
-                    { type: "GivenName", value: "Jim" },
-                    { type: "FamilyName", value: "Ferguson" },
-                  ],
-                },
-              ],
-              socialSecurityRecord: [{ personalNumber: "AA000003D" }],
-            },
-            evidence: [
-              {
-                ci: [],
-                failedCheckDetails: [{ checkMethod: "data" }],
-                strengthScore: 2,
-                txn: "mock-txn",
-                type: "IdentityCheck",
-                validityScore: 0,
-              },
-            ],
-            type: ["VerifiableCredential", "IdentityCheckCredential"],
-          },
-        });
-      });
-
-      it("creates VC with failedCheckDetails and ci with values, when user has failed with score 0 and strength 2", () => {
-        const session: SessionItem = {
-          sessionId: "test-session",
-          txn: "mock-txn",
-          evidenceRequest,
-        } as SessionItem;
-
-        const result = buildVerifiableCredential(
-          failedAttempt,
-          mockPersonIdentity,
-          mockNinoUser,
-          session,
-          mockJwtClaims,
-          [{ ci: "ci_3", reason: "ci_3 reason" }]
-        );
-
-        expect(result).toEqual({
-          exp: 1710403763,
-          iss: "https://review-hc.dev.account.gov.uk",
-          jti: "urn:uuid:f540b78c-9e52-4a0f-b033-c78e7ab327ea",
-          nbf: 1710396563,
-          sub: "test",
-          vc: {
-            "@context": [
-              "https://www.w3.org/2018/credentials/v1",
-              "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld",
-            ],
-            credentialSubject: {
-              birthDate: [{ value: "1948-04-23" }],
-              name: [
-                {
-                  nameParts: [
-                    { type: "GivenName", value: "Jim" },
-                    { type: "FamilyName", value: "Ferguson" },
-                  ],
-                },
-              ],
-              socialSecurityRecord: [{ personalNumber: "AA000003D" }],
-            },
-            evidence: [
-              {
-                ci: ["ci_3"],
-                failedCheckDetails: [{ checkMethod: "data" }],
-                strengthScore: 2,
-                txn: "mock-txn",
-                type: "IdentityCheck",
-                validityScore: 0,
-              },
-            ],
-            type: ["VerifiableCredential", "IdentityCheckCredential"],
-          },
-        });
-      });
-    });
-
-    describe("Record Check", () => {
-      it("creates VC with checkDetails and dataCheck exists with record_check value when user has passed without any scores", () => {
-        const session: SessionItem = {
-          sessionId: "test-session",
-          txn: "mock-txn",
-        } as SessionItem;
-
-        const result = buildVerifiableCredential(
-          passedAttempt,
-          mockPersonIdentity,
-          mockNinoUser,
-          session,
-          mockJwtClaims,
-          []
-        );
-
-        expect(result).toEqual({
-          exp: 1710403763,
-          iss: "https://review-hc.dev.account.gov.uk",
-          jti: "urn:uuid:f540b78c-9e52-4a0f-b033-c78e7ab327ea",
-          nbf: 1710396563,
-          sub: "test",
-          vc: {
-            "@context": [
-              "https://www.w3.org/2018/credentials/v1",
-              "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld",
-            ],
-            credentialSubject: {
-              birthDate: [{ value: "1948-04-23" }],
-              name: [
-                {
-                  nameParts: [
-                    { type: "GivenName", value: "Jim" },
-                    { type: "FamilyName", value: "Ferguson" },
-                  ],
-                },
-              ],
-              socialSecurityRecord: [{ personalNumber: "AA000003D" }],
-            },
-            evidence: [
-              {
-                checkDetails: [{ checkMethod: "data", dataCheck: "record_check" }],
-                txn: "mock-txn",
-                type: "IdentityCheck",
-              },
-            ],
-            type: ["VerifiableCredential", "IdentityCheckCredential"],
-          },
-        });
-      });
-      it("creates VC with failedCheckDetails and dataCheck exists with record_check and no scores and no ci when user failed", () => {
-        const session: SessionItem = {
-          sessionId: "test-session",
-          txn: "mock-txn",
-        } as SessionItem;
-
-        const result = buildVerifiableCredential(
-          failedAttempt,
-          mockPersonIdentity,
-          mockNinoUser,
-          session,
-          mockJwtClaims,
-          []
-        );
-
-        expect(result).toEqual({
-          exp: 1710403763,
-          iss: "https://review-hc.dev.account.gov.uk",
-          jti: "urn:uuid:f540b78c-9e52-4a0f-b033-c78e7ab327ea",
-          nbf: 1710396563,
-          sub: "test",
-          vc: {
-            "@context": [
-              "https://www.w3.org/2018/credentials/v1",
-              "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld",
-            ],
-            credentialSubject: {
-              birthDate: [{ value: "1948-04-23" }],
-              name: [
-                {
-                  nameParts: [
-                    { type: "GivenName", value: "Jim" },
-                    { type: "FamilyName", value: "Ferguson" },
-                  ],
-                },
-              ],
-              socialSecurityRecord: [{ personalNumber: "AA000003D" }],
-            },
-            evidence: [
-              {
-                failedCheckDetails: [{ checkMethod: "data", dataCheck: "record_check" }],
-                txn: "mock-txn",
-                type: "IdentityCheck",
-              },
-            ],
-            type: ["VerifiableCredential", "IdentityCheckCredential"],
-          },
-        });
-      });
-    });
-
-    it("preserves JWT claims in the result", () => {
+    const evidenceRequest = {
+      scoringPolicy: "gpg45",
+      strengthScore: 2,
+    };
+    it("creates VC with checkDetails when user has passed with score 2 and strength 2", () => {
       const session: SessionItem = {
         sessionId: "test-session",
         txn: "mock-txn",
+        evidenceRequest,
       } as SessionItem;
 
       const result = buildVerifiableCredential(
         passedAttempt,
+        mockPersonIdentity as PersonIdentityItem,
+        mockNinoUser as NinoUser,
+        session,
+        mockJwtClaims,
+        []
+      );
+
+      expect(result).toEqual({
+        exp: 1710403763,
+        iss: "https://review-hc.dev.account.gov.uk",
+        jti: "urn:uuid:f540b78c-9e52-4a0f-b033-c78e7ab327ea",
+        nbf: 1710396563,
+        sub: "test",
+        vc: {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld",
+          ],
+          credentialSubject: {
+            birthDate: [{ value: "1948-04-23" }],
+            name: [
+              {
+                nameParts: [
+                  { type: "GivenName", value: "Jim" },
+                  { type: "FamilyName", value: "Ferguson" },
+                ],
+              },
+            ],
+            socialSecurityRecord: [{ personalNumber: "AA000003D" }],
+          },
+          evidence: [
+            {
+              checkDetails: [{ checkMethod: "data" }],
+              strengthScore: 2,
+              txn: "mock-txn",
+              type: "IdentityCheck",
+              validityScore: 2,
+            },
+          ],
+          type: ["VerifiableCredential", "IdentityCheckCredential"],
+        },
+      });
+    });
+    it("creates VC with failedCheckDetails and ci non-existent, when user has failed with score 0 and strength 2", () => {
+      const session: SessionItem = {
+        sessionId: "test-session",
+        txn: "mock-txn",
+        evidenceRequest,
+      } as SessionItem;
+
+      const result = buildVerifiableCredential(
+        failedAttempt,
         mockPersonIdentity,
         mockNinoUser,
         session,
@@ -333,11 +123,118 @@ describe("vc-builder", () => {
         []
       );
 
-      expect(result.iss).toBe(mockJwtClaims.iss);
-      expect(result.jti).toBe(mockJwtClaims.jti);
-      expect(result.nbf).toBe(mockJwtClaims.nbf);
-      expect(result.exp).toBe(mockJwtClaims.exp);
-      expect(result.sub).toBe(mockJwtClaims.sub);
+      expect(result).toEqual({
+        exp: 1710403763,
+        iss: "https://review-hc.dev.account.gov.uk",
+        jti: "urn:uuid:f540b78c-9e52-4a0f-b033-c78e7ab327ea",
+        nbf: 1710396563,
+        sub: "test",
+        vc: {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld",
+          ],
+          credentialSubject: {
+            birthDate: [{ value: "1948-04-23" }],
+            name: [
+              {
+                nameParts: [
+                  { type: "GivenName", value: "Jim" },
+                  { type: "FamilyName", value: "Ferguson" },
+                ],
+              },
+            ],
+            socialSecurityRecord: [{ personalNumber: "AA000003D" }],
+          },
+          evidence: [
+            {
+              ci: [],
+              failedCheckDetails: [{ checkMethod: "data" }],
+              strengthScore: 2,
+              txn: "mock-txn",
+              type: "IdentityCheck",
+              validityScore: 0,
+            },
+          ],
+          type: ["VerifiableCredential", "IdentityCheckCredential"],
+        },
+      });
     });
+
+    it("creates VC with failedCheckDetails and ci with values, when user has failed with score 0 and strength 2", () => {
+      const session: SessionItem = {
+        sessionId: "test-session",
+        txn: "mock-txn",
+        evidenceRequest,
+      } as SessionItem;
+
+      const result = buildVerifiableCredential(
+        failedAttempt,
+        mockPersonIdentity,
+        mockNinoUser,
+        session,
+        mockJwtClaims,
+        [{ ci: "ci_3", reason: "ci_3 reason" }]
+      );
+
+      expect(result).toEqual({
+        exp: 1710403763,
+        iss: "https://review-hc.dev.account.gov.uk",
+        jti: "urn:uuid:f540b78c-9e52-4a0f-b033-c78e7ab327ea",
+        nbf: 1710396563,
+        sub: "test",
+        vc: {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld",
+          ],
+          credentialSubject: {
+            birthDate: [{ value: "1948-04-23" }],
+            name: [
+              {
+                nameParts: [
+                  { type: "GivenName", value: "Jim" },
+                  { type: "FamilyName", value: "Ferguson" },
+                ],
+              },
+            ],
+            socialSecurityRecord: [{ personalNumber: "AA000003D" }],
+          },
+          evidence: [
+            {
+              ci: ["ci_3"],
+              failedCheckDetails: [{ checkMethod: "data" }],
+              strengthScore: 2,
+              txn: "mock-txn",
+              type: "IdentityCheck",
+              validityScore: 0,
+            },
+          ],
+          type: ["VerifiableCredential", "IdentityCheckCredential"],
+        },
+      });
+    });
+  });
+
+  it("preserves JWT claims in the result", () => {
+    const session: SessionItem = {
+      sessionId: "test-session",
+      txn: "mock-txn",
+    } as SessionItem;
+
+    const result = buildVerifiableCredential(
+      passedAttempt,
+      mockPersonIdentity,
+      mockNinoUser,
+      session,
+      mockJwtClaims,
+      []
+    );
+
+    expect(result.iss).toBe(mockJwtClaims.iss);
+    expect(result.jti).toBe(mockJwtClaims.jti);
+    expect(result.nbf).toBe(mockJwtClaims.nbf);
+    expect(result.exp).toBe(mockJwtClaims.exp);
+    expect(result.sub).toBe(mockJwtClaims.sub);
   });
 });


### PR DESCRIPTION
## Proposed changes

### What changed

- Removed record check functionality from the credential issuer function
- Minor refactor of the evidence generation function
- Removal of record-check-related unit tests

### Why did it change

The record check functionality is only necessary for HMRC KBV CRI, which has been deprecated. The Check HMRC CRI should therefore always perform identity checks.

### Issue tracking

- OJ-2860

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
