### PR TITLE
OJ-3625: OAuthCommon Migration Guide

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -15,10 +15,14 @@ jobs:
   build:
     name: Build SAM app
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       cache-key: ${{ steps.build.outputs.cache-key }}
       cache-restore-keys: ${{ steps.build.outputs.cache-restore-keys }}
+    environment:
+      name: development
     steps:
       - name: Install latest SAM
         uses: aws-actions/setup-sam@d78e1a4a9656d3b223e59b80676a797f20093133
@@ -26,13 +30,14 @@ jobs:
           version: 1.159.1
 
       - name: Build SAM application
-        uses: govuk-one-login/github-actions/sam/build-application@e6b6ed890b35904e1be79f7f35ffec983fa4d9db
+        uses: govuk-one-login/github-actions/sam/build-application@4c76410195b5fcb1804fc7c183ed20704252830f
         id: build
         with:
           template: infrastructure/template.yaml
           cache-name: check-hmrc-api
           pull-repository: true
           source-dir: lambdas
+          aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
 
   deploy:
     name: Deploy stack
@@ -56,12 +61,12 @@ jobs:
         with:
           version: 1.159.1
       - name: Deploy stack
-        uses: govuk-one-login/github-actions/sam/deploy-stack@e6b6ed890b35904e1be79f7f35ffec983fa4d9db
+        uses: govuk-one-login/github-actions/sam/deploy-stack@4c76410195b5fcb1804fc7c183ed20704252830f
         id: deploy
         with:
           sam-deployment-bucket: ${{ vars.DEPLOYMENT_ARTIFACTS_BUCKET }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
-          stack-name-prefix: preview-check-hmrc-api
+          stack-name-prefix: preview
           cache-key: ${{ needs.build.outputs.cache-key }}
           cache-restore-keys: ${{ needs.build.outputs.cache-restore-keys }}
           s3-prefix: preview

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,7 +23,7 @@ sam deploy --stack-name "$stack_name" \
   --resolve-s3 \
   --s3-prefix "$stack_name" \
   --region "${AWS_REGION:-eu-west-2}" \
-  --capabilities CAPABILITY_IAM \
+  --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
   --tags \
   cri:component=ipv-cri-check-hmrc-api \
   cri:stack-type=localdev \

--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -38,7 +38,13 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-AuthorizationFunctionTS:live/invocations
+          Fn::Sub:
+            - arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${FunctionName}:live/invocations
+            - FunctionName:
+                Fn::If:
+                  - UseOAuthCommon
+                  - Fn::Sub: ${OAuth.Outputs.LambdaAuthorizationFunctionName}
+                  - Fn::Sub: ${CommonStackName}-AuthorizationFunctionTS
         passthroughBehavior: "when_no_match"
 
   /session:
@@ -100,7 +106,13 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-SessionFunctionTS:live/invocations
+          Fn::Sub:
+            - arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${FunctionName}:live/invocations
+            - FunctionName:
+                Fn::If:
+                  - UseOAuthCommon
+                  - Fn::Sub: ${OAuth.Outputs.LambdaSessionFunctionName}
+                  - Fn::Sub: ${CommonStackName}-SessionFunctionTS
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/public-api.yaml
+++ b/infrastructure/public-api.yaml
@@ -185,7 +185,13 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-AccessTokenFunctionTS:live/invocations
+          Fn::Sub:
+            - arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${FunctionName}:live/invocations
+            - FunctionName:
+                Fn::If:
+                  - UseOAuthCommon
+                  - Fn::Sub: ${OAuth.Outputs.LambdaAccessTokenFunctionName}
+                  - Fn::Sub: ${CommonStackName}-AccessTokenFunctionTS
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -50,6 +50,8 @@ Conditions:
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, ""]]
   IsDevEnvironment: !Equals [!Ref Environment, dev]
   IsLocalDevEnvironment: !Equals [!Ref Environment, localdev]
+  IsNotLocalDevEnvironment: !Not
+   - !Condition IsLocalDevEnvironment
   IsIntEnvironment: !Equals [!Ref Environment, integration]
   IsProdEnvironment: !Equals [!Ref Environment, production]
   IsDevLikeEnvironment: !Or [!Condition IsLocalDevEnvironment, !Condition IsDevEnvironment]
@@ -128,21 +130,33 @@ Mappings:
   EnvironmentConfiguration:
     localdev:
       DOMAINNAME: review-hc.localdev.account.gov.uk
+      VcDomain: review-hc.dev.account.gov.uk
+      ServiceDomain: review-hc.localdev.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
     dev:
       DOMAINNAME: review-hc.dev.account.gov.uk
+      VcDomain: review-hc.dev.account.gov.uk
+      ServiceDomain: review-hc.dev.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
     build:
       DOMAINNAME: review-hc.build.account.gov.uk
+      VcDomain: review-hc.build.account.gov.uk
+      ServiceDomain: review-hc.build.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
     staging:
       DOMAINNAME: review-hc.staging.account.gov.uk
+      VcDomain: review-hc.staging.account.gov.uk
+      ServiceDomain: review-hc.staging.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
     integration:
       DOMAINNAME: review-hc.integration.account.gov.uk
+      VcDomain: review-hc.integration.account.gov.uk
+      ServiceDomain: review-hc.integration.account.gov.uk
       HealthcheckSSMClientId: ipv-core
     production:
       DOMAINNAME: review-hc.production.account.gov.uk
+      VcDomain: review-hc.production.account.gov.uk
+      ServiceDomain: review-hc.production.account.gov.uk
       HealthcheckSSMClientId: ipv-core
 
 Globals:
@@ -192,6 +206,31 @@ Globals:
       - !Ref AWS::NoValue
 
 Resources:
+  OAuth:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:eu-west-2:667736788427:applications/di-ipv-cri-oauth-common
+        SemanticVersion: 0.4.0
+      Parameters:
+        AuditEventNamePrefix: IPV_HMRC_RECORD_CHECK_CRI
+        CriIdentifier: di-ipv-cri-check-hmrc-api
+        CriAudience: !Sub
+          - "https://${domain}"
+          - domain: !FindInMap [EnvironmentConfiguration, !Ref Environment, VcDomain]
+        CriVcIssuer: !Sub
+          - "https://${domain}"
+          - domain: !FindInMap [EnvironmentConfiguration, !Ref Environment, VcDomain]
+        CriPrivateApiGwName: !Sub ${AWS::StackName}-private
+        CriPublicApiGwName: !Sub ${AWS::StackName}-public
+        Environment: !If
+          - IsLocalDevEnvironment
+          - dev
+          - !Ref Environment
+        IPVCoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=nino
+        IPVCoreStubJwksEndpoint: https://test-resources.review-hc.dev.account.gov.uk/.well-known/jwks.json
+        LambdaVpcConfiguration: di-devplatform-deploy
+
   JWKSBucketRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -1534,6 +1573,33 @@ Resources:
       Type: String
       Value: !Ref CommonStackName
       Description: The stack currently used for OAuth (common-lambdas or oauth-common). Only required for test-resources.
+
+  OAuthSessionTableName:
+    Type: AWS::SSM::Parameter
+    Condition: IsNotLocalDevEnvironment
+    Properties:
+      Name: !Sub "/common-cri/oauth-common/OAuthSessionTableName"
+      Value: !GetAtt OAuth.Outputs.DbSessionTableName
+      Type: String
+      Description: The OAuthSessionTableName for configuring the DynamoDB Stream table from common-lambdas
+
+  OAuthPersonIdentityTableName:
+    Type: AWS::SSM::Parameter
+    Condition: IsNotLocalDevEnvironment
+    Properties:
+      Name: !Sub "/common-cri/oauth-common/OAuthPersonIdentityTableName"
+      Value: !GetAtt OAuth.Outputs.DbPersonIdentityTableName
+      Type: String
+      Description: The OAuthPersonIdentityTableName for configuring the DynamoDB Stream table from common-lambdas
+
+  OAuthCustomerManagedKeyId:
+    Type: AWS::SSM::Parameter
+    Condition: IsNotLocalDevEnvironment
+    Properties:
+      Name: !Sub "/common-cri/oauth-common/OAuthCustomerManagedKeyId"
+      Value: !GetAtt OAuth.Outputs.DbCustomerManagedKeyID
+      Type: String
+      Description: The OAuthCustomerManagedKeyId for configuring the DynamoDB Stream table from common-lambdas
 
 
 ##################################################################

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1,6 +1,11 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Digital Identity IPV CRI Pdv-Matching API
 Transform: [AWS::LanguageExtensions, AWS::Serverless-2016-10-31]
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - W8003 #For UseOAuthCommon condition - Can be removed one migration complete.
 
 Parameters:
   AuditEventNamePrefix:
@@ -72,6 +77,9 @@ Conditions:
   CreateOAuthSSMParam: !And
     - !Not [!Condition IsLocalDevEnvironment]
     - !Not [!Condition IsProdEnvironment]
+  UseOAuthCommon: !Equals
+  - !FindInMap [EnvironmentConfiguration, !Ref Environment, OAuthCommon]
+  - true
 
 Mappings:
   StaticVariables:
@@ -129,35 +137,35 @@ Mappings:
 
   EnvironmentConfiguration:
     localdev:
-      DOMAINNAME: review-hc.localdev.account.gov.uk
       VcDomain: review-hc.dev.account.gov.uk
       ServiceDomain: review-hc.localdev.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
+      OAuthCommon: true
     dev:
-      DOMAINNAME: review-hc.dev.account.gov.uk
       VcDomain: review-hc.dev.account.gov.uk
       ServiceDomain: review-hc.dev.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
+      OAuthCommon: false
     build:
-      DOMAINNAME: review-hc.build.account.gov.uk
       VcDomain: review-hc.build.account.gov.uk
       ServiceDomain: review-hc.build.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
+      OAuthCommon: false
     staging:
-      DOMAINNAME: review-hc.staging.account.gov.uk
       VcDomain: review-hc.staging.account.gov.uk
       ServiceDomain: review-hc.staging.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
+      OAuthCommon: false
     integration:
-      DOMAINNAME: review-hc.integration.account.gov.uk
       VcDomain: review-hc.integration.account.gov.uk
       ServiceDomain: review-hc.integration.account.gov.uk
       HealthcheckSSMClientId: ipv-core
+      OAuthCommon: false
     production:
-      DOMAINNAME: review-hc.production.account.gov.uk
       VcDomain: review-hc.production.account.gov.uk
       ServiceDomain: review-hc.production.account.gov.uk
       HealthcheckSSMClientId: ipv-core
+      OAuthCommon: false
 
 Globals:
   Function:
@@ -198,7 +206,6 @@ Globals:
           - SecretArn: !FindInMap [Dynatrace, SecretArn, !Ref Environment]
         AUDIT_QUEUE_URL:
           Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
-        AUDIT_COMPONENT_ID: !Sub "{{resolve:ssm:/${CommonStackName}/verifiable-credential/issuer}}"
     AutoPublishAlias: live
     ProvisionedConcurrencyConfig: !If
       - AddProvisionedConcurrency
@@ -491,7 +498,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${CommonStackName}-SessionFunctionTS
+                  Value: !If
+                    - UseOAuthCommon
+                    - !GetAtt OAuth.Outputs.LambdaSessionFunctionName
+                    - !Sub ${CommonStackName}-SessionFunctionTS
             Period: 300
             Stat: Sum
 
@@ -537,7 +547,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${CommonStackName}-SessionFunctionTS
+                  Value: !If
+                    - UseOAuthCommon
+                    - !GetAtt OAuth.Outputs.LambdaSessionFunctionName
+                    - !Sub ${CommonStackName}-SessionFunctionTS
             Period: 300
             Stat: Sum
 
@@ -581,7 +594,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${CommonStackName}-AccessTokenFunctionTS
+                  Value: !If
+                    - UseOAuthCommon
+                    - !GetAtt OAuth.Outputs.LambdaAccessTokenFunctionName
+                    - !Sub ${CommonStackName}-AccessTokenFunctionTS
             Period: 300
             Stat: Sum
 
@@ -627,7 +643,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${CommonStackName}-AccessTokenFunctionTS
+                  Value: !If
+                    - UseOAuthCommon
+                    - !GetAtt OAuth.Outputs.LambdaAccessTokenFunctionName
+                    - !Sub ${CommonStackName}-AccessTokenFunctionTS
             Period: 300
             Stat: Sum
 
@@ -735,16 +754,30 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-Abandon"
-          SESSION_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
-          ISSUER: !Sub "{{resolve:ssm:/${CommonStackName}/verifiable-credential/issuer}}"
+          SESSION_TABLE: !If
+            - UseOAuthCommon
+            - !GetAtt OAuth.Outputs.DbSessionTableName
+            - !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+          ISSUER: !Sub
+            - "https://${domain}"
+            - domain: !FindInMap [EnvironmentConfiguration, !Ref Environment, ServiceDomain]
           LOG_FULL_ERRORS: !If [IsIntOrProdEnvironment, "false", "true"]
+          AUDIT_COMPONENT_ID: !Sub
+            - "https://${domain}"
+            - domain: !FindInMap [EnvironmentConfiguration, !Ref Environment, ServiceDomain]
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
         - DynamoDBWritePolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+        - DynamoDBReadPolicy:
+            TableName: !GetAtt OAuth.Outputs.DbSessionTableName
+        - DynamoDBWritePolicy:
+            TableName: !GetAtt OAuth.Outputs.DbSessionTableName
         - KMSDecryptPolicy:
             KeyId: !Sub "{{resolve:ssm:/${CommonStackName}/DynamoDBCustomerManagedKeyID}}"
+        - KMSDecryptPolicy:
+            KeyId: !GetAtt OAuth.Outputs.DbCustomerManagedKeyID
         - SQSSendMessagePolicy:
             QueueName:
               Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueName
@@ -1166,6 +1199,14 @@ Resources:
         - DynamoDBWritePolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
         - DynamoDBReadPolicy:
+            TableName: !GetAtt OAuth.Outputs.DbSessionTableName
+        - DynamoDBWritePolicy:
+            TableName: !GetAtt OAuth.Outputs.DbSessionTableName
+        - DynamoDBReadPolicy:
+            TableName: !GetAtt OAuth.Outputs.DbPersonIdentityTableName
+        - DynamoDBWritePolicy:
+            TableName: !GetAtt OAuth.Outputs.DbPersonIdentityTableName
+        - DynamoDBReadPolicy:
             TableName: !Ref UserAttemptsTable
         - DynamoDBWritePolicy:
             TableName: !Ref UserAttemptsTable
@@ -1177,6 +1218,8 @@ Resources:
             KeyId: !Ref DynamoTablesEncryptionKey
         - KMSDecryptPolicy:
             KeyId: !Sub "{{resolve:ssm:/${CommonStackName}/DynamoDBCustomerManagedKeyID}}"
+        - KMSDecryptPolicy:
+            KeyId: !GetAtt OAuth.Outputs.DbCustomerManagedKeyID
         - SQSSendMessagePolicy:
             QueueName:
               Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueName
@@ -1192,11 +1235,20 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-NinoCheckFunction"
-          SESSION_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
-          PERSON_IDENTITY_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
+          SESSION_TABLE: !If
+            - UseOAuthCommon
+            - !GetAtt OAuth.Outputs.DbSessionTableName
+            - !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+          PERSON_IDENTITY_TABLE: !If
+            - UseOAuthCommon
+            - !GetAtt OAuth.Outputs.DbPersonIdentityTableName
+            - !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
           ATTEMPT_TABLE: !Ref UserAttemptsTable
           NINO_USER_TABLE: !Ref NinoUsersTable
           LOG_FULL_ERRORS: !If [IsIntOrProdEnvironment, "false", "true"]
+          AUDIT_COMPONENT_ID: !Sub
+            - "https://${domain}"
+            - domain: !FindInMap [EnvironmentConfiguration, !Ref Environment, ServiceDomain]
 
   NinoCheckFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1251,6 +1303,10 @@ Resources:
         - DynamoDBReadPolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
         - DynamoDBReadPolicy:
+            TableName: !GetAtt OAuth.Outputs.DbSessionTableName
+        - DynamoDBReadPolicy:
+            TableName: !GetAtt OAuth.Outputs.DbPersonIdentityTableName
+        - DynamoDBReadPolicy:
             TableName: !Ref UserAttemptsTable
         - DynamoDBReadPolicy:
             TableName: !Ref NinoUsersTable
@@ -1258,12 +1314,12 @@ Resources:
             KeyId: !Ref DynamoTablesEncryptionKey
         - KMSDecryptPolicy:
             KeyId: !Sub "{{resolve:ssm:/${CommonStackName}/DynamoDBCustomerManagedKeyID}}"
+        - KMSDecryptPolicy:
+            KeyId: !GetAtt OAuth.Outputs.DbCustomerManagedKeyID
         - SSMParameterReadPolicy:
             ParameterName: check-hmrc-cri-api/contraindicationMappings
         - SSMParameterReadPolicy:
             ParameterName: check-hmrc-cri-api/contraIndicatorReasonsMapping
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${CommonStackName}/verifiableCredentialKmsSigningKeyId
         - Statement:
             Effect: Allow
             Action: kms:Sign
@@ -1282,16 +1338,30 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-IssueCredentialFunction"
-          SESSION_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
-          PERSON_IDENTITY_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
+          SESSION_TABLE: !If
+            - UseOAuthCommon
+            - !GetAtt OAuth.Outputs.DbSessionTableName
+            - !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+          PERSON_IDENTITY_TABLE: !If
+            - UseOAuthCommon
+            - !GetAtt OAuth.Outputs.DbPersonIdentityTableName
+            - !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
           ATTEMPT_TABLE: !Ref UserAttemptsTable
           NINO_USER_TABLE: !Ref NinoUsersTable
-          ISSUER: !Sub "{{resolve:ssm:/${CommonStackName}/verifiable-credential/issuer}}"
+          ISSUER: !Sub
+            - "https://${domain}"
+            - domain: !FindInMap [EnvironmentConfiguration, !Ref Environment, ServiceDomain]
           MAX_JWT_TTL: !FindInMap [MaxJwtTtl, Environment, !Ref Environment]
           JWT_TTL_UNIT: !FindInMap [JwtTtlUnit, Environment, !Ref Environment]
           LOG_FULL_ERRORS: !If [IsIntOrProdEnvironment, "false", "true"]
-          COMMON_STACK_NAME: !Sub ${CommonStackName}
-          DOMAIN_NAME: !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
+          VC_SIGNING_KEY_ID: !If
+            - UseOAuthCommon
+            - !GetAtt OAuth.Outputs.VCSigningKeyID
+            - !Sub "{{resolve:ssm:/${CommonStackName}/verifiableCredentialKmsSigningKeyId}}"
+          DOMAIN_NAME: !FindInMap [EnvironmentConfiguration, !Ref Environment, ServiceDomain]
+          AUDIT_COMPONENT_ID: !Sub
+            - "https://${domain}"
+            - domain: !FindInMap [EnvironmentConfiguration, !Ref Environment, ServiceDomain]
 
   IssueCredentialFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1571,7 +1641,10 @@ Resources:
     Properties:
       Name: /common-cri/oauth-common/stack-name
       Type: String
-      Value: !Ref CommonStackName
+      Value: !If
+        - UseOAuthCommon
+        - !Select [1, !Split ["/", !Ref OAuth]]
+        - !Ref CommonStackName
       Description: The stack currently used for OAuth (common-lambdas or oauth-common). Only required for test-resources.
 
   OAuthSessionTableName:
@@ -1624,8 +1697,11 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-PrivateApiGatewayId
   CommonStackName:
-    Description: Common Stack Name
-    Value: !Ref CommonStackName
+    Description: Common OAuth Lambdas Stack Name
+    Value: !If
+      - UseOAuthCommon
+      - !Select [1, !Split ["/", !Ref OAuth]]
+      - !Ref CommonStackName
   UserAttemptsTable:
     Description: UserAttemptsTable table name
     Value: !Ref UserAttemptsTable

--- a/lambdas/issue-credential/src/config/function-config.ts
+++ b/lambdas/issue-credential/src/config/function-config.ts
@@ -14,7 +14,7 @@ const envVarNames = {
   ninoUserTable: "NINO_USER_TABLE",
   maxJwtTtl: "MAX_JWT_TTL",
   jwtTtlUnit: "JWT_TTL_UNIT",
-  commonStackName: "COMMON_STACK_NAME",
+  vcSigningKeyId: "VC_SIGNING_KEY_ID",
   vcIssuer: "ISSUER",
 };
 
@@ -22,7 +22,7 @@ export type CredentialIssuerEnv = {
   issuer: string;
   maxJwtTtl: number;
   jwtTtlUnit: TimeUnits;
-  commonStackName: string;
+  vcSigningKeyId: string;
 };
 export class IssueCredFunctionConfig extends BaseFunctionConfig {
   public readonly credentialIssuerEnv: CredentialIssuerEnv;
@@ -36,7 +36,7 @@ export class IssueCredFunctionConfig extends BaseFunctionConfig {
       issuer: process.env[envVarNames.vcIssuer] as string,
       maxJwtTtl: Number(process.env[envVarNames.maxJwtTtl]),
       jwtTtlUnit: process.env[envVarNames.jwtTtlUnit] as TimeUnits,
-      commonStackName: process.env[envVarNames.commonStackName] as string,
+      vcSigningKeyId: process.env[envVarNames.vcSigningKeyId] as string,
     };
   }
 

--- a/lambdas/issue-credential/src/config/vc-config.ts
+++ b/lambdas/issue-credential/src/config/vc-config.ts
@@ -8,15 +8,14 @@ export type VcCheckConfig = {
   readonly kms: { signingKeyId: string };
   readonly contraIndicator: { errorMapping: string[]; reasonsMapping: CiReasonsMapping[] };
 };
-export const getVcConfig = async (commonStackName: string): Promise<VcCheckConfig> => {
-  const vcSigningKeyId = `/${commonStackName}/verifiableCredentialKmsSigningKeyId`;
+export const getVcConfig = async (vcSigningKeyId: string): Promise<VcCheckConfig> => {
   const errorMapping = "/check-hmrc-cri-api/contraindicationMappings";
   const reasonsMapping = "/check-hmrc-cri-api/contraIndicatorReasonsMapping";
   try {
-    const ssmParams = await getParametersValues([vcSigningKeyId, errorMapping, reasonsMapping], cacheTtlInSeconds);
+    const ssmParams = await getParametersValues([errorMapping, reasonsMapping], cacheTtlInSeconds);
     logger.info("Retrieved Check Hmrc VC parameters.");
     return {
-      kms: { signingKeyId: ssmParams[vcSigningKeyId] },
+      kms: { signingKeyId: vcSigningKeyId },
       contraIndicator: {
         errorMapping: ssmParams[errorMapping].split("||"),
         reasonsMapping: JSON.parse(ssmParams[reasonsMapping]),

--- a/lambdas/issue-credential/src/handler.ts
+++ b/lambdas/issue-credential/src/handler.ts
@@ -38,7 +38,7 @@ class IssueCredentialHandler implements LambdaInterface {
 
       const { attempts, personIdentity, ninoUser, session } = await this.getCheckedUserData(accessToken);
 
-      vcConfig ??= await getVcConfig(functionConfig.credentialIssuerEnv.commonStackName);
+      vcConfig ??= await getVcConfig(functionConfig.credentialIssuerEnv.vcSigningKeyId);
       const contraIndicators = getHmrcContraIndicators({
         contraIndicationMapping: vcConfig.contraIndicator.errorMapping,
         contraIndicatorReasonsMapping: vcConfig.contraIndicator.reasonsMapping,

--- a/lambdas/issue-credential/tests/config/function-config.test.ts
+++ b/lambdas/issue-credential/tests/config/function-config.test.ts
@@ -13,7 +13,7 @@ const validEnvVars = {
   ISSUER: "bob",
   MAX_JWT_TTL: "3600",
   JWT_TTL_UNIT: "seconds",
-  COMMON_STACK_NAME: "common-stack",
+  VC_SIGNING_KEY_ID: "key-id-here",
 };
 
 describe("function config", () => {
@@ -41,7 +41,7 @@ describe("function config", () => {
           issuer: "bob",
           maxJwtTtl: 3600,
           jwtTtlUnit: "seconds",
-          commonStackName: "common-stack",
+          vcSigningKeyId: "key-id-here",
         },
       });
       expect(config.tableNames).toEqual({

--- a/lambdas/issue-credential/tests/config/vc-config.test.ts
+++ b/lambdas/issue-credential/tests/config/vc-config.test.ts
@@ -16,13 +16,11 @@ type spyGetParametersValues = MockInstance<
 describe("getVcConfig", () => {
   let getParametersValuesSpy: spyGetParametersValues;
 
-  const mockCommonStackName = "test-stack";
-  const expectedVcSigningKeyId = `/${mockCommonStackName}/verifiableCredentialKmsSigningKeyId`;
+  const mockVcSigningKeyId = "test-signing-key-id";
   const expectedErrorMapping = "/check-hmrc-cri-api/contraindicationMappings";
   const expectedReasonsMapping = "/check-hmrc-cri-api/contraIndicatorReasonsMapping";
 
   const mockSsmParams: Record<string, string> = {
-    [expectedVcSigningKeyId]: "test-signing-key-id",
     [expectedErrorMapping]: "error1||error2||error3",
     [expectedReasonsMapping]: JSON.stringify([
       { code: "A", reason: "Reason A" },
@@ -41,7 +39,7 @@ describe("getVcConfig", () => {
     it("returns correctly typed VcCheckConfig with valid parameters", async () => {
       getParametersValuesSpy.mockResolvedValueOnce(mockSsmParams);
 
-      const result: VcCheckConfig = await getVcConfig(mockCommonStackName);
+      const result: VcCheckConfig = await getVcConfig(mockVcSigningKeyId);
 
       expect(result).toEqual({
         kms: { signingKeyId: "test-signing-key-id" },
@@ -58,12 +56,9 @@ describe("getVcConfig", () => {
     it("calls getParametersValues with correct parameter paths", async () => {
       getParametersValuesSpy.mockResolvedValueOnce(mockSsmParams);
 
-      await getVcConfig(mockCommonStackName);
+      await getVcConfig(mockVcSigningKeyId);
 
-      expect(getParametersValuesSpy).toHaveBeenCalledWith(
-        [expectedVcSigningKeyId, expectedErrorMapping, expectedReasonsMapping],
-        300
-      );
+      expect(getParametersValuesSpy).toHaveBeenCalledWith([expectedErrorMapping, expectedReasonsMapping], 300);
       expect(getParametersValuesSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -71,7 +66,7 @@ describe("getVcConfig", () => {
       getParametersValuesSpy.mockResolvedValueOnce(mockSsmParams);
       vi.spyOn(logger, "info");
 
-      await getVcConfig(mockCommonStackName);
+      await getVcConfig(mockVcSigningKeyId);
 
       expect(logger.info).toHaveBeenCalledWith("Retrieved Check Hmrc VC parameters.");
       expect(logger.info).toHaveBeenCalledTimes(1);
@@ -83,7 +78,7 @@ describe("getVcConfig", () => {
         [expectedErrorMapping]: "",
       });
 
-      const result = await getVcConfig(mockCommonStackName);
+      const result = await getVcConfig(mockVcSigningKeyId);
 
       expect(result.contraIndicator.errorMapping).toEqual([""]);
     });
@@ -94,7 +89,7 @@ describe("getVcConfig", () => {
         [expectedErrorMapping]: "single-error",
       });
 
-      const result = await getVcConfig(mockCommonStackName);
+      const result = await getVcConfig(mockVcSigningKeyId);
 
       expect(result.contraIndicator.errorMapping).toEqual(["single-error"]);
     });
@@ -110,7 +105,7 @@ describe("getVcConfig", () => {
         [expectedReasonsMapping]: JSON.stringify(multipleReasons),
       });
 
-      const result = await getVcConfig(mockCommonStackName);
+      const result = await getVcConfig(mockVcSigningKeyId);
 
       expect(result.contraIndicator.reasonsMapping).toEqual(multipleReasons);
     });
@@ -120,7 +115,7 @@ describe("getVcConfig", () => {
     it("throws CriError when getParametersValues throws Error", async () => {
       getParametersValuesSpy.mockRejectedValue(new Error("SSM parameter not found"));
 
-      await expect(getVcConfig(mockCommonStackName)).rejects.toThrow(
+      await expect(getVcConfig(mockVcSigningKeyId)).rejects.toThrow(
         new CriError(500, "Failed to load VC config: SSM parameter not found")
       );
     });
@@ -128,7 +123,7 @@ describe("getVcConfig", () => {
     it("throws CriError when getParametersValues throws non-Error", async () => {
       getParametersValuesSpy.mockRejectedValueOnce("String error");
 
-      await expect(getVcConfig(mockCommonStackName)).rejects.toThrow(
+      await expect(getVcConfig(mockVcSigningKeyId)).rejects.toThrow(
         new CriError(500, "Failed to load VC config: String error")
       );
     });
@@ -136,7 +131,7 @@ describe("getVcConfig", () => {
     it("throws CriError when getParametersValues throws null", async () => {
       getParametersValuesSpy.mockRejectedValue(null);
 
-      await expect(getVcConfig(mockCommonStackName)).rejects.toThrow(
+      await expect(getVcConfig(mockVcSigningKeyId)).rejects.toThrow(
         new CriError(500, "Failed to load VC config: null")
       );
     });
@@ -144,7 +139,7 @@ describe("getVcConfig", () => {
     it("throws CriError when getParametersValues throws undefined", async () => {
       getParametersValuesSpy.mockRejectedValue(undefined);
 
-      await expect(getVcConfig(mockCommonStackName)).rejects.toThrow(
+      await expect(getVcConfig(mockVcSigningKeyId)).rejects.toThrow(
         new CriError(500, "Failed to load VC config: undefined")
       );
     });
@@ -152,11 +147,11 @@ describe("getVcConfig", () => {
     it("throws CriError when JSON.parse fails on reasonsMapping", async () => {
       getParametersValuesSpy.mockResolvedValueOnce({
         ...mockSsmParams,
-        [expectedReasonsMapping]: "invalid-json",
+        [expectedReasonsMapping]: "invalid-json", //TODO FIX
       });
 
-      await expect(getVcConfig(mockCommonStackName)).rejects.toThrow(CriError);
-      await expect(getVcConfig(mockCommonStackName)).rejects.toThrow(
+      await expect(getVcConfig(mockVcSigningKeyId)).rejects.toThrow(CriError);
+      await expect(getVcConfig(mockVcSigningKeyId)).rejects.toThrow(
         expect.objectContaining({
           statusCode: 500,
           message: expect.stringContaining("Failed to load VC config:"),
@@ -168,49 +163,8 @@ describe("getVcConfig", () => {
       const specificErrorMessage = "Specific AWS SSM error occurred";
       getParametersValuesSpy.mockRejectedValueOnce(new Error(specificErrorMessage));
 
-      await expect(getVcConfig(mockCommonStackName)).rejects.toThrow(
+      await expect(getVcConfig(mockVcSigningKeyId)).rejects.toThrow(
         new CriError(500, `Failed to load VC config: ${specificErrorMessage}`)
-      );
-    });
-  });
-
-  describe("parameter path construction", () => {
-    it("constructs correct vcSigningKeyId path with different stack names", async () => {
-      const customStackName = "custom-stack-name";
-      const expectedCustomPath = `/${customStackName}/verifiableCredentialKmsSigningKeyId`;
-
-      getParametersValuesSpy.mockResolvedValueOnce({
-        [expectedCustomPath]: "custom-key-id",
-        [expectedErrorMapping]: "error1||error2",
-        [expectedReasonsMapping]: JSON.stringify([]),
-      });
-
-      await getVcConfig(customStackName);
-
-      expect(getParametersValuesSpy).toHaveBeenCalledWith(
-        [expectedCustomPath, expectedErrorMapping, expectedReasonsMapping],
-        300
-      );
-    });
-
-    it("handles stack names with special characters", async () => {
-      const specialStackName = "stack-with-123_special.chars";
-      const expectedSpecialPath = `/${specialStackName}/verifiableCredentialKmsSigningKeyId`;
-
-      const specialMockParams = {
-        [expectedSpecialPath]: "special-key-id",
-        [expectedErrorMapping]: "error1",
-        [expectedReasonsMapping]: JSON.stringify([]),
-      };
-
-      getParametersValuesSpy.mockResolvedValueOnce(specialMockParams);
-
-      const result = await getVcConfig(specialStackName);
-
-      expect(result.kms.signingKeyId).toBe("special-key-id");
-      expect(getParametersValuesSpy).toHaveBeenCalledWith(
-        [expectedSpecialPath, expectedErrorMapping, expectedReasonsMapping],
-        300
       );
     });
   });
@@ -219,7 +173,7 @@ describe("getVcConfig", () => {
     it("returns object matching VcCheckConfig type", async () => {
       getParametersValuesSpy.mockResolvedValueOnce(mockSsmParams);
 
-      const result = await getVcConfig(mockCommonStackName);
+      const result = await getVcConfig(mockVcSigningKeyId);
 
       expect(typeof result.kms.signingKeyId).toBe("string");
       expect(Array.isArray(result.contraIndicator.errorMapping)).toBe(true);
@@ -235,29 +189,13 @@ describe("getVcConfig", () => {
   });
 
   describe("some edge cases", () => {
-    it("handles empty commonStackName", async () => {
-      getParametersValuesSpy.mockResolvedValueOnce({
-        "//verifiableCredentialKmsSigningKeyId": "empty-stack-key",
-        [expectedErrorMapping]: "error1",
-        [expectedReasonsMapping]: JSON.stringify([]),
-      });
-
-      const result = await getVcConfig("");
-
-      expect(getParametersValuesSpy).toHaveBeenCalledWith(
-        ["//verifiableCredentialKmsSigningKeyId", expectedErrorMapping, expectedReasonsMapping],
-        300
-      );
-      expect(result.kms.signingKeyId).toBe("empty-stack-key");
-    });
-
     it("handles reasonsMapping as empty array", async () => {
       getParametersValuesSpy.mockResolvedValueOnce({
         ...mockSsmParams,
         [expectedReasonsMapping]: "[]",
       });
 
-      const result = await getVcConfig(mockCommonStackName);
+      const result = await getVcConfig(mockVcSigningKeyId);
 
       expect(result.contraIndicator.reasonsMapping).toEqual([]);
     });
@@ -268,7 +206,7 @@ describe("getVcConfig", () => {
         [expectedErrorMapping]: "error1||||error2||error3",
       });
 
-      const result = await getVcConfig(mockCommonStackName);
+      const result = await getVcConfig(mockVcSigningKeyId);
 
       expect(result.contraIndicator.errorMapping).toEqual(["error1", "", "error2", "error3"]);
     });

--- a/lambdas/issue-credential/tests/handler.test.ts
+++ b/lambdas/issue-credential/tests/handler.test.ts
@@ -23,7 +23,7 @@ const { mockIssueCredConfig } = vi.hoisted(() => ({
       issuer: "bob",
       maxJwtTtl: 1000,
       jwtTtlUnit: "Hours",
-      commonStackName: "big-stack",
+      vcSigningKeyId: "big-stack",
     },
     tableNames: {
       sessionTable: "session-table",

--- a/lambdas/issue-credential/tests/mocks/mockConfig.ts
+++ b/lambdas/issue-credential/tests/mocks/mockConfig.ts
@@ -13,7 +13,7 @@ export const mockCredentialIssuerEnv: CredentialIssuerEnv = {
   issuer: "bob",
   maxJwtTtl: 1000,
   jwtTtlUnit: TimeUnits.Hours,
-  commonStackName: "big-stack",
+  vcSigningKeyId: "key-id",
 };
 
 export const mockFunctionConfig: IssueCredFunctionConfig = {


### PR DESCRIPTION
## OAuth Migration Guide

**This PR is only a guide and should not be merged. This was the original plan, we are looking into this further here: https://govukverify.atlassian.net/browse/OJ-3717**

### Step Overview

Although some of the steps are included in this single PR, this is only an example. Each step below requires a deploy to either `common-lambdas` or the CRI API stack.

### Step 1 - Ensure Common Lambdas is up-to-date

Ensure you have the most recent common-lambdas deployed, with this PR in particular: https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/645

At this point, the `EnableDynamoDbStream` mapping should be set to `false` for your CRI. The stream lambda will not be deployed at this point.

### Step 2 - Add OAuthCommon to the CRI API stack

Add OAuthCommon to your CRI API stack, but do not yet use. This is to ensure the new tables are created so we can migrate to them. 

You also need to output the Session table name, Person Identity table name and CMK key ID to the SSM parameter paths below. 
`/common-cri/oauth-common/OAuthSessionTableName`
`/common-cri/oauth-common/OAuthPersonIdentityTableName`
`/common-cri/oauth-common/OAuthCustomerManagedKeyId`*

**Important**: The SSM parameters have hardcoded paths so they can only be deployed once per account, hence the `IsNotLocalDevEnvironment` condition. Unfortunately `common-lambdas` does not know much about the application stack using it, so configuring it to look for dynamic parameters was not possible. 

Changes will need to be made to the action that deploys pre-merge stacks also: 
- Update the SHAs of the `govuk-one-login/github-actions/sam` to `4c76410195b5fcb1804fc7c183ed20704252830f` (or more recent). 
- The build action will now also need AWS creds. 
- `stack-name-prefix:` may also need shortening, due to the OAuth lambda names getting too long.

**Pipelines** - At time of writing, deploying through the pipelines is currently not working. The tickets below are tracking this, there may be additional work prior to completing this step to ensure the pipelines deploy
https://govukverify.atlassian.net/browse/PSREDEV-3425 & https://govukverify.atlassian.net/browse/LIME-2144

**Example**: See the first commit on this PR for this step in practice: https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/pull/773/changes/01536877005ae0a706313c7de91e0508dc6d7e44

*If you do not want to use a CustomerManagedKey for the OAuthCommon databases, and are going to overwrite the parameter `DbCustomerManagedKey` to `false`. You'll need to make a slight change to the Stream lambda in common-lambdas to wrap the `KMSDecryptPolicy` in a `if` condition. (This has been done for the existing `common-lambdas` CMK so can be easily copied)

Before proceeding to Step 3, ensure the nested OAuthCommon stack exists in all accounts, and the SSM parameters are populated with the correct names and ID.

### Step 3 - Enable the DynamoDB stream in Common Lambdas (lower envs only)

We now want to enable the stream from the common-lambdas tables to the OAuthCommon tables. To do so, set `EnableDynamoDbStream` to `true` in `common-lambdas`

I would recommend only doing this is `dev` & `build` initially. We can then conduct some testing in build.

Validate this is working correctly, by running a through journeys and checking the `OAuthCommon` tables mirror the `common-lambdas` tables.

### Step 4 - Migrate CRI API stack to use OAuthCommon (lower envs only)

Recommend: Start some average traffic perf tests. 
Optional: Wait beyond the session TTL of the CRI.

Migrate the CRI API stack to using OAuthCommon. See the second commit on this repo: https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/pull/773/changes/a4fd03b35cbaa94296a2e8d0065322e96ba6452a

This will involve adding a condition `UseOAuthCommon`, that be configured per env.

The Lambda uri, table names env vars and `CommonStackName` outputs will need wrapping in conditionals.

There is also some changes to Issue, Domain and the VC signing key ID. That latter involves code changes also.

Note: Allow both Dynamo tables policies on the lambdas, to avoid any permission issues during updates. These can be removed after.

### Step 5 - Enable the DynamoDB stream in Common Lambdas (all envs)

Set `EnableDynamoDbStream` to `true` in `common-lambdas` in all environments. 

As this now includes `prod` we need to ensure all sessions are in the `OAuthCommon` tables. This time we need to wait longer than the TTL before proceeding to the next step (usually 2 hrs, some CRIs may differ).

Then, validate the `OAuthCommon` tables mirror the `common-lambdas` tables.

### Step 6 - Migrate CRI API stack to use OAuthCommon (all envs)

Set `UseOAuthCommon` to true in all environments.

### Step 7 - Remove Common Lambdas

This is not an exhaustive guide, this step will need detailing separately. This is a few reminders what can be removed from the repo as it's fresh in my mind.

`CommonStackName` CF param
`common_stack_name` from `deploy.sh`
`OAuthCommon` mapping, `UseOAuthCommon` condition and all conditional logic using this. 
SSM param - `OAuthSessionTableName`, `OAuthPersonIdentityTableName` & `OAuthCustomerManagedKeyId`
`W8003` linting ignore

### Issue tracking

- [OJ-3625](https://govukverify.atlassian.net/browse/OJ-3625)

[OJ-3625]: https://govukverify.atlassian.net/browse/OJ-3625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ