### PR TITLE
OJ-3724: Remove exp from VC

### DIFF
--- a/integration-tests/api-gateway/contract/utils/PactJwtFormatter.ts
+++ b/integration-tests/api-gateway/contract/utils/PactJwtFormatter.ts
@@ -13,7 +13,6 @@ export const formatJwtForPactTest = (body: string) => {
 const replaceDynamicVcFieldsIfPresent = (parseVc: JWTClaimsSet) => {
   parseVc.nbf = parseVc.nbf == null ? parseVc.nbf : 4070908800;
   parseVc.iss = parseVc.iss == null ? parseVc.iss : "dummyNinoComponentId";
-  parseVc.exp = parseVc.exp == null ? parseVc.exp : 4070909400;
   parseVc.jti = parseVc.jti == null ? parseVc.jti : "dummyJti";
   return parseVc;
 };

--- a/integration-tests/api-gateway/env-variables.ts
+++ b/integration-tests/api-gateway/env-variables.ts
@@ -52,6 +52,5 @@ export const claimSet = {
   },
   redirect_uri: CLIENT_URL,
   state: "diWgdrCGYnjrZK7cMPEKwJXvpGn6rvhCBteCl_I2ejg",
-  exp: Date.now() + 100000000000,
   iat: 1697516406,
 };

--- a/integration-tests/api-gateway/types.ts
+++ b/integration-tests/api-gateway/types.ts
@@ -4,7 +4,6 @@ export type JWTClaimsSet = {
   sub: string;
   aud: string;
   iat: number;
-  exp: number;
   nbf: number;
   jti: string;
   response_type: string;

--- a/lambdas/issue-credential/src/handler.ts
+++ b/lambdas/issue-credential/src/handler.ts
@@ -141,10 +141,6 @@ class IssueCredentialHandler implements LambdaInterface {
       sub: subject,
       nbf: toEpochSecondsFromNow(),
       iss: functionConfig.credentialIssuerEnv.issuer,
-      exp: toEpochSecondsFromNow(
-        functionConfig.credentialIssuerEnv.maxJwtTtl,
-        functionConfig.credentialIssuerEnv.jwtTtlUnit
-      ),
       jti: `urn:uuid:${randomUUID().toString()}`,
     };
   }

--- a/lambdas/issue-credential/src/types/verifiable-credential.ts
+++ b/lambdas/issue-credential/src/types/verifiable-credential.ts
@@ -15,7 +15,7 @@ export type VerifiableCredential = {
   evidence?: Evidence[];
 };
 
-export type JwtClass = { iss: string; jti: string; nbf: number; exp: number; sub: string };
+export type JwtClass = { iss: string; jti: string; nbf: number; sub: string };
 export type VerifiableIdentityCredential = JwtClass & {
   vc: VerifiableCredential;
 };

--- a/lambdas/issue-credential/src/vc/vc-builder.ts
+++ b/lambdas/issue-credential/src/vc/vc-builder.ts
@@ -36,7 +36,6 @@ export const buildVerifiableCredential = (
     sub: jwtClaims.sub,
     nbf: jwtClaims.nbf,
     iss: jwtClaims.iss,
-    exp: jwtClaims.exp,
     vc: {
       evidence: [getEvidence(session, attempts, CHECK_DETAIL, contraIndicators)],
       credentialSubject,

--- a/lambdas/issue-credential/tests/kms-signer/test-data.ts
+++ b/lambdas/issue-credential/tests/kms-signer/test-data.ts
@@ -62,7 +62,6 @@ export const claimsSet = {
   scope: "openid",
   redirect_uri: "https://cri.core.build.stubs.account.gov.uk/callback",
   state: "diWgdrCGYnjrZK7cMPEKwJXvpGn6rvhCBteCl_I2ejg",
-  exp: 4102444800,
   iat: 1697516406,
 };
 
@@ -119,7 +118,6 @@ export const largeClaimsSet = {
   scope: "openid",
   redirect_uri: "https://cri.core.build.stubs.account.gov.uk/callback",
   state: "diWgdrCGYnjrZK7cMPEKwJXvpGn6rvhCBteCl_I2ejg",
-  exp: 4102444800,
   iat: 1697516406,
 };
 

--- a/lambdas/issue-credential/tests/vc/vc-builder.test.ts
+++ b/lambdas/issue-credential/tests/vc/vc-builder.test.ts
@@ -50,7 +50,6 @@ describe("vc-builder", () => {
     iss: "https://review-hc.dev.account.gov.uk",
     jti: "urn:uuid:f540b78c-9e52-4a0f-b033-c78e7ab327ea",
     nbf: 1710396563,
-    exp: 1710403763,
     sub: "test",
     vc: {} as VerifiableCredential,
   };
@@ -77,7 +76,6 @@ describe("vc-builder", () => {
       );
 
       expect(result).toEqual({
-        exp: 1710403763,
         iss: "https://review-hc.dev.account.gov.uk",
         jti: "urn:uuid:f540b78c-9e52-4a0f-b033-c78e7ab327ea",
         nbf: 1710396563,
@@ -129,7 +127,6 @@ describe("vc-builder", () => {
       );
 
       expect(result).toEqual({
-        exp: 1710403763,
         iss: "https://review-hc.dev.account.gov.uk",
         jti: "urn:uuid:f540b78c-9e52-4a0f-b033-c78e7ab327ea",
         nbf: 1710396563,
@@ -183,7 +180,6 @@ describe("vc-builder", () => {
       );
 
       expect(result).toEqual({
-        exp: 1710403763,
         iss: "https://review-hc.dev.account.gov.uk",
         jti: "urn:uuid:f540b78c-9e52-4a0f-b033-c78e7ab327ea",
         nbf: 1710396563,
@@ -239,7 +235,6 @@ describe("vc-builder", () => {
     expect(result.iss).toBe(mockJwtClaims.iss);
     expect(result.jti).toBe(mockJwtClaims.jti);
     expect(result.nbf).toBe(mockJwtClaims.nbf);
-    expect(result.exp).toBe(mockJwtClaims.exp);
     expect(result.sub).toBe(mockJwtClaims.sub);
   });
 });


### PR DESCRIPTION
## Proposed changes

### What changed

Remove `exp` from the VC.

### Why did it change

Since "exp" is no longer being used in the VC based on this [decision](https://github.com/govuk-one-login/architecture/blob/main/adr/0076-vc-lifetime.md). This has already been removed from Address & KBV CRI.

Core PR that needs merging first: https://github.com/govuk-one-login/ipv-core-back/pull/4049

### Issue tracking

- [OJ-3724](https://govukverify.atlassian.net/browse/OJ-3724)

[OJ-3724]: https://govukverify.atlassian.net/browse/OJ-3724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ