### PR TITLE
OJ-3402: Refactor UserAgent to be no longer be an SSM param

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1039,10 +1039,6 @@ Resources:
             ParameterName: check-hmrc-cri-api/OtgUrl/*
         - SSMParameterReadPolicy:
             ParameterName: check-hmrc-cri-api/NinoCheckUrl/*
-        - SSMParameterReadPolicy:
-            # I would use !Ref UserAgent here, but this returns the name with leading slash.
-            # There is no easy native way to strip the first character of a string in CloudFormation syntax.
-            ParameterName: !Sub ${AWS::StackName}/UserAgent
         - DynamoDBReadPolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
         - DynamoDBWritePolicy:
@@ -1074,7 +1070,6 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-NinoCheckFunction"
-          PDV_USER_AGENT_PARAM_NAME: !Ref UserAgent
           SESSION_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
           PERSON_IDENTITY_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
           ATTEMPT_TABLE: !Ref UserAttemptsTable

--- a/lambdas/nino-check/src/handler.ts
+++ b/lambdas/nino-check/src/handler.ts
@@ -50,7 +50,7 @@ class NinoCheckHandler implements LambdaInterface {
       });
       logger.info(`Identified government journey id: ${session.clientSessionId}. Retrieving HMRC config from SSM...`);
 
-      const hmrcApiConfig = await getHmrcConfig(session.clientId, functionConfig.hmrcApi.pdvUserAgentParamName);
+      const hmrcApiConfig = await getHmrcConfig(session.clientId);
 
       logger.info(`HMRC config retrieved from SSM.`);
 

--- a/lambdas/nino-check/src/helpers/function-config.ts
+++ b/lambdas/nino-check/src/helpers/function-config.ts
@@ -1,9 +1,5 @@
 import { BaseFunctionConfig } from "../../../common/src/config/base-function-config";
 
-export type HmrcEnvVars = {
-  pdvUserAgentParamName: string;
-};
-
 export type TableNames = {
   sessionTable: string;
   personIdentityTable: string;
@@ -15,20 +11,13 @@ const envVarNames = {
   personIdentityTable: "PERSON_IDENTITY_TABLE",
   attemptTable: "ATTEMPT_TABLE",
   ninoUserTable: "NINO_USER_TABLE",
-  pdvUserAgentParamName: "PDV_USER_AGENT_PARAM_NAME",
 };
 
 export class NinoCheckFunctionConfig extends BaseFunctionConfig {
-  public readonly hmrcApi: HmrcEnvVars;
 
   constructor() {
     super();
-
     Object.values(envVarNames).forEach(BaseFunctionConfig.checkEnvEntry);
-
-    this.hmrcApi = {
-      pdvUserAgentParamName: process.env[envVarNames.pdvUserAgentParamName] as string,
-    };
   }
 
   public get tableNames(): TableNames {

--- a/lambdas/nino-check/src/helpers/nino.ts
+++ b/lambdas/nino-check/src/helpers/nino.ts
@@ -16,10 +16,10 @@ export type HmrcApiConfig = {
 
 const cacheTtlInSeconds = Number(process.env.POWERTOOLS_PARAMETERS_MAX_AGE) || 300;
 
-export async function getHmrcConfig(clientId: string, pdvUserAgentParamName: string): Promise<HmrcApiConfig> {
+export async function getHmrcConfig(clientId: string): Promise<HmrcApiConfig> {
   const otgParamName = `/check-hmrc-cri-api/OtgUrl/${clientId}`;
   const pdvParamName = `/check-hmrc-cri-api/NinoCheckUrl/${clientId}`;
-  const paramPaths = [otgParamName, pdvParamName, pdvUserAgentParamName];
+  const paramPaths = [otgParamName, pdvParamName];
 
   try {
     const ssmParams = await getParametersValues(paramPaths, cacheTtlInSeconds);
@@ -30,7 +30,6 @@ export async function getHmrcConfig(clientId: string, pdvUserAgentParamName: str
       },
       pdv: {
         apiUrl: ssmParams[pdvParamName],
-        userAgent: ssmParams[pdvUserAgentParamName],
       },
     };
   } catch (err) {

--- a/lambdas/nino-check/src/hmrc-apis/pdv.ts
+++ b/lambdas/nino-check/src/hmrc-apis/pdv.ts
@@ -4,7 +4,7 @@ import { captureLatency } from "../../../common/src/util/metrics";
 import { safeStringifyError } from "../../../common/src/util/stringify-error";
 
 export async function callPdvMatchingApi(
-  { apiUrl, userAgent }: PdvConfig,
+  { apiUrl }: PdvConfig,
   oAuthToken: string,
   apiInput: PdvApiInput
 ): Promise<ParsedPdvMatchResponse> {
@@ -13,7 +13,7 @@ export async function callPdvMatchingApi(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "User-Agent": userAgent,
+        "User-Agent": "govuk-one-login",
         Authorization: `Bearer ${oAuthToken}`,
       },
       body: JSON.stringify(apiInput),

--- a/lambdas/nino-check/src/hmrc-apis/types/pdv.ts
+++ b/lambdas/nino-check/src/hmrc-apis/types/pdv.ts
@@ -18,4 +18,4 @@ export type ParsedPdvMatchResponse = {
   txn: string;
 };
 
-export type PdvConfig = { apiUrl: string; userAgent: string };
+export type PdvConfig = { apiUrl: string; };

--- a/lambdas/nino-check/tests/helpers/function-config.test.ts
+++ b/lambdas/nino-check/tests/helpers/function-config.test.ts
@@ -32,7 +32,6 @@ describe("NINo Check function config", () => {
         queueUrl: "cool-queuez.com",
         componentId: "https://check-hmrc-time.account.gov.uk",
       },
-      hmrcApi: { pdvUserAgentParamName: "user-agent-param" },
     });
     expect(config.tableNames).toEqual({
       sessionTable: "session-table",

--- a/lambdas/nino-check/tests/helpers/nino.test.ts
+++ b/lambdas/nino-check/tests/helpers/nino.test.ts
@@ -20,12 +20,10 @@ const mockDynamoClient = ddbMock as unknown as DynamoDBClient;
 
 describe("getHmrcConfig()", () => {
   const mockClientId = "my-cool-client";
-  const pdvParamName = "big-ssm-param";
 
   const ssmRes = {
     [`/check-hmrc-cri-api/OtgUrl/${mockClientId}`]: "https://otg.hmrc.gov.uk",
     [`/check-hmrc-cri-api/NinoCheckUrl/${mockClientId}`]: "https://pdv.hmrc.gov.uk",
-    [pdvParamName]: "billybob",
   };
 
   beforeEach(() => {
@@ -35,10 +33,10 @@ describe("getHmrcConfig()", () => {
   it("behaves as expected when the SSM fetch works", async () => {
     const paramSpy = jest.spyOn(GetParameters, "getParametersValues").mockResolvedValueOnce(ssmRes);
 
-    const config = await getHmrcConfig(mockClientId, pdvParamName);
+    const config = await getHmrcConfig(mockClientId);
 
     expect(paramSpy).toHaveBeenCalledWith(
-      ["/check-hmrc-cri-api/OtgUrl/my-cool-client", "/check-hmrc-cri-api/NinoCheckUrl/my-cool-client", "big-ssm-param"],
+      ["/check-hmrc-cri-api/OtgUrl/my-cool-client", "/check-hmrc-cri-api/NinoCheckUrl/my-cool-client"],
       300
     );
 
@@ -48,7 +46,6 @@ describe("getHmrcConfig()", () => {
       },
       pdv: {
         apiUrl: "https://pdv.hmrc.gov.uk",
-        userAgent: "billybob",
       },
     });
   });
@@ -58,14 +55,14 @@ describe("getHmrcConfig()", () => {
       .spyOn(GetParameters, "getParametersValues")
       .mockRejectedValueOnce(
         new Error(
-          "Following SSM parameters do not exist: [/check-hmrc-cri-api/OtgUrl/my-cool-client, /check-hmrc-cri-api/NinoCheckUrl/my-cool-client, big-ssm-param]"
+          "Following SSM parameters do not exist: [/check-hmrc-cri-api/OtgUrl/my-cool-client, /check-hmrc-cri-api/NinoCheckUrl/my-cool-client]"
         )
       );
 
-    await expect(() => getHmrcConfig(mockClientId, pdvParamName)).rejects.toThrow(
+    await expect(() => getHmrcConfig(mockClientId)).rejects.toThrow(
       new CriError(
         500,
-        "Failed to load HMRC config: Following SSM parameters do not exist: [/check-hmrc-cri-api/OtgUrl/my-cool-client, /check-hmrc-cri-api/NinoCheckUrl/my-cool-client, big-ssm-param]"
+        "Failed to load HMRC config: Following SSM parameters do not exist: [/check-hmrc-cri-api/OtgUrl/my-cool-client, /check-hmrc-cri-api/NinoCheckUrl/my-cool-client]"
       )
     );
   });

--- a/lambdas/nino-check/tests/mocks/mockConfig.ts
+++ b/lambdas/nino-check/tests/mocks/mockConfig.ts
@@ -1,12 +1,8 @@
-import { HmrcEnvVars, NinoCheckFunctionConfig, TableNames } from "../../src/helpers/function-config";
+import { NinoCheckFunctionConfig, TableNames } from "../../src/helpers/function-config";
 import { HmrcApiConfig } from "../../src/helpers/nino";
 import { mockAuditConfig } from "../../../common/tests/mocks/mockConfig";
 
 export const mockDeviceInformationHeader = "big-device-time";
-
-export const mockHmrcEnvVars: HmrcEnvVars = {
-  pdvUserAgentParamName: "user-agent-param",
-};
 
 export const mockTableNames: TableNames = {
   sessionTable: "session-table",
@@ -21,14 +17,12 @@ export const mockHmrcConfig: HmrcApiConfig = {
   },
   pdv: {
     apiUrl: "https://pdv.hmrc.gov.uk",
-    userAgent: "billybob",
   },
 };
 
 export const mockFunctionConfig: NinoCheckFunctionConfig = {
   tableNames: mockTableNames,
-  audit: mockAuditConfig,
-  hmrcApi: mockHmrcEnvVars,
+  audit: mockAuditConfig
 };
 
 export const mockSaveRes = {


### PR DESCRIPTION
## Proposed changes

### What changed

Refactor the `UserAgent` used for the PDV API request to just be hardcoded, it does not change per environment. 

### Why did it change

The UserAgent was an SSM param, but it is not needed. It also does not change per environment so also removing it from Env variables. Now just set in code for simplicity.

SSM param will be removed in another PR.

### Issue tracking

- [OJ-3402](https://govukverify.atlassian.net/browse/OJ-3402)

[OJ-3402]: https://govukverify.atlassian.net/browse/OJ-3402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ