### PR TITLE
OJ-3759: Bump OAuthCommon to 1.0.0, prior to enabling in prod

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -243,7 +243,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:eu-west-2:667736788427:applications/di-ipv-cri-oauth-common
-        SemanticVersion: 0.7.0
+        SemanticVersion: 1.0.0
       Parameters:
         AuditEventNamePrefix: IPV_HMRC_RECORD_CHECK_CRI
         CommonLambdasStackName: !If


### PR DESCRIPTION
## Proposed changes

### What changed

Bump OAuthCommon to 1.0.0, prior to enabling in prod

### Why did it change

- [OJ-3759](https://govukverify.atlassian.net/browse/OJ-3759)


[OJ-3759]: https://govukverify.atlassian.net/browse/OJ-3759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ