### PR TITLE
OJ-3350: Create CMKs for Dynamo tables and add necessary permissions

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -958,6 +958,37 @@ Resources:
             Period: 300
             Stat: Sum
 
+  DynamoTablesEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      Description: !Sub ${AWS::StackName} customer-managed key for DynamoDB at-rest encryption
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - kms:*
+            Resource: "*"
+          - Effect: Allow
+            Principal:
+              Service: "dynamodb.amazonaws.com"
+            Action:
+              - "kms:Encrypt*"
+              - "kms:Decrypt*"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:Describe*"
+            Resource: "*"
+            Condition:
+              StringEquals:
+                "kms:CallerAccount": !Sub "${AWS::AccountId}"
+                "kms:ViaService":
+                  - "dynamodb.amazonaws.com"
+                  - !Sub "lambda.${AWS::Region}.amazonaws.com"
+
   UserAttemptsTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -1031,6 +1062,8 @@ Resources:
             TableName: !Ref NinoUsersTable
         - DynamoDBWritePolicy:
             TableName: !Ref NinoUsersTable
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoTablesEncryptionKey
         - SQSSendMessagePolicy:
             QueueName:
               Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueName
@@ -1100,6 +1133,8 @@ Resources:
             TableName: !Ref UserAttemptsTable
         - DynamoDBReadPolicy:
             TableName: !Ref NinoUsersTable
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoTablesEncryptionKey
         - SSMParameterReadPolicy:
             ParameterName: check-hmrc-cri-api/contraindicationMappings
         - SSMParameterReadPolicy:


### PR DESCRIPTION
## Proposed changes

### What changed

- Created new customer-managed KMS keys to encrypt NINo user & attempts tables at rest in DynamoDB

### Why did it change

- It is a security best practice to use CMKs rather than relying on AWS-owned keys (which is the default)
- The new keys will be applied in a separate PR (#698)

### Issue tracking

- [OJ-3350](https://govukverify.atlassian.net/browse/OJ-3350)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3350]: https://govukverify.atlassian.net/browse/OJ-3350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ