### PR TITLE
OJ-3350: Apply CMKs to encrypt Dynamo tables

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1007,6 +1007,10 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: ttl
         Enabled: true
+      SSESpecification:
+        KMSMasterKeyId: !Ref DynamoTablesEncryptionKey
+        SSEEnabled: true
+        SSEType: KMS
 
   NinoUsersTable:
     Type: AWS::DynamoDB::Table
@@ -1022,6 +1026,10 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: ttl
         Enabled: true
+      SSESpecification:
+        KMSMasterKeyId: !Ref DynamoTablesEncryptionKey
+        SSEEnabled: true
+        SSEType: KMS
 
   NinoCheckFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
## Proposed changes

### What changed

- Applied new customer-managed KMS keys to encrypt NINo user & attempts tables at rest in DynamoDB

### Why did it change

- It is a security best practice to use CMKs rather than relying on AWS-owned keys (which is the default)

### Issue tracking

- [OJ-3350](https://govukverify.atlassian.net/browse/OJ-3350)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks

### Testing evidence:

<details>
<summary>Expand</summary>

<img width="1202" height="416" alt="image" src="https://github.com/user-attachments/assets/1a887f91-e7eb-4c65-a919-9fccd5d819a7" />

<img width="1185" height="401" alt="image" src="https://github.com/user-attachments/assets/a9dfd333-8068-4480-a2c7-4801287c40c5" />

<img width="1613" height="828" alt="image" src="https://github.com/user-attachments/assets/e40fe2ea-4946-4638-8c2a-f821a3ded8a8" />

<img width="1700" height="676" alt="image" src="https://github.com/user-attachments/assets/f0aa0a91-d975-4ffa-bb41-67a8cde537d9" />

</details>

[OJ-3350]: https://govukverify.atlassian.net/browse/OJ-3350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ