### PR TITLE
OJ-3755: Add mappings to enable the use of OAuthCommon

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -38,7 +38,13 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-AuthorizationFunctionTS:live/invocations
+          Fn::Sub:
+            - arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${FunctionName}:live/invocations
+            - FunctionName:
+                Fn::If:
+                  - UseOAuthCommonLambdas
+                  - Fn::Sub: ${OAuth.Outputs.LambdaAuthorizationFunctionName}
+                  - Fn::Sub: ${CommonStackName}-AuthorizationFunctionTS
         passthroughBehavior: "when_no_match"
 
   /session:
@@ -100,7 +106,13 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-SessionFunctionTS:live/invocations
+          Fn::Sub:
+            - arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${FunctionName}:live/invocations
+            - FunctionName:
+                Fn::If:
+                  - UseOAuthCommonLambdas
+                  - Fn::Sub: ${OAuth.Outputs.LambdaSessionFunctionName}
+                  - Fn::Sub: ${CommonStackName}-SessionFunctionTS
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/public-api.yaml
+++ b/infrastructure/public-api.yaml
@@ -185,7 +185,13 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-AccessTokenFunctionTS:live/invocations
+          Fn::Sub:
+            - arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${FunctionName}:live/invocations
+            - FunctionName:
+                Fn::If:
+                  - UseOAuthCommonLambdas
+                  - Fn::Sub: ${OAuth.Outputs.LambdaAccessTokenFunctionName}
+                  - Fn::Sub: ${CommonStackName}-AccessTokenFunctionTS
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1,6 +1,11 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Digital Identity IPV CRI Pdv-Matching API
 Transform: [AWS::LanguageExtensions, AWS::Serverless-2016-10-31]
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - W8003 #For UseOAuthCommonLambdas & UseOAuthCommonTables condition - Can be removed one migration complete.
 
 Parameters:
   AuditEventNamePrefix:
@@ -70,6 +75,14 @@ Conditions:
   CreateOAuthSSMParam: !And
     - !Not [!Condition IsLocalDevEnvironment]
     - !Not [!Condition IsProdEnvironment]
+  UseOAuthCommonLambdas: !Equals
+    - !FindInMap [EnvironmentConfiguration, !Ref Environment, OAuthCommonLambdas]
+    - true
+  UseOAuthCommonTables: !And
+    - !Condition UseOAuthCommonLambdas
+    - !Equals
+      - !FindInMap [EnvironmentConfiguration, !Ref Environment, OAuthCommonTables]
+      - true
 
 Mappings:
   StaticVariables:
@@ -132,36 +145,48 @@ Mappings:
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
       CoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=nino
       StubJwksEndpoint: https://test-resources.review-hc.dev.account.gov.uk/.well-known/jwks.json
+      OAuthCommonLambdas: false
+      OAuthCommonTables: false
     dev:
       Domain: review-hc.dev.account.gov.uk
       BaseURL: https://review-hc.dev.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
       CoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=nino
       StubJwksEndpoint: https://test-resources.review-hc.dev.account.gov.uk/.well-known/jwks.json
+      OAuthCommonLambdas: false
+      OAuthCommonTables: false
     build:
       Domain: review-hc.build.account.gov.uk
       BaseURL: https://review-hc.build.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
       CoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=nino
       StubJwksEndpoint: https://test-resources.review-hc.build.account.gov.uk/.well-known/jwks.json
+      OAuthCommonLambdas: false
+      OAuthCommonTables: false
     staging:
       Domain: review-hc.staging.account.gov.uk
       BaseURL: https://review-hc.staging.account.gov.uk
       HealthcheckSSMClientId: ipv-core-stub-aws-prod
       CoreRedirectURI: https://identity.staging.account.gov.uk/credential-issuer/callback?id=nino
       StubJwksEndpoint: https://test-resources.review-hc.staging.account.gov.uk/.well-known/jwks.json
+      OAuthCommonLambdas: false
+      OAuthCommonTables: false
     integration:
       Domain: review-hc.integration.account.gov.uk
       BaseURL: https://review-hc.integration.account.gov.uk
       HealthcheckSSMClientId: ipv-core
       CoreRedirectURI: https://identity.integration.account.gov.uk/credential-issuer/callback?id=nino
       StubJwksEndpoint: https://test-resources.review-hc.integration.account.gov.uk/.well-known/jwks.json
+      OAuthCommonLambdas: false
+      OAuthCommonTables: false
     production:
       Domain: review-hc.production.account.gov.uk
       BaseURL: https://review-hc.account.gov.uk
       HealthcheckSSMClientId: ipv-core
       CoreRedirectURI: https://identity.account.gov.uk/credential-issuer/callback?id=nino
       StubJwksEndpoint: ""
+      OAuthCommonLambdas: false
+      OAuthCommonTables: false
 
 Globals:
   Function:
@@ -202,7 +227,10 @@ Globals:
           - SecretArn: !FindInMap [Dynatrace, SecretArn, !Ref Environment]
         AUDIT_QUEUE_URL:
           Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
-        AUDIT_COMPONENT_ID: !Sub "{{resolve:ssm:/${CommonStackName}/verifiable-credential/issuer}}"
+        AUDIT_COMPONENT_ID: !If
+          - UseOAuthCommonLambdas
+          - !FindInMap [EnvironmentConfiguration, !Ref Environment, BaseURL]
+          - !Sub "{{resolve:ssm:/${CommonStackName}/verifiable-credential/issuer}}"
     AutoPublishAlias: live
     ProvisionedConcurrencyConfig: !If
       - AddProvisionedConcurrency
@@ -215,9 +243,17 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:eu-west-2:667736788427:applications/di-ipv-cri-oauth-common
-        SemanticVersion: 0.6.0
+        SemanticVersion: 0.7.0
       Parameters:
         AuditEventNamePrefix: IPV_HMRC_RECORD_CHECK_CRI
+        CommonLambdasStackName: !If
+          - UseOAuthCommonTables
+          - !Ref AWS::NoValue
+          - !Ref CommonStackName
+        CommonLambdasUsesCMK: !If
+          - UseOAuthCommonTables
+          - !Ref AWS::NoValue
+          - true
         CSLSDestinationArn: !If
           - IsNotDevBuildEnvironment
           - !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
@@ -505,7 +541,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${CommonStackName}-SessionFunctionTS
+                  Value: !If
+                    - UseOAuthCommonLambdas
+                    - !GetAtt OAuth.Outputs.LambdaSessionFunctionName
+                    - !Sub ${CommonStackName}-SessionFunctionTS
             Period: 300
             Stat: Sum
 
@@ -551,7 +590,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${CommonStackName}-SessionFunctionTS
+                  Value: !If
+                    - UseOAuthCommonLambdas
+                    - !GetAtt OAuth.Outputs.LambdaSessionFunctionName
+                    - !Sub ${CommonStackName}-SessionFunctionTS
             Period: 300
             Stat: Sum
 
@@ -595,7 +637,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${CommonStackName}-AccessTokenFunctionTS
+                  Value: !If
+                    - UseOAuthCommonLambdas
+                    - !GetAtt OAuth.Outputs.LambdaAccessTokenFunctionName
+                    - !Sub ${CommonStackName}-AccessTokenFunctionTS
             Period: 300
             Stat: Sum
 
@@ -641,7 +686,10 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${CommonStackName}-AccessTokenFunctionTS
+                  Value: !If
+                    - UseOAuthCommonLambdas
+                    - !GetAtt OAuth.Outputs.LambdaAccessTokenFunctionName
+                    - !Sub ${CommonStackName}-AccessTokenFunctionTS
             Period: 300
             Stat: Sum
 
@@ -749,16 +797,28 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-Abandon"
-          SESSION_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
-          ISSUER: !Sub "{{resolve:ssm:/${CommonStackName}/verifiable-credential/issuer}}"
+          SESSION_TABLE: !If
+            - UseOAuthCommonTables
+            - !GetAtt OAuth.Outputs.DbSessionTableName
+            - !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+          ISSUER: !If
+            - UseOAuthCommonTables
+            - !FindInMap [EnvironmentConfiguration, !Ref Environment, BaseURL]
+            - !Sub "{{resolve:ssm:/${CommonStackName}/verifiable-credential/issuer}}"
           LOG_FULL_ERRORS: !If [IsIntOrProdEnvironment, "false", "true"]
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
         - DynamoDBWritePolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+        - DynamoDBReadPolicy:
+            TableName: !GetAtt OAuth.Outputs.DbSessionTableName
+        - DynamoDBWritePolicy:
+            TableName: !GetAtt OAuth.Outputs.DbSessionTableName
         - KMSDecryptPolicy:
             KeyId: !Sub "{{resolve:ssm:/${CommonStackName}/DynamoDBCustomerManagedKeyID}}"
+        - KMSDecryptPolicy:
+            KeyId: !GetAtt OAuth.Outputs.DbCustomerManagedKeyID
         - SQSSendMessagePolicy:
             QueueName:
               Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueName
@@ -1182,6 +1242,14 @@ Resources:
         - DynamoDBWritePolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
         - DynamoDBReadPolicy:
+            TableName: !GetAtt OAuth.Outputs.DbSessionTableName
+        - DynamoDBWritePolicy:
+            TableName: !GetAtt OAuth.Outputs.DbSessionTableName
+        - DynamoDBReadPolicy:
+            TableName: !GetAtt OAuth.Outputs.DbPersonIdentityTableName
+        - DynamoDBWritePolicy:
+            TableName: !GetAtt OAuth.Outputs.DbPersonIdentityTableName
+        - DynamoDBReadPolicy:
             TableName: !Ref UserAttemptsTable
         - DynamoDBWritePolicy:
             TableName: !Ref UserAttemptsTable
@@ -1193,6 +1261,8 @@ Resources:
             KeyId: !Ref DynamoTablesEncryptionKey
         - KMSDecryptPolicy:
             KeyId: !Sub "{{resolve:ssm:/${CommonStackName}/DynamoDBCustomerManagedKeyID}}"
+        - KMSDecryptPolicy:
+            KeyId: !GetAtt OAuth.Outputs.DbCustomerManagedKeyID
         - SQSSendMessagePolicy:
             QueueName:
               Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueName
@@ -1204,12 +1274,17 @@ Resources:
                 - kms:GenerateDataKey
               Resource:
                 Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueEncryptionKeyArn
-
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-NinoCheckFunction"
-          SESSION_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
-          PERSON_IDENTITY_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
+          SESSION_TABLE: !If
+            - UseOAuthCommonTables
+            - !GetAtt OAuth.Outputs.DbSessionTableName
+            - !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+          PERSON_IDENTITY_TABLE: !If
+            - UseOAuthCommonTables
+            - !GetAtt OAuth.Outputs.DbPersonIdentityTableName
+            - !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
           ATTEMPT_TABLE: !Ref UserAttemptsTable
           NINO_USER_TABLE: !Ref NinoUsersTable
           LOG_FULL_ERRORS: !If [IsIntOrProdEnvironment, "false", "true"]
@@ -1269,6 +1344,10 @@ Resources:
         - DynamoDBReadPolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
         - DynamoDBReadPolicy:
+            TableName: !GetAtt OAuth.Outputs.DbSessionTableName
+        - DynamoDBReadPolicy:
+            TableName: !GetAtt OAuth.Outputs.DbPersonIdentityTableName
+        - DynamoDBReadPolicy:
             TableName: !Ref UserAttemptsTable
         - DynamoDBReadPolicy:
             TableName: !Ref NinoUsersTable
@@ -1276,12 +1355,12 @@ Resources:
             KeyId: !Ref DynamoTablesEncryptionKey
         - KMSDecryptPolicy:
             KeyId: !Sub "{{resolve:ssm:/${CommonStackName}/DynamoDBCustomerManagedKeyID}}"
+        - KMSDecryptPolicy:
+            KeyId: !GetAtt OAuth.Outputs.DbCustomerManagedKeyID
         - SSMParameterReadPolicy:
             ParameterName: check-hmrc-cri-api/contraindicationMappings
         - SSMParameterReadPolicy:
             ParameterName: check-hmrc-cri-api/contraIndicatorReasonsMapping
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${CommonStackName}/verifiableCredentialKmsSigningKeyId
         - Statement:
             Effect: Allow
             Action: kms:Sign
@@ -1300,16 +1379,29 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-IssueCredentialFunction"
-          SESSION_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
-          PERSON_IDENTITY_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
+          SESSION_TABLE: !If
+            - UseOAuthCommonTables
+            - !GetAtt OAuth.Outputs.DbSessionTableName
+            - !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+          PERSON_IDENTITY_TABLE: !If
+            - UseOAuthCommonTables
+            - !GetAtt OAuth.Outputs.DbPersonIdentityTableName
+            - !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
           ATTEMPT_TABLE: !Ref UserAttemptsTable
           NINO_USER_TABLE: !Ref NinoUsersTable
-          ISSUER: !Sub "{{resolve:ssm:/${CommonStackName}/verifiable-credential/issuer}}"
+          ISSUER: !If
+            - UseOAuthCommonLambdas
+            - !FindInMap [EnvironmentConfiguration, !Ref Environment, BaseURL]
+            - !Sub "{{resolve:ssm:/${CommonStackName}/verifiable-credential/issuer}}"
           MAX_JWT_TTL: !FindInMap [MaxJwtTtl, Environment, !Ref Environment]
           JWT_TTL_UNIT: !FindInMap [JwtTtlUnit, Environment, !Ref Environment]
           LOG_FULL_ERRORS: !If [IsIntOrProdEnvironment, "false", "true"]
           COMMON_STACK_NAME: !Sub ${CommonStackName}
           DOMAIN_NAME: !FindInMap [EnvironmentConfiguration, !Ref Environment, Domain]
+          VC_SIGNING_KEY_ID: !If
+            - UseOAuthCommonLambdas
+            - !GetAtt OAuth.Outputs.VCSigningKeyID
+            - !Sub "{{resolve:ssm:/${CommonStackName}/verifiableCredentialKmsSigningKeyId}}"
 
   IssueCredentialFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1593,7 +1685,10 @@ Resources:
     Properties:
       Name: /common-cri/oauth-common/stack-name
       Type: String
-      Value: !Ref CommonStackName
+      Value: !If
+        - UseOAuthCommonTables
+        - !Select [1, !Split ["/", !Ref OAuth]]
+        - !Ref CommonStackName
       Description: The stack currently used for OAuth (common-lambdas or oauth-common). Only required for test-resources.
 
 
@@ -1620,7 +1715,10 @@ Outputs:
       Name: !Sub ${AWS::StackName}-PrivateApiGatewayId
   CommonStackName:
     Description: Common Stack Name
-    Value: !Ref CommonStackName
+    Value: !If
+      - UseOAuthCommonTables
+      - !Select [1, !Split ["/", !Ref OAuth]]
+      - !Ref CommonStackName
   UserAttemptsTable:
     Description: UserAttemptsTable table name
     Value: !Ref UserAttemptsTable

--- a/lambdas/issue-credential/src/config/function-config.ts
+++ b/lambdas/issue-credential/src/config/function-config.ts
@@ -14,7 +14,7 @@ const envVarNames = {
   ninoUserTable: "NINO_USER_TABLE",
   maxJwtTtl: "MAX_JWT_TTL",
   jwtTtlUnit: "JWT_TTL_UNIT",
-  commonStackName: "COMMON_STACK_NAME",
+  vcSigningKeyId: "VC_SIGNING_KEY_ID",
   vcIssuer: "ISSUER",
 };
 
@@ -22,7 +22,7 @@ export type CredentialIssuerEnv = {
   issuer: string;
   maxJwtTtl: number;
   jwtTtlUnit: TimeUnits;
-  commonStackName: string;
+  vcSigningKeyId: string;
 };
 export class IssueCredFunctionConfig extends BaseFunctionConfig {
   public readonly credentialIssuerEnv: CredentialIssuerEnv;
@@ -36,7 +36,7 @@ export class IssueCredFunctionConfig extends BaseFunctionConfig {
       issuer: process.env[envVarNames.vcIssuer] as string,
       maxJwtTtl: Number(process.env[envVarNames.maxJwtTtl]),
       jwtTtlUnit: process.env[envVarNames.jwtTtlUnit] as TimeUnits,
-      commonStackName: process.env[envVarNames.commonStackName] as string,
+      vcSigningKeyId: process.env[envVarNames.vcSigningKeyId] as string,
     };
   }
 

--- a/lambdas/issue-credential/src/config/vc-config.ts
+++ b/lambdas/issue-credential/src/config/vc-config.ts
@@ -8,15 +8,14 @@ export type VcCheckConfig = {
   readonly kms: { signingKeyId: string };
   readonly contraIndicator: { errorMapping: string[]; reasonsMapping: CiReasonsMapping[] };
 };
-export const getVcConfig = async (commonStackName: string): Promise<VcCheckConfig> => {
-  const vcSigningKeyId = `/${commonStackName}/verifiableCredentialKmsSigningKeyId`;
+export const getVcConfig = async (vcSigningKeyId: string): Promise<VcCheckConfig> => {
   const errorMapping = "/check-hmrc-cri-api/contraindicationMappings";
   const reasonsMapping = "/check-hmrc-cri-api/contraIndicatorReasonsMapping";
   try {
-    const ssmParams = await getParametersValues([vcSigningKeyId, errorMapping, reasonsMapping], cacheTtlInSeconds);
+    const ssmParams = await getParametersValues([errorMapping, reasonsMapping], cacheTtlInSeconds);
     logger.info("Retrieved Check Hmrc VC parameters.");
     return {
-      kms: { signingKeyId: ssmParams[vcSigningKeyId] },
+      kms: { signingKeyId: vcSigningKeyId },
       contraIndicator: {
         errorMapping: ssmParams[errorMapping].split("||"),
         reasonsMapping: JSON.parse(ssmParams[reasonsMapping]),

--- a/lambdas/issue-credential/src/handler.ts
+++ b/lambdas/issue-credential/src/handler.ts
@@ -38,7 +38,7 @@ class IssueCredentialHandler implements LambdaInterface {
 
       const { attempts, personIdentity, ninoUser, session } = await this.getCheckedUserData(accessToken);
 
-      vcConfig ??= await getVcConfig(functionConfig.credentialIssuerEnv.commonStackName);
+      vcConfig ??= await getVcConfig(functionConfig.credentialIssuerEnv.vcSigningKeyId);
       const contraIndicators = getHmrcContraIndicators({
         contraIndicationMapping: vcConfig.contraIndicator.errorMapping,
         contraIndicatorReasonsMapping: vcConfig.contraIndicator.reasonsMapping,

--- a/lambdas/issue-credential/tests/config/function-config.test.ts
+++ b/lambdas/issue-credential/tests/config/function-config.test.ts
@@ -13,7 +13,7 @@ const validEnvVars = {
   ISSUER: "bob",
   MAX_JWT_TTL: "3600",
   JWT_TTL_UNIT: "seconds",
-  COMMON_STACK_NAME: "common-stack",
+  VC_SIGNING_KEY_ID: "key-id-here",
 };
 
 describe("function config", () => {
@@ -41,7 +41,7 @@ describe("function config", () => {
           issuer: "bob",
           maxJwtTtl: 3600,
           jwtTtlUnit: "seconds",
-          commonStackName: "common-stack",
+          vcSigningKeyId: "key-id-here",
         },
       });
       expect(config.tableNames).toEqual({

--- a/lambdas/issue-credential/tests/config/vc-config.test.ts
+++ b/lambdas/issue-credential/tests/config/vc-config.test.ts
@@ -16,13 +16,11 @@ type spyGetParametersValues = MockInstance<
 describe("getVcConfig", () => {
   let getParametersValuesSpy: spyGetParametersValues;
 
-  const mockCommonStackName = "test-stack";
-  const expectedVcSigningKeyId = `/${mockCommonStackName}/verifiableCredentialKmsSigningKeyId`;
+  const mockVcSigningKeyId = "test-signing-key-id"
   const expectedErrorMapping = "/check-hmrc-cri-api/contraindicationMappings";
   const expectedReasonsMapping = "/check-hmrc-cri-api/contraIndicatorReasonsMapping";
 
   const mockSsmParams: Record<string, string> = {
-    [expectedVcSigningKeyId]: "test-signing-key-id",
     [expectedErrorMapping]: "error1||error2||error3",
     [expectedReasonsMapping]: JSON.stringify([
       { code: "A", reason: "Reason A" },
@@ -41,7 +39,7 @@ describe("getVcConfig", () => {
     it("returns correctly typed VcCheckConfig with valid parameters", async () => {
       getParametersValuesSpy.mockResolvedValueOnce(mockSsmParams);
 
-      const result: VcCheckConfig = await getVcConfig(mockCommonStackName);
+      const result: VcCheckConfig = await getVcConfig(mockVcSigningKeyId);
 
       expect(result).toEqual({
         kms: { signingKeyId: "test-signing-key-id" },
@@ -58,12 +56,9 @@ describe("getVcConfig", () => {
     it("calls getParametersValues with correct parameter paths", async () => {
       getParametersValuesSpy.mockResolvedValueOnce(mockSsmParams);
 
-      await getVcConfig(mockCommonStackName);
+      await getVcConfig(mockVcSigningKeyId);
 
-      expect(getParametersValuesSpy).toHaveBeenCalledWith(
-        [expectedVcSigningKeyId, expectedErrorMapping, expectedReasonsMapping],
-        300
-      );
+      expect(getParametersValuesSpy).toHaveBeenCalledWith([expectedErrorMapping, expectedReasonsMapping], 300);
       expect(getParametersValuesSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -71,7 +66,7 @@ describe("getVcConfig", () => {
       getParametersValuesSpy.mockResolvedValueOnce(mockSsmParams);
       vi.spyOn(logger, "info");
 
-      await getVcConfig(mockCommonStackName);
+      await getVcConfig(mockVcSigningKeyId);
 
       expect(logger.info).toHaveBeenCalledWith("Retrieved Check Hmrc VC parameters.");
       expect(logger.info).toHaveBeenCalledTimes(1);
@@ -83,7 +78,7 @@ describe("getVcConfig", () => {
         [expectedErrorMapping]: "",
       });
 
-      const result = await getVcConfig(mockCommonStackName);
+      const result = await getVcConfig(mockVcSigningKeyId);
 
       expect(result.contraIndicator.errorMapping).toEqual([""]);
     });
@@ -94,7 +89,7 @@ describe("getVcConfig", () => {
         [expectedErrorMapping]: "single-error",
       });
 
-      const result = await getVcConfig(mockCommonStackName);
+      const result = await getVcConfig(mockVcSigningKeyId);
 
       expect(result.contraIndicator.errorMapping).toEqual(["single-error"]);
     });
@@ -110,7 +105,7 @@ describe("getVcConfig", () => {
         [expectedReasonsMapping]: JSON.stringify(multipleReasons),
       });
 
-      const result = await getVcConfig(mockCommonStackName);
+      const result = await getVcConfig(mockVcSigningKeyId);
 
       expect(result.contraIndicator.reasonsMapping).toEqual(multipleReasons);
     });
@@ -120,7 +115,7 @@ describe("getVcConfig", () => {
     it("throws CriError when getParametersValues throws Error", async () => {
       getParametersValuesSpy.mockRejectedValue(new Error("SSM parameter not found"));
 
-      await expect(getVcConfig(mockCommonStackName)).rejects.toThrow(
+      await expect(getVcConfig(mockVcSigningKeyId)).rejects.toThrow(
         new CriError(500, "Failed to load VC config: SSM parameter not found")
       );
     });
@@ -128,7 +123,7 @@ describe("getVcConfig", () => {
     it("throws CriError when getParametersValues throws non-Error", async () => {
       getParametersValuesSpy.mockRejectedValueOnce("String error");
 
-      await expect(getVcConfig(mockCommonStackName)).rejects.toThrow(
+      await expect(getVcConfig(mockVcSigningKeyId)).rejects.toThrow(
         new CriError(500, "Failed to load VC config: String error")
       );
     });
@@ -136,7 +131,7 @@ describe("getVcConfig", () => {
     it("throws CriError when getParametersValues throws null", async () => {
       getParametersValuesSpy.mockRejectedValue(null);
 
-      await expect(getVcConfig(mockCommonStackName)).rejects.toThrow(
+      await expect(getVcConfig(mockVcSigningKeyId)).rejects.toThrow(
         new CriError(500, "Failed to load VC config: null")
       );
     });
@@ -144,7 +139,7 @@ describe("getVcConfig", () => {
     it("throws CriError when getParametersValues throws undefined", async () => {
       getParametersValuesSpy.mockRejectedValue(undefined);
 
-      await expect(getVcConfig(mockCommonStackName)).rejects.toThrow(
+      await expect(getVcConfig(mockVcSigningKeyId)).rejects.toThrow(
         new CriError(500, "Failed to load VC config: undefined")
       );
     });
@@ -155,8 +150,8 @@ describe("getVcConfig", () => {
         [expectedReasonsMapping]: "invalid-json",
       });
 
-      await expect(getVcConfig(mockCommonStackName)).rejects.toThrow(CriError);
-      await expect(getVcConfig(mockCommonStackName)).rejects.toThrow(
+      await expect(getVcConfig(mockVcSigningKeyId)).rejects.toThrow(CriError);
+      await expect(getVcConfig(mockVcSigningKeyId)).rejects.toThrow(
         expect.objectContaining({
           statusCode: 500,
           message: expect.stringContaining("Failed to load VC config:"),
@@ -168,49 +163,8 @@ describe("getVcConfig", () => {
       const specificErrorMessage = "Specific AWS SSM error occurred";
       getParametersValuesSpy.mockRejectedValueOnce(new Error(specificErrorMessage));
 
-      await expect(getVcConfig(mockCommonStackName)).rejects.toThrow(
+      await expect(getVcConfig(mockVcSigningKeyId)).rejects.toThrow(
         new CriError(500, `Failed to load VC config: ${specificErrorMessage}`)
-      );
-    });
-  });
-
-  describe("parameter path construction", () => {
-    it("constructs correct vcSigningKeyId path with different stack names", async () => {
-      const customStackName = "custom-stack-name";
-      const expectedCustomPath = `/${customStackName}/verifiableCredentialKmsSigningKeyId`;
-
-      getParametersValuesSpy.mockResolvedValueOnce({
-        [expectedCustomPath]: "custom-key-id",
-        [expectedErrorMapping]: "error1||error2",
-        [expectedReasonsMapping]: JSON.stringify([]),
-      });
-
-      await getVcConfig(customStackName);
-
-      expect(getParametersValuesSpy).toHaveBeenCalledWith(
-        [expectedCustomPath, expectedErrorMapping, expectedReasonsMapping],
-        300
-      );
-    });
-
-    it("handles stack names with special characters", async () => {
-      const specialStackName = "stack-with-123_special.chars";
-      const expectedSpecialPath = `/${specialStackName}/verifiableCredentialKmsSigningKeyId`;
-
-      const specialMockParams = {
-        [expectedSpecialPath]: "special-key-id",
-        [expectedErrorMapping]: "error1",
-        [expectedReasonsMapping]: JSON.stringify([]),
-      };
-
-      getParametersValuesSpy.mockResolvedValueOnce(specialMockParams);
-
-      const result = await getVcConfig(specialStackName);
-
-      expect(result.kms.signingKeyId).toBe("special-key-id");
-      expect(getParametersValuesSpy).toHaveBeenCalledWith(
-        [expectedSpecialPath, expectedErrorMapping, expectedReasonsMapping],
-        300
       );
     });
   });
@@ -219,7 +173,7 @@ describe("getVcConfig", () => {
     it("returns object matching VcCheckConfig type", async () => {
       getParametersValuesSpy.mockResolvedValueOnce(mockSsmParams);
 
-      const result = await getVcConfig(mockCommonStackName);
+      const result = await getVcConfig(mockVcSigningKeyId);
 
       expect(typeof result.kms.signingKeyId).toBe("string");
       expect(Array.isArray(result.contraIndicator.errorMapping)).toBe(true);
@@ -235,21 +189,6 @@ describe("getVcConfig", () => {
   });
 
   describe("some edge cases", () => {
-    it("handles empty commonStackName", async () => {
-      getParametersValuesSpy.mockResolvedValueOnce({
-        "//verifiableCredentialKmsSigningKeyId": "empty-stack-key",
-        [expectedErrorMapping]: "error1",
-        [expectedReasonsMapping]: JSON.stringify([]),
-      });
-
-      const result = await getVcConfig("");
-
-      expect(getParametersValuesSpy).toHaveBeenCalledWith(
-        ["//verifiableCredentialKmsSigningKeyId", expectedErrorMapping, expectedReasonsMapping],
-        300
-      );
-      expect(result.kms.signingKeyId).toBe("empty-stack-key");
-    });
 
     it("handles reasonsMapping as empty array", async () => {
       getParametersValuesSpy.mockResolvedValueOnce({
@@ -257,7 +196,7 @@ describe("getVcConfig", () => {
         [expectedReasonsMapping]: "[]",
       });
 
-      const result = await getVcConfig(mockCommonStackName);
+      const result = await getVcConfig(mockVcSigningKeyId);
 
       expect(result.contraIndicator.reasonsMapping).toEqual([]);
     });
@@ -268,7 +207,7 @@ describe("getVcConfig", () => {
         [expectedErrorMapping]: "error1||||error2||error3",
       });
 
-      const result = await getVcConfig(mockCommonStackName);
+      const result = await getVcConfig(mockVcSigningKeyId);
 
       expect(result.contraIndicator.errorMapping).toEqual(["error1", "", "error2", "error3"]);
     });

--- a/lambdas/issue-credential/tests/handler.test.ts
+++ b/lambdas/issue-credential/tests/handler.test.ts
@@ -23,7 +23,7 @@ const { mockIssueCredConfig } = vi.hoisted(() => ({
       issuer: "bob",
       maxJwtTtl: 1000,
       jwtTtlUnit: "Hours",
-      commonStackName: "big-stack",
+      vcSigningKeyId: "key-id",
     },
     tableNames: {
       sessionTable: "session-table",
@@ -163,7 +163,7 @@ describe("issue-credential handler", () => {
       },
       body: expectedJwt,
     });
-    expect(spyVcConfig).toHaveBeenCalledWith("big-stack");
+    expect(spyVcConfig).toHaveBeenCalledWith("key-id");
     expect(mockLogger.appendKeys).toHaveBeenCalledWith({ govuk_signin_journey_id: mockSession.clientSessionId });
     expect(getAttempts).toHaveBeenCalledWith(
       mockFunctionConfig.tableNames.attemptTable,

--- a/lambdas/issue-credential/tests/mocks/mockConfig.ts
+++ b/lambdas/issue-credential/tests/mocks/mockConfig.ts
@@ -13,7 +13,7 @@ export const mockCredentialIssuerEnv: CredentialIssuerEnv = {
   issuer: "bob",
   maxJwtTtl: 1000,
   jwtTtlUnit: TimeUnits.Hours,
-  commonStackName: "big-stack",
+  vcSigningKeyId: "key-id",
 };
 
 export const mockFunctionConfig: IssueCredFunctionConfig = {


### PR DESCRIPTION
## Proposed changes

### What changed

- Added `UseOAuthCommonLambdas`
- Added `UseOAuthCommonTables`
- Updated APIGW configuration, OAuthCommon Stack to use these conditions.
- Refactored Issue Credential handler to now handle the `vcSigningKeyId` as an env var instead of retrieving from SSM inside the handler. 

### Why did it change

So we can configure the use of `OAuthCommon` resources in each env.

### Issue tracking

- [OJ-3755](https://govukverify.atlassian.net/browse/OJ-3755)


[OJ-3755]: https://govukverify.atlassian.net/browse/OJ-3755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ