### PR TITLE
OJ-3403: Removed unused SSM params

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -715,30 +715,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref AbandonFunctionLogGroup
 
-  UserAgent:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Type: String
-      Name: !Sub /${AWS::StackName}/UserAgent
-      Value: govuk-one-login
-      Description: User agent for HMRC requests
-
-  MaxJwtTtlParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Type: String
-      Name: !Sub /${AWS::StackName}/MaxJwtTtl
-      Value: !FindInMap [MaxJwtTtl, Environment, !Ref Environment]
-      Description: Default time to live for an JWT in (seconds)
-
-  JwtTtlUnitParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Type: String
-      Name: !Sub /${AWS::StackName}/JwtTtlUnit
-      Value: !FindInMap [JwtTtlUnit, Environment, !Ref Environment]
-      Description: The unit for the time-to-live for an JWT e.g. (MONTHS)
-
   PublicNinoCheckApi:
     Type: AWS::Serverless::Api
     Properties:


### PR DESCRIPTION
## Proposed changes

### What changed

Remove `UserAgent`, `MaxJwtTtlParameter` and `JwtTtlUnitParameter`.

### Why did it change

The 3 SSM params have been deprecated and are no longer used. 

### Issue tracking

- [OJ-3403](https://govukverify.atlassian.net/browse/OJ-3403)


[OJ-3403]: https://govukverify.atlassian.net/browse/OJ-3403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ