### PR TITLE
feat: enable OAuthCommonLambdas in integration and production

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -177,7 +177,7 @@ Mappings:
       HealthcheckSSMClientId: ipv-core
       CoreRedirectURI: https://identity.integration.account.gov.uk/credential-issuer/callback?id=nino
       StubJwksEndpoint: https://test-resources.review-hc.integration.account.gov.uk/.well-known/jwks.json
-      OAuthCommonLambdas: false
+      OAuthCommonLambdas: true
       OAuthCommonTables: false
     production:
       Domain: review-hc.production.account.gov.uk
@@ -185,7 +185,7 @@ Mappings:
       HealthcheckSSMClientId: ipv-core
       CoreRedirectURI: https://identity.account.gov.uk/credential-issuer/callback?id=nino
       StubJwksEndpoint: ""
-      OAuthCommonLambdas: false
+      OAuthCommonLambdas: true
       OAuthCommonTables: false
 
 Globals:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -243,7 +243,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:eu-west-2:667736788427:applications/di-ipv-cri-oauth-common
-        SemanticVersion: 0.7.0
+        SemanticVersion: 1.0.0
       Parameters:
         AuditEventNamePrefix: IPV_HMRC_RECORD_CHECK_CRI
         CommonLambdasStackName: !If


### PR DESCRIPTION
## Proposed changes

### What changed
Set `OAuthCommonLambdas` for integration and production to true.

### Why did it change
Following the release of v1.0.0 of OAuth Common, we are now ready to start using the OAuth Common Lambdas.

### Issue tracking
- [OJ-3760](https://govukverify.atlassian.net/browse/OJ-3760)


[OJ-3760]: https://govukverify.atlassian.net/browse/OJ-3760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ