### PR TITLE
OJ-3434 - Omit client_id in audit events

### DIFF
--- a/integration-tests/api-gateway/abandon/abandon-happy.test.ts
+++ b/integration-tests/api-gateway/abandon/abandon-happy.test.ts
@@ -65,7 +65,7 @@ describe("Given the session is valid and expecting to abandon the journey", () =
     const events = await pollForTestHarnessEvents(ABANDONED_EVENT_NAME, sessionId);
 
     expect(events).toHaveLength(1);
-    expect(events[0].event).toStrictEqual<AuditEvent>(baseExpectedEvent(ABANDONED_EVENT_NAME, clientId, sessionId));
+    expect(events[0].event).toStrictEqual<AuditEvent>(baseExpectedEvent(ABANDONED_EVENT_NAME, sessionId));
   });
 
   it("Should receive a 200 response when /abandon endpoint is called with optional headers", async () => {
@@ -87,7 +87,7 @@ describe("Given the session is valid and expecting to abandon the journey", () =
 
     expect(events).toHaveLength(1);
     expect(events[0].event).toStrictEqual<AuditEvent>({
-      ...baseExpectedEvent(ABANDONED_EVENT_NAME, clientId, sessionId),
+      ...baseExpectedEvent(ABANDONED_EVENT_NAME, sessionId),
       restricted: { device_information: { encoded: "test encoded header" } },
     });
   });

--- a/integration-tests/api-gateway/audit.ts
+++ b/integration-tests/api-gateway/audit.ts
@@ -53,9 +53,8 @@ export async function pollForTestHarnessEvents(eventName: string, sessionId: str
 
 const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
-export function baseExpectedEvent(eventName: string, clientId: string | undefined, sessionId: string): AuditEvent {
+export function baseExpectedEvent(eventName: string, sessionId: string): AuditEvent {
   return {
-    ...(clientId ? { client_id: clientId } : {}),
     component_id: expect.stringMatching(/^https:\/\/.+\.account\.gov\.uk$/),
     event_name: eventName,
     event_timestamp_ms: expect.any(Number),

--- a/integration-tests/api-gateway/check/check-lambda-happy.test.ts
+++ b/integration-tests/api-gateway/check/check-lambda-happy.test.ts
@@ -15,7 +15,6 @@ jest.setTimeout(60_000); // 1 min
 describe("Given the session and NINO is valid", () => {
   let sessionId: string;
   let sessionData: { session_id: string };
-  let clientId: string;
   let sessionTableName: string;
   let privateApi: string;
   let issuer: string | undefined;
@@ -23,7 +22,6 @@ describe("Given the session and NINO is valid", () => {
   beforeEach(async () => {
     const data = await getJarAuthorization();
     const request = await data.json();
-    clientId = request.client_id;
     privateApi = `${process.env.PRIVATE_API}`;
     sessionTableName = `${process.env.SESSION_TABLE}`;
     const session = await createSession(privateApi, request);
@@ -61,7 +59,7 @@ describe("Given the session and NINO is valid", () => {
     const reqSentEvents = await pollForTestHarnessEvents(REQUEST_SENT_EVENT_NAME, sessionId);
     expect(reqSentEvents).toHaveLength(1);
     expect(reqSentEvents[0].event).toStrictEqual<AuditEvent>({
-      ...baseExpectedEvent(REQUEST_SENT_EVENT_NAME, clientId, sessionId),
+      ...baseExpectedEvent(REQUEST_SENT_EVENT_NAME, sessionId),
       restricted: {
         birthDate: [{ value: testUser.dob }],
         name: testUser.formattedName,
@@ -72,7 +70,7 @@ describe("Given the session and NINO is valid", () => {
     const resReceivedEvents = await pollForTestHarnessEvents(RESPONSE_RECEIVED_EVENT_NAME, sessionId);
     expect(resReceivedEvents).toHaveLength(1);
     expect(resReceivedEvents[0].event).toStrictEqual<AuditEvent>({
-      ...baseExpectedEvent(RESPONSE_RECEIVED_EVENT_NAME, clientId, sessionId),
+      ...baseExpectedEvent(RESPONSE_RECEIVED_EVENT_NAME, sessionId),
       extensions: {
         evidence: { txn: expect.any(String) },
       },
@@ -96,7 +94,7 @@ describe("Given the session and NINO is valid", () => {
     const reqSentEvents = await pollForTestHarnessEvents(REQUEST_SENT_EVENT_NAME, sessionId);
     expect(reqSentEvents).toHaveLength(1);
     expect(reqSentEvents[0].event).toStrictEqual<AuditEvent>({
-      ...baseExpectedEvent(REQUEST_SENT_EVENT_NAME, clientId, sessionId),
+      ...baseExpectedEvent(REQUEST_SENT_EVENT_NAME, sessionId),
       restricted: {
         birthDate: [{ value: testUser.dob }],
         name: testUser.formattedName,
@@ -110,7 +108,7 @@ describe("Given the session and NINO is valid", () => {
     const resReceivedEvents = await pollForTestHarnessEvents(RESPONSE_RECEIVED_EVENT_NAME, sessionId);
     expect(resReceivedEvents).toHaveLength(1);
     expect(resReceivedEvents[0].event).toStrictEqual<AuditEvent>({
-      ...baseExpectedEvent(RESPONSE_RECEIVED_EVENT_NAME, clientId, sessionId),
+      ...baseExpectedEvent(RESPONSE_RECEIVED_EVENT_NAME, sessionId),
       restricted: {
         device_information: {
           encoded: "test encoded header",
@@ -175,7 +173,7 @@ describe("Given the session and NINO is valid", () => {
     const reqSentEvents = await pollForTestHarnessEvents(REQUEST_SENT_EVENT_NAME, sessionId);
     expect(reqSentEvents).toHaveLength(1);
     expect(reqSentEvents[0].event).toStrictEqual<AuditEvent>({
-      ...baseExpectedEvent(REQUEST_SENT_EVENT_NAME, clientId, sessionId),
+      ...baseExpectedEvent(REQUEST_SENT_EVENT_NAME, sessionId),
       restricted: {
         birthDate: deceasedPersonSession.birthDate,
         name: deceasedPersonSession.name,
@@ -189,7 +187,7 @@ describe("Given the session and NINO is valid", () => {
     const resReceivedEvents = await pollForTestHarnessEvents(RESPONSE_RECEIVED_EVENT_NAME, sessionId);
     expect(resReceivedEvents).toHaveLength(1);
     expect(resReceivedEvents[0].event).toStrictEqual<AuditEvent>({
-      ...baseExpectedEvent(RESPONSE_RECEIVED_EVENT_NAME, clientId, sessionId),
+      ...baseExpectedEvent(RESPONSE_RECEIVED_EVENT_NAME, sessionId),
       restricted: {
         device_information: {
           encoded: "test encoded header",
@@ -256,7 +254,7 @@ describe("Given the session and NINO is valid", () => {
     const reqSentEvents = await pollForTestHarnessEvents(REQUEST_SENT_EVENT_NAME, sessionId);
     expect(reqSentEvents).toHaveLength(1);
     expect(reqSentEvents[0].event).toStrictEqual<AuditEvent>({
-      ...baseExpectedEvent(REQUEST_SENT_EVENT_NAME, clientId, sessionId),
+      ...baseExpectedEvent(REQUEST_SENT_EVENT_NAME, sessionId),
       restricted: {
         birthDate: [{ value: "2000-02-02" }],
         name: multipleNamesSession.name,
@@ -267,7 +265,7 @@ describe("Given the session and NINO is valid", () => {
     const resReceivedEvents = await pollForTestHarnessEvents(RESPONSE_RECEIVED_EVENT_NAME, sessionId);
     expect(resReceivedEvents).toHaveLength(1);
     expect(resReceivedEvents[0].event).toStrictEqual<AuditEvent>({
-      ...baseExpectedEvent(RESPONSE_RECEIVED_EVENT_NAME, clientId, sessionId),
+      ...baseExpectedEvent(RESPONSE_RECEIVED_EVENT_NAME, sessionId),
       extensions: {
         evidence: { txn: expect.any(String) },
       },

--- a/lambdas/common/src/util/audit.ts
+++ b/lambdas/common/src/util/audit.ts
@@ -30,7 +30,6 @@ export async function sendAuditEvent(
   const secondsTimestamp = Math.round(timestamp / 1000) as UnixSecondsTimestamp;
 
   const auditEvent: AuditEvent = {
-    client_id: session.clientId,
     component_id: auditConfig.componentId,
     event_name: `${AUDIT_PREFIX}_${eventType}`,
     event_timestamp_ms: timestamp,

--- a/lambdas/common/tests/util/audit.test.ts
+++ b/lambdas/common/tests/util/audit.test.ts
@@ -28,7 +28,6 @@ const mockAuditUser: AuditUser = {
 };
 
 const validBaseEvent: AuditEvent = {
-  client_id: mockSession.clientId,
   component_id: mockAuditConfig.componentId,
   event_name: `${AUDIT_PREFIX}_${REQUEST_SENT}`,
   event_timestamp_ms: 9090909 as UnixMillisecondsTimestamp,


### PR DESCRIPTION
## Proposed changes

### What changed

- Removed `client_id` from `sendAuditEvent()` function

### Why did it change

The `clientId` in the session table is not the same thing as the `client_id` in the audit event. The former is the caller of our specific CRI, whereas the latter is the caller of One Login (ie, the RP). Leaving `client_id` unset allows the TxMA event processing logic to enrich the event with the RP client id from other events that correspond to the same user journey.

### Issue tracking

- OJ-3434

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
