### PR TITLE
OJ-3798: Bump cri-error-response to resolve message key warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@aws-sdk/client-dynamodb": "3.1012.0",
         "@aws-sdk/client-ssm": "3.1012.0",
         "@govuk-one-login/cri-audit": "1.0.2",
-        "@govuk-one-login/cri-error-response": "1.0.0",
+        "@govuk-one-login/cri-error-response": "1.0.2",
         "@govuk-one-login/cri-logger": "1.0.0",
         "@govuk-one-login/cri-metrics": "1.0.1",
         "esbuild": "0.28.1",
@@ -2663,9 +2663,9 @@
       "license": "MIT"
     },
     "node_modules/@govuk-one-login/cri-error-response": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/cri-error-response/-/cri-error-response-1.0.0.tgz",
-      "integrity": "sha512-0BazVTZbCN4+cTBVJWQ4jxLTMuwWd+jvnz+MoUgrjcN5iTdavYJlO9iZvB+v/7og8EECfc0rWzFtIm8Dogz8Kw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/cri-error-response/-/cri-error-response-1.0.2.tgz",
+      "integrity": "sha512-h234ZSw4HgoYWBVi8tnNHQw8/zcTl8VpiNncyBta8AbMN9ec16/3ZOr7ksQ7RuAC8TISTikHodvNKw4oUnOr5A==",
       "license": "MIT",
       "peerDependencies": {
         "@govuk-one-login/cri-logger": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/client-dynamodb": "3.1012.0",
     "@aws-sdk/client-ssm": "3.1012.0",
     "@govuk-one-login/cri-audit": "1.0.2",
-    "@govuk-one-login/cri-error-response": "1.0.0",
+    "@govuk-one-login/cri-error-response": "1.0.2",
     "@govuk-one-login/cri-logger": "1.0.0",
     "@govuk-one-login/cri-metrics": "1.0.1",
     "esbuild": "0.28.1",


### PR DESCRIPTION
## Proposed changes

### What changed

bump `cri-error-response`

### Why did it change

Fix `Powertools` reserved message key warning in error logging

### Issue tracking

- [OJ-3798](https://govukverify.atlassian.net/browse/OJ-3798)


[OJ-3798]: https://govukverify.atlassian.net/browse/OJ-3798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ