### PR TITLE
OJ-3744: New post-merge GHA

### DIFF
--- a/.github/workflows/post-merge-deploy-to-build.yml
+++ b/.github/workflows/post-merge-deploy-to-build.yml
@@ -1,8 +1,6 @@
 name: Package for Build
 on:
-  workflow_dispatch:
-  push:
-    branches: [main]
+  workflow_call:
 
 jobs:
   deploy:

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -1,8 +1,7 @@
 name: Package for Dev
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
+  workflow_call:
 
 jobs:
   deploy:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,28 @@
+name: Post merge
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write
+  security-events: write
+
+jobs:
+  scan-and-unit-test:
+    name: Scan repo
+    uses: ./.github/workflows/scan-repo.yml
+    secrets: inherit
+
+  deploy-dev:
+    name: Deploy dev
+    needs: scan-and-unit-test
+    uses: ./.github/workflows/post-merge-deploy-to-dev.yml
+    secrets: inherit
+
+  deploy-build:
+    name: Deploy to build
+    needs: scan-and-unit-test
+    uses: ./.github/workflows/post-merge-deploy-to-build.yml
+    secrets: inherit

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -3,8 +3,7 @@ name: Scan repository
 on:
   workflow_dispatch:
   pull_request:
-  push:
-    branches: [main]
+  workflow_call:
   schedule:
     # Every Monday at 9am
     - cron: "0 9 * * 1"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -129,7 +129,8 @@
         "goodToken",
         "badToken",
         "02ba5dbd2a3664670bf5c4689a9f8e014fe2c019209c9e5db7641a2b2a4bc7a8",
-        "74c5b00d698a18178a738f5305ee67f9d50fc620f8be6b89d94638fa16a4c828"
+        "74c5b00d698a18178a738f5305ee67f9d50fc620f8be6b89d94638fa16a4c828",
+        "inherit"
       ]
     }
   ],


### PR DESCRIPTION
## Proposed changes

### What changed

Created a new `post-merge.yml `GHA. 

### Why did it change

We previously deployed even if scan-repo failed post-merge. This now makes deploying depend on scan-repo completing successfully.

### Issue tracking

- [OJ-3744](https://govukverify.atlassian.net/browse/OJ-3744)

[OJ-3744]: https://govukverify.atlassian.net/browse/OJ-3744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ