### PR TITLE
chore: use commit sha for actions

### DIFF
--- a/.github/workflows/clean-up-deployments.yml
+++ b/.github/workflows/clean-up-deployments.yml
@@ -20,7 +20,7 @@ jobs:
     environment: development
     steps:
       - name: Assume AWS Role
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
         with:
           role-to-assume: ${{ vars.DEPLOYMENT_ROLE_ARN }}
           aws-region: eu-west-2

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -21,7 +21,7 @@ jobs:
       cache-restore-keys: ${{ steps.build.outputs.cache-restore-keys }}
     steps:
       - name: Install latest SAM
-        uses: aws-actions/setup-sam@v2
+        uses: aws-actions/setup-sam@d78e1a4a9656d3b223e59b80676a797f20093133
 
       - name: Build SAM application
         uses: govuk-one-login/github-actions/sam/build-application@e6b6ed890b35904e1be79f7f35ffec983fa4d9db

--- a/.github/workflows/post-merge-deploy-to-build.yml
+++ b/.github/workflows/post-merge-deploy-to-build.yml
@@ -34,7 +34,7 @@ jobs:
           sam build -t infrastructure/template.yaml -b out/
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.10.1
+        uses: govuk-one-login/devplatform-upload-action@720ddb75fba8951db5a648ebb416eb233f1b6bc9
         with:
           artifact-bucket-name: ${{ secrets.BUILD_ARTIFACT_SOURCE_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE_NAME }}

--- a/.github/workflows/post-merge-deploy-to-build.yml
+++ b/.github/workflows/post-merge-deploy-to-build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
         with:
           role-to-assume: ${{ secrets.BUILD_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
         with:
           role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -34,7 +34,7 @@ jobs:
           sam build -t infrastructure/template.yaml -b out/
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.10.1
+        uses: govuk-one-login/devplatform-upload-action@720ddb75fba8951db5a648ebb416eb233f1b6bc9
         with:
           artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_SOURCE_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}

--- a/.github/workflows/run-apigw-tests.yml
+++ b/.github/workflows/run-apigw-tests.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm ci --include-workspace-root # nosonar - esbuild postinstall is required to fetch its native binary
 
       - name: Assume AWS Role
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
         with:
           role-to-assume: ${{ vars.DEPLOYMENT_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/run-pact-tests.yml
+++ b/.github/workflows/run-pact-tests.yml
@@ -40,7 +40,7 @@ jobs:
       run: npm ci --include-workspace-root # nosonar - esbuild and @pact-foundation/pact postinstall scripts are required to fetch their native binaries
 
     - name: Assume AWS Role
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
       with:
         role-to-assume: ${{ vars.DEPLOYMENT_ROLE_ARN }}
         aws-region: ${{ inputs.aws-region }}


### PR DESCRIPTION
## Proposed changes

### Why did it change
Sonar wants us to use commit sha for our actions. 

Steps to find this:
1. `gh api repos/aws-actions/configure-aws-credentials/git/ref/tags/v4`
2. `gh api repos/aws-actions/configure-aws-credentials/git/tags/ff717079ee2060e4bcee96c4779b553acc87447c`

### Issue tracking
- [OJ-3751](https://govukverify.atlassian.net/browse/OJ-3751)
