### PR TITLE
OJ-3798: Change OTG thrown errors to CriErrors for better logging

### DIFF
--- a/lambdas/common/src/hmrc-apis/otg.ts
+++ b/lambdas/common/src/hmrc-apis/otg.ts
@@ -1,3 +1,4 @@
+import { CriError } from "@govuk-one-login/cri-error-response";
 import { OtgConfig, OtgTokenResponse } from "./types/otg";
 import { logger } from "@govuk-one-login/cri-logger";
 import { captureLatency } from "@govuk-one-login/cri-metrics";
@@ -22,10 +23,10 @@ export async function getTokenFromOtg({ apiUrl }: OtgConfig, signal?: AbortSigna
     const expiry = body.expiry;
     const now = Date.now();
     if (now > expiry) {
-      throw new Error("OTG returned an expired Bearer Token");
+      throw new CriError(500, "OTG returned an expired Bearer Token");
     }
     return body.token;
   }
 
-  throw new Error(`Error response received from OTG ${response.status} ${response.statusText}`);
+  throw new CriError(500, `Error response received from OTG ${response.status} ${response.statusText}`);
 }

--- a/lambdas/common/tests/hmrc-apis/otg.test.ts
+++ b/lambdas/common/tests/hmrc-apis/otg.test.ts
@@ -7,6 +7,7 @@ vi.mock("@govuk-one-login/cri-metrics");
 import { logger } from "@govuk-one-login/cri-logger";
 import { captureLatency } from "@govuk-one-login/cri-metrics";
 import { getTokenFromOtg } from "../../src/hmrc-apis/otg";
+import { CriError } from "@govuk-one-login/cri-error-response";
 
 const apiUrl = "https://apigwId-vpceId.execute-api.eu-west-2.amazonaws.com/dev/token/?tokenType=stub";
 
@@ -61,7 +62,7 @@ describe("getTokenFromOtg", () => {
     } as unknown as Response);
 
     await expect(() => getTokenFromOtg(...mockParams)).rejects.toThrow(
-      new Error("Error response received from OTG 400 Forbidden")
+      new CriError(500, "Error response received from OTG 400 Forbidden")
     );
   });
 
@@ -80,7 +81,7 @@ describe("getTokenFromOtg", () => {
     } as unknown as Response);
 
     await expect(() => getTokenFromOtg(...mockParams)).rejects.toThrow(
-      new Error("OTG returned an expired Bearer Token")
+      new CriError(500, "OTG returned an expired Bearer Token")
     );
   });
 });


### PR DESCRIPTION
## Proposed changes

### What changed

Change the error type thrown from OTG request errors from `Error` to `CriError` for better logging.

### Why did it change

We are getting occasional 5xx errors from NinoCheckFunction in prod. The last log is `OTG API response received` then the following log is `UnhandledExpection`.

### Issue tracking

- [OJ-3798](https://govukverify.atlassian.net/browse/OJ-3798)


[OJ-3798]: https://govukverify.atlassian.net/browse/OJ-3798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ