### PR TITLE
OJ-3462: Add param to force localdev lambdas to update when env var c…

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -50,6 +50,10 @@ jobs:
       aws-region: ${{ steps.deploy.outputs.aws-region }}
       stack-name: ${{ steps.deploy.outputs.stack-name }}
     steps:
+      - name: Set timestamp
+        id: set_timestamp
+        run: echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
+
       - name: Deploy stack
         uses: govuk-one-login/github-actions/sam/deploy-stack@e6b6ed890b35904e1be79f7f35ffec983fa4d9db
         id: deploy
@@ -69,3 +73,4 @@ jobs:
             cri:deployment-source=github-actions
           parameters: |
             Environment=localdev
+            ForceLambdaUpdate=${{ steps.set_timestamp.outputs.timestamp }}

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,4 +32,5 @@ sam deploy --stack-name "$stack_name" \
   --parameter-overrides \
   ${common_stack_name:+CommonStackName=$common_stack_name} \
   ${txma_stack_name:+TxmaStackName=$txma_stack_name} \
-  Environment=localdev
+  Environment=localdev \
+  ForceLambdaUpdate="$(date +%s)"

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -44,6 +44,10 @@ Parameters:
     Description: "Specifies the configuration to enable gradual Lambda deployments. It can be used to set deployment type and also allows skipping canary deployment by setting to 'AllAtOnce'"
     Type: String
     Default: "AllAtOnce"
+  ForceLambdaUpdate:
+    Type: String
+    Default: "initial"
+    Description: "For localdev only - used to force Lambda version updates"
 
 Conditions:
   EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]
@@ -155,6 +159,7 @@ Globals:
         AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: true
         POWERTOOLS_METRICS_NAMESPACE: !Ref CriIdentifier
+        FORCE_LAMBDA_UPDATE: !If [IsLocalDevEnvironment, !Ref ForceLambdaUpdate, !Ref AWS::NoValue]
         DT_CONNECTION_AUTH_TOKEN: !Sub
           - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}"
           - SecretArn: !FindInMap [Dynatrace, SecretArn, !Ref Environment]


### PR DESCRIPTION
## Proposed changes

### What changed

Add `ForceLambdaUpdate` CF param and env var that can be used to force sam deployed (localdev) stacks to deploy new lambda versions if an env var changes.

### Why did it change

With moving to resolving SSM Params at deploy time and passing them directly into our Lambda functions as environment variables, when deploying using Sam (local or pre-merge GHA) sometimes the small changes (e.g. an env var) do not publish new Lambda versions. This can cause deployment issues.

### Issue tracking
- [OJ-3462](https://govukverify.atlassian.net/browse/OJ-3462)

[OJ-3462]: https://govukverify.atlassian.net/browse/OJ-3462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ