### PR TITLE
OJ-3752: Add OAuthCommon upto staging

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -15,10 +15,14 @@ jobs:
   build:
     name: Build SAM app
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       cache-key: ${{ steps.build.outputs.cache-key }}
       cache-restore-keys: ${{ steps.build.outputs.cache-restore-keys }}
+    environment:
+      name: development
     steps:
       - name: Install latest SAM
         uses: aws-actions/setup-sam@d78e1a4a9656d3b223e59b80676a797f20093133
@@ -26,13 +30,14 @@ jobs:
           version: 1.159.1
 
       - name: Build SAM application
-        uses: govuk-one-login/github-actions/sam/build-application@e6b6ed890b35904e1be79f7f35ffec983fa4d9db
+        uses: govuk-one-login/github-actions/sam/build-application@4c76410195b5fcb1804fc7c183ed20704252830f
         id: build
         with:
           template: infrastructure/template.yaml
           cache-name: check-hmrc-api
           pull-repository: true
           source-dir: lambdas
+          aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
 
   deploy:
     name: Deploy stack
@@ -56,12 +61,12 @@ jobs:
         with:
           version: 1.159.1
       - name: Deploy stack
-        uses: govuk-one-login/github-actions/sam/deploy-stack@e6b6ed890b35904e1be79f7f35ffec983fa4d9db
+        uses: govuk-one-login/github-actions/sam/deploy-stack@4c76410195b5fcb1804fc7c183ed20704252830f
         id: deploy
         with:
           sam-deployment-bucket: ${{ vars.DEPLOYMENT_ARTIFACTS_BUCKET }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
-          stack-name-prefix: preview-check-hmrc-api
+          stack-name-prefix: preview
           cache-key: ${{ needs.build.outputs.cache-key }}
           cache-restore-keys: ${{ needs.build.outputs.cache-restore-keys }}
           s3-prefix: preview

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,7 +23,7 @@ sam deploy --stack-name "$stack_name" \
   --resolve-s3 \
   --s3-prefix "$stack_name" \
   --region "${AWS_REGION:-eu-west-2}" \
-  --capabilities CAPABILITY_IAM \
+  --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
   --tags \
   cri:component=ipv-cri-check-hmrc-api \
   cri:stack-type=localdev \

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -127,23 +127,41 @@ Mappings:
 
   EnvironmentConfiguration:
     localdev:
-      DOMAINNAME: review-hc.localdev.account.gov.uk
+      Domain: review-hc.localdev.account.gov.uk
+      BaseURL: https://review-hc.dev.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
+      CoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=nino
+      StubJwksEndpoint: https://test-resources.review-hc.dev.account.gov.uk/.well-known/jwks.json
     dev:
-      DOMAINNAME: review-hc.dev.account.gov.uk
+      Domain: review-hc.dev.account.gov.uk
+      BaseURL: https://review-hc.dev.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
+      CoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=nino
+      StubJwksEndpoint: https://test-resources.review-hc.dev.account.gov.uk/.well-known/jwks.json
     build:
-      DOMAINNAME: review-hc.build.account.gov.uk
+      Domain: review-hc.build.account.gov.uk
+      BaseURL: https://review-hc.build.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
+      CoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=nino
+      StubJwksEndpoint: https://test-resources.review-hc.build.account.gov.uk/.well-known/jwks.json
     staging:
-      DOMAINNAME: review-hc.staging.account.gov.uk
+      Domain: review-hc.staging.account.gov.uk
+      BaseURL: https://review-hc.staging.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
+      CoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=nino
+      StubJwksEndpoint: https://test-resources.review-hc.staging.account.gov.uk/.well-known/jwks.json
     integration:
-      DOMAINNAME: review-hc.integration.account.gov.uk
+      Domain: review-hc.integration.account.gov.uk
+      BaseURL: https://review-hc.integration.account.gov.uk
       HealthcheckSSMClientId: ipv-core
+      CoreRedirectURI: https://identity.integration.account.gov.uk/credential-issuer/callback?id=nino
+      StubJwksEndpoint: https://test-resources.review-hc.integration.account.gov.uk/.well-known/jwks.json
     production:
-      DOMAINNAME: review-hc.production.account.gov.uk
+      Domain: review-hc.production.account.gov.uk
+      BaseURL: https://review-hc.account.gov.uk
       HealthcheckSSMClientId: ipv-core
+      CoreRedirectURI: https://identity.account.gov.uk/credential-issuer/callback?id=nino
+      StubJwksEndpoint: ""
 
 Globals:
   Function:
@@ -192,6 +210,42 @@ Globals:
       - !Ref AWS::NoValue
 
 Resources:
+  OAuth:
+    Type: AWS::Serverless::Application
+    Condition: IsNotIntOrProdEnvironment
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:eu-west-2:667736788427:applications/di-ipv-cri-oauth-common
+        SemanticVersion: 0.5.0
+      Parameters:
+        AuditEventNamePrefix: IPV_HMRC_RECORD_CHECK_CRI
+        CSLSDestinationArn: !If
+          - IsNotDevBuildEnvironment
+          - !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
+          - !Ref AWS::NoValue
+        CriIdentifier: di-ipv-cri-check-hmrc-api
+        CriAudience: !FindInMap [EnvironmentConfiguration, !Ref Environment, BaseURL]
+        CriVcIssuer: !FindInMap [EnvironmentConfiguration, !Ref Environment, BaseURL]
+        CriPrivateApiGwName: !Sub ${AWS::StackName}-private
+        CriPublicApiGwName: !Sub ${AWS::StackName}-public
+        Environment: !If
+          - IsLocalDevEnvironment
+          - dev
+          - !Ref Environment
+        IPVCoreRedirectURI: !FindInMap [EnvironmentConfiguration, !Ref Environment, CoreRedirectURI]
+        IPVCoreStubJwksEndpoint: !FindInMap [EnvironmentConfiguration, !Ref Environment, StubJwksEndpoint]
+        LambdaCodeSigningConfigArn: !If
+          - EnforceCodeSigning
+          - !Ref CodeSigningConfigArn
+          - !Ref AWS::NoValue
+        LambdaDeploymentPreference: !Ref LambdaDeploymentPreference
+        LambdaProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, Environment, !Ref Environment]
+        LambdaVpcConfiguration: di-devplatform-deploy
+        PermissionsBoundaryArn: !If
+          - UsePermissionsBoundary
+          - !Ref PermissionsBoundary
+          - !Ref AWS::NoValue
+
   JWKSBucketRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -1256,7 +1310,7 @@ Resources:
           JWT_TTL_UNIT: !FindInMap [JwtTtlUnit, Environment, !Ref Environment]
           LOG_FULL_ERRORS: !If [IsIntOrProdEnvironment, "false", "true"]
           COMMON_STACK_NAME: !Sub ${CommonStackName}
-          DOMAIN_NAME: !FindInMap [EnvironmentConfiguration, !Ref Environment, DOMAINNAME]
+          DOMAIN_NAME: !FindInMap [EnvironmentConfiguration, !Ref Environment, Domain]
 
   IssueCredentialFunctionLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Proposed changes

### What changed

- Add OAuthCommon stack up to staging.
- Bump build & deploy preview stack actions to now support SAR.

### Why did it change

The first step of the migration will require us to have the OAuth Common stack deployed and ready for the CRI to use as part of subsequent steps.

### Issue tracking

- [OJ-3752](https://govukverify.atlassian.net/browse/OJ-3752)


[OJ-3752]: https://govukverify.atlassian.net/browse/OJ-3752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ