### PR TITLE
OJ-3446: Apply FMS tags to APIGW outside int/prod

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -56,6 +56,8 @@ Conditions:
   IsNotDevLikeEnvironment: !Not
     - !Condition IsDevLikeEnvironment
   IsIntOrProdEnvironment: !Or [!Condition IsIntEnvironment, !Condition IsProdEnvironment]
+  IsNotIntOrProdEnvironment: !Not
+    - !Condition IsIntOrProdEnvironment
   UseCanaryDeploymentAlarms: !Not [!Equals [!Ref LambdaDeploymentPreference, AllAtOnce]]
   DeployAlarms: !Or
     - !Condition IsNotDevLikeEnvironment
@@ -744,6 +746,7 @@ Resources:
       TracingEnabled: true
       Name: !Sub ${AWS::StackName}-public
       StageName: !Ref Environment
+      AlwaysDeploy: true
       DefinitionBody:
         openapi: 3.0.1
         Fn::Transform:
@@ -753,6 +756,9 @@ Resources:
       OpenApiVersion: 3.0.1
       EndpointConfiguration:
         Type: REGIONAL
+      Tags:
+        FMSRegionalPolicy: !If [IsNotIntOrProdEnvironment, "false", ""]
+        CustomPolicy: !If [IsNotIntOrProdEnvironment, "true", ""]
 
   PublicNinoCheckApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
@@ -836,6 +842,7 @@ Resources:
       TracingEnabled: true
       Name: !Sub ${AWS::StackName}-private
       StageName: !Ref Environment
+      AlwaysDeploy: true
       DefinitionBody:
         openapi: 3.0.1
         paths: # workaround to get `sam validate` to work
@@ -857,6 +864,9 @@ Resources:
                 Resource: execute-api:/*
                 Action: execute-api:Invoke
                 Principal: "*"
+      Tags:
+        FMSRegionalPolicy: !If [IsNotIntOrProdEnvironment, "false", ""]
+        CustomPolicy: !If [IsNotIntOrProdEnvironment, "true", ""]
 
   PrivateNinoCheckApiAccessLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Proposed changes

### What changed

- Applied FMS regional policy tags to API Gateways in dev+build+staging

### Why did it change

- The new FMS policy improves the security stance of the CRI

### Issue tracking

- OJ-3446

## Evidence

<img width="3170" height="1628" alt="image" src="https://github.com/user-attachments/assets/04afae2f-9955-41ed-bc88-2f7ebb5f2376" />

<img width="3136" height="1642" alt="image" src="https://github.com/user-attachments/assets/9bd4686e-1440-44b8-a913-ff3298d558f8" />

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
